### PR TITLE
Add basic Dynamic Fhir Server and tests

### DIFF
--- a/Microsoft.Health.Dicom.sln
+++ b/Microsoft.Health.Dicom.sln
@@ -22,7 +22,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Dicom.Blob
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Blob.UnitTests", "src\Microsoft.Health.Blob.UnitTests\Microsoft.Health.Blob.UnitTests.csproj", "{875E8062-FF09-42BB-8244-8C6145C95E5B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Dicom.Tests.Integration", "test\Microsoft.Health.Dicom.Tests.Integration\Microsoft.Health.Dicom.Tests.Integration.csproj", "{DFB41ECC-726C-4DBA-8AD3-17FB0A2546CA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Dicom.Tests.Integration", "test\Microsoft.Health.Dicom.Tests.Integration\Microsoft.Health.Dicom.Tests.Integration.csproj", "{DFB41ECC-726C-4DBA-8AD3-17FB0A2546CA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Dicom.DynamicFhir.Tests.E2E", "test\Microsoft.Health.Dicom.DynamicFhir.Tests.E2E\Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.csproj", "{F3B199AF-C998-48C0-9F17-42BAD70F0F34}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Dicom.DynamicFhir.Core", "src\Microsoft.Health.Dicom.DynamicFhir.Core\Microsoft.Health.Dicom.DynamicFhir.Core.csproj", "{5073F6E9-45CB-4E12-90C9-A2B4C1406594}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Dicom.DynamicFhir.Web", "src\Microsoft.Health.Dicom.DynamicFhir.Web\Microsoft.Health.Dicom.DynamicFhir.Web.csproj", "{7495A426-3442-4D6A-84ED-17A1B1921880}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -54,6 +60,18 @@ Global
 		{DFB41ECC-726C-4DBA-8AD3-17FB0A2546CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DFB41ECC-726C-4DBA-8AD3-17FB0A2546CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DFB41ECC-726C-4DBA-8AD3-17FB0A2546CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F3B199AF-C998-48C0-9F17-42BAD70F0F34}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F3B199AF-C998-48C0-9F17-42BAD70F0F34}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F3B199AF-C998-48C0-9F17-42BAD70F0F34}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F3B199AF-C998-48C0-9F17-42BAD70F0F34}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5073F6E9-45CB-4E12-90C9-A2B4C1406594}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5073F6E9-45CB-4E12-90C9-A2B4C1406594}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5073F6E9-45CB-4E12-90C9-A2B4C1406594}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5073F6E9-45CB-4E12-90C9-A2B4C1406594}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7495A426-3442-4D6A-84ED-17A1B1921880}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7495A426-3442-4D6A-84ED-17A1B1921880}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7495A426-3442-4D6A-84ED-17A1B1921880}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7495A426-3442-4D6A-84ED-17A1B1921880}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -65,9 +83,12 @@ Global
 		{1FFFABFB-B30A-4AB8-8193-67016B1C5276} = {176641B3-297C-4E04-A83D-8F80F80485E8}
 		{875E8062-FF09-42BB-8244-8C6145C95E5B} = {176641B3-297C-4E04-A83D-8F80F80485E8}
 		{DFB41ECC-726C-4DBA-8AD3-17FB0A2546CA} = {8C9A0050-5D22-4398-9F93-DDCD80B3BA51}
+		{F3B199AF-C998-48C0-9F17-42BAD70F0F34} = {8C9A0050-5D22-4398-9F93-DDCD80B3BA51}
+		{5073F6E9-45CB-4E12-90C9-A2B4C1406594} = {176641B3-297C-4E04-A83D-8F80F80485E8}
+		{7495A426-3442-4D6A-84ED-17A1B1921880} = {176641B3-297C-4E04-A83D-8F80F80485E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {E370FB31-CF95-47D1-B1E1-863A77973FF8}
 		RESX_SortFileContentOnSave = True
+		SolutionGuid = {E370FB31-CF95-47D1-B1E1-863A77973FF8}
 	EndGlobalSection
 EndGlobal

--- a/src/Microsoft.Health.Dicom.DynamicFhir.Core/DefaultCapabilities.json
+++ b/src/Microsoft.Health.Dicom.DynamicFhir.Core/DefaultCapabilities.json
@@ -1,0 +1,156 @@
+{
+    "resourceType": "CapabilityStatement",
+    "id": "#metadata",
+    "url": "/metadata",
+    "version": "1.0.0.0",
+    "name": "Microsoft DICOM Dyanmic FHIR Server Capability Statement",
+    "status": "draft",
+    "experimental": true,
+    "publisher": "Microsoft Corporation",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.microsoft.com"
+                }
+            ]
+        }
+    ],
+    "description": "This is the Microsoft DICOM Dyanmic FHIR Server implementation base capability statement.",
+    "kind": "capability",
+    "software": {
+        "name": "Microsoft FHIR Server",
+        "version": "1.0.0.0"
+    },
+    "date": "2017-10-01",
+    "fhirVersion": "3.0.1",
+    "acceptUnknown": "both",
+    "format": [
+        "json"
+    ],
+    "rest": [
+        {
+            "mode": "server",
+            "documentation": "Microsoft implementation of the FHIR Specification",
+            "resource": [
+                {
+                    "type": "Bundle",
+                    "profile": {
+                        "reference": "http://hl7.org/fhir/StructureDefinition/Bundle"
+                    },
+                    "interaction": [
+                        {
+                            "code": "read",
+                            "documentation": "Implemented per the specification"
+                        }
+                    ],
+                    "readHistory": false,
+                    "updateCreate": false,
+                    "versioning": "no-version",
+                    "conditionalCreate": false,
+                    "conditionalRead": "not-supported",
+                    "conditionalUpdate": false,
+                    "conditionalDelete": "not-supported"
+                },
+                {
+                    "type": "CapabilityStatement",
+                    "profile": {
+                        "reference": "http://hl7.org/fhir/StructureDefinition/CapabilityStatement"
+                    },
+                    "interaction": [
+                        {
+                            "code": "read",
+                            "documentation": "Implemented per the specification"
+                        }
+                    ],
+                    "readHistory": false,
+                    "updateCreate": false,
+                    "versioning": "no-version",
+                    "conditionalCreate": false,
+                    "conditionalRead": "not-supported",
+                    "conditionalUpdate": false,
+                    "conditionalDelete": "not-supported"
+                },
+                {
+                    "type": "CompartmentDefinition",
+                    "profile": {
+                        "reference": "http://hl7.org/fhir/StructureDefinition/CompartmentDefinition"
+                    },
+                    "interaction": [
+                        {
+                            "code": "read",
+                            "documentation": "Implemented per the specification"
+                        }
+                    ],
+                    "readHistory": false,
+                    "updateCreate": false,
+                    "versioning": "no-version",
+                    "conditionalCreate": false,
+                    "conditionalRead": "not-supported",
+                    "conditionalUpdate": false,
+                    "conditionalDelete": "not-supported"
+                },
+                {
+                    "type": "Endpoint",
+                    "profile": {
+                        "reference": "http://hl7.org/fhir/StructureDefinition/Endpoint"
+                    },
+                    "interaction": [
+                        {
+                            "code": "read",
+                            "documentation": "Implemented per the specification"
+                        }
+                    ],
+                    "readHistory": false,
+                    "updateCreate": false,
+                    "versioning": "no-version",
+                    "conditionalCreate": false,
+                    "conditionalRead": "not-supported",
+                    "conditionalUpdate": false,
+                    "conditionalDelete": "not-supported"
+                },
+                {
+                    "type": "ImagingStudy",
+                    "profile": {
+                        "reference": "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                    },
+                    "interaction": [
+                        {
+                            "code": "read",
+                            "documentation": "Implemented per the specification"
+                        }
+                    ],
+                    "readHistory": false,
+                    "updateCreate": false,
+                    "versioning": "no-version",
+                    "conditionalCreate": false,
+                    "conditionalRead": "not-supported",
+                    "conditionalUpdate": false,
+                    "conditionalDelete": "not-supported"
+                },
+                {
+                    "type": "Patient",
+                    "profile": {
+                        "reference": "http://hl7.org/fhir/StructureDefinition/Patient"
+                    },
+                    "interaction": [
+                        {
+                            "code": "read",
+                            "documentation": "Implemented per the specification"
+                        }
+                    ],
+                    "readHistory": false,
+                    "updateCreate": false,
+                    "versioning": "no-version",
+                    "conditionalCreate": false,
+                    "conditionalRead": "not-supported",
+                    "conditionalUpdate": false,
+                    "conditionalDelete": "not-supported"
+                }
+            ],
+            "interaction": [
+            ]
+        }
+    ]
+}

--- a/src/Microsoft.Health.Dicom.DynamicFhir.Core/DynamicFhirConfiguredConformanceProvider.cs
+++ b/src/Microsoft.Health.Dicom.DynamicFhir.Core/DynamicFhirConfiguredConformanceProvider.cs
@@ -1,0 +1,63 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using Microsoft.Health.Fhir.Core.Features.Conformance;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Core
+{
+    public class DynamicFhirConfiguredConformanceProvider : ConformanceProviderBase, IConfiguredConformanceProvider
+    {
+        private readonly FhirJsonParser _parser;
+
+        private CapabilityStatement _capabilityStatement;
+        private readonly List<Action<CapabilityStatement>> _builderActions = new List<Action<CapabilityStatement>>();
+
+        public DynamicFhirConfiguredConformanceProvider(FhirJsonParser parser)
+        {
+            EnsureArg.IsNotNull(parser, nameof(parser));
+
+            _parser = parser;
+        }
+
+        public override async Task<CapabilityStatement> GetCapabilityStatementAsync(CancellationToken cancellationToken = default)
+        {
+            if (_capabilityStatement == null)
+            {
+                string manifestName = $"{GetType().Namespace}.DefaultCapabilities.json";
+
+                using (Stream resourceStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(manifestName))
+                using (var reader = new StreamReader(resourceStream))
+                {
+                    _capabilityStatement = _parser.Parse<CapabilityStatement>(await reader.ReadToEndAsync());
+                }
+
+                _builderActions.ForEach(action => action(_capabilityStatement));
+            }
+
+            return _capabilityStatement;
+        }
+
+        public void ConfigureOptionalCapabilities(Action<CapabilityStatement> builder)
+        {
+            if (_capabilityStatement != null)
+            {
+                builder(_capabilityStatement);
+            }
+            else
+            {
+                _builderActions.Add(builder);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.DynamicFhir.Core/DynamicFhirGetResourceHandler.cs
+++ b/src/Microsoft.Health.Dicom.DynamicFhir.Core/DynamicFhirGetResourceHandler.cs
@@ -1,0 +1,57 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using MediatR;
+using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Messages.Get;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Core
+{
+    public class DynamicFhirGetResourceHandler : IRequestHandler<GetResourceRequest, GetResourceResponse>
+    {
+        private readonly IFhirDataStore _fhirDataStore;
+        private readonly ResourceDeserializer _deserializer;
+
+        public DynamicFhirGetResourceHandler(
+            IFhirDataStore fhirDataStore,
+            ResourceDeserializer deserializer)
+        {
+            EnsureArg.IsNotNull(fhirDataStore, nameof(fhirDataStore));
+            EnsureArg.IsNotNull(deserializer, nameof(deserializer));
+
+            _fhirDataStore = fhirDataStore;
+            _deserializer = deserializer;
+        }
+
+        /// <summary>
+        /// This is a duplicate of Microsoft.Health.Fhir.Core.Resources.ResourceNotFoundById,
+        /// this is internal in the current fhir-server code base.
+        /// </summary>
+        private static string ResourceNotFoundById
+        {
+            get { return "Resource type '{0}' with id '{1}' couldn't be found."; }
+        }
+
+        public async Task<GetResourceResponse> Handle(GetResourceRequest message, CancellationToken cancellationToken)
+        {
+            EnsureArg.IsNotNull(message, nameof(message));
+
+            var key = message.ResourceKey;
+
+            ResourceWrapper currentDoc = await _fhirDataStore.GetAsync(key, cancellationToken);
+
+            if (currentDoc == null)
+            {
+                throw new ResourceNotFoundException(string.Format(ResourceNotFoundById, key.ResourceType, key.Id));
+            }
+
+            return new GetResourceResponse(_deserializer.Deserialize(currentDoc));
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.DynamicFhir.Core/DynamicFhirServerRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Dicom.DynamicFhir.Core/DynamicFhirServerRegistrationExtensions.cs
@@ -1,0 +1,65 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Linq;
+using EnsureThat;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Features.Conformance;
+using Microsoft.Health.Fhir.Core.Features.Resources.Create;
+using Microsoft.Health.Fhir.Core.Features.Resources.Delete;
+using Microsoft.Health.Fhir.Core.Features.Resources.Get;
+using Microsoft.Health.Fhir.Core.Features.Resources.Upsert;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Core
+{
+    public static class DynamicFhirServerRegistrationExtensions
+    {
+        public static IServiceCollection ReplaceConfiguredConformanceProvider(this IServiceCollection services)
+        {
+            EnsureArg.IsNotNull(services, nameof(services));
+            var serviceDescriptor = services.FirstOrDefault(service => service.ServiceType == typeof(IConfiguredConformanceProvider));
+            services.Remove(serviceDescriptor);
+
+            // Add conformance provider for implementation metadata.
+            services.AddSingleton<IConfiguredConformanceProvider, DynamicFhirConfiguredConformanceProvider>();
+            return services;
+        }
+
+        public static IServiceCollection ReplaceResourceHandlers(this IServiceCollection services)
+        {
+            EnsureArg.IsNotNull(services, nameof(services));
+
+            var typesToRemove = new[]
+            {
+                typeof(CreateResourceHandler),
+                typeof(DeleteResourceHandler),
+                typeof(UpsertResourceHandler),
+                typeof(GetResourceHandler),
+            };
+
+            foreach (var typeToRemove in typesToRemove)
+            {
+                var serviceDescriptors = services.Where(service => service.ImplementationType == typeToRemove).ToArray();
+                foreach (var serviceToRemove in serviceDescriptors)
+                {
+                    services.Remove(serviceToRemove);
+                }
+            }
+
+            services.Add<FhirDicomStore>()
+                .Scoped()
+                .AsSelf()
+                .AsImplementedInterfaces();
+
+            services.Add<DynamicFhirGetResourceHandler>()
+                .Scoped()
+                .AsSelf()
+                .AsImplementedInterfaces();
+
+            return services;
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.DynamicFhir.Core/FhirDicomStore.cs
+++ b/src/Microsoft.Health.Dicom.DynamicFhir.Core/FhirDicomStore.cs
@@ -1,0 +1,89 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Features.Conformance;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Core
+{
+    public class FhirDicomStore : IFhirDataStore, IProvideCapability
+    {
+        private const string _fhirDicomCodingScheme = "dicom";
+        private const string _testModality = "CT";
+        private const string _testDescription = "Test Description";
+        private const string _testUid = "1.2.3.4";
+        private const string _resourceId = "42";
+
+        private readonly IResourceWrapperFactory _resourceWrapperFactory;
+
+        public FhirDicomStore(IResourceWrapperFactory resourceWrapperFactory)
+        {
+            EnsureArg.IsNotNull(resourceWrapperFactory, nameof(resourceWrapperFactory));
+
+            _resourceWrapperFactory = resourceWrapperFactory;
+        }
+
+        public void Build(ListedCapabilityStatement statement)
+        {
+            var supportedResources = new[]
+            {
+                ResourceType.Patient,
+                ResourceType.ImagingStudy,
+                ResourceType.Endpoint,
+                ResourceType.CompartmentDefinition,
+                ResourceType.Bundle,
+                ResourceType.CapabilityStatement,
+            };
+
+            foreach (var resourceType in supportedResources)
+            {
+                statement.BuildRestResourceComponent(resourceType, builder =>
+                {
+                    builder.Versioning.Add(CapabilityStatement.ResourceVersionPolicy.NoVersion);
+                    builder.ReadHistory = false;
+                });
+
+                statement.TryAddRestInteraction(resourceType, CapabilityStatement.TypeRestfulInteraction.Read);
+            }
+        }
+
+        public Task<ResourceWrapper> GetAsync(ResourceKey key, CancellationToken cancellationToken)
+        {
+            if (key.Id == _resourceId && key.ResourceType == ResourceType.ImagingStudy.ToString())
+            {
+                // Fake implementation untill we can hook up to Dicom Storage
+                var imagingStudy = new ImagingStudy();
+                imagingStudy.Id = key.Id;
+                imagingStudy.Meta = new Meta() { VersionId = key.Id };
+
+                imagingStudy.Description = _testDescription;
+                imagingStudy.Uid = _testUid;
+                imagingStudy.ModalityList = new[] { _testModality }.Select(t => new Coding(_fhirDicomCodingScheme, t)).ToList();
+
+                return Task.FromResult(_resourceWrapperFactory.Create(imagingStudy, false));
+            }
+            else
+            {
+                return Task.FromResult<ResourceWrapper>(null);
+            }
+        }
+
+        public Task HardDeleteAsync(ResourceKey key, CancellationToken cancellationToken)
+        {
+            throw new System.NotSupportedException();
+        }
+
+        public Task<UpsertOutcome> UpsertAsync(ResourceWrapper resource, WeakETag weakETag, bool allowCreate, bool keepHistory, CancellationToken cancellationToken)
+        {
+            throw new System.NotSupportedException();
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.DynamicFhir.Core/Microsoft.Health.Dicom.DynamicFhir.Core.csproj
+++ b/src/Microsoft.Health.Dicom.DynamicFhir.Core/Microsoft.Health.Dicom.DynamicFhir.Core.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="DefaultCapabilities.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="DefaultCapabilities.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Health.Fhir.Core" Version="1.0.0-master-20190514-1" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.Health.Dicom.DynamicFhir.Web/Microsoft.Health.Dicom.DynamicFhir.Web.csproj
+++ b/src/Microsoft.Health.Dicom.DynamicFhir.Web/Microsoft.Health.Dicom.DynamicFhir.Web.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <IsPackable>true</IsPackable>
+    <CodeAnalysisRuleSet>..\..\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
+    <UserSecretsId>29a71f18-2146-4ff0-a511-da3cf615d951</UserSecretsId>
+    <AssemblyName>Microsoft.Health.Dicom.DynamicFhir.Web</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="IdentityServer4" Version="2.4.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.6.1" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.4.0" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.2.0-preview2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.9.1" />
+    <PackageReference Include="Microsoft.Health.Fhir.Web" Version="1.0.0-master-20190514-1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Health.Dicom.DynamicFhir.Core\Microsoft.Health.Dicom.DynamicFhir.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.Health.Dicom.DynamicFhir.Web/Program.cs
+++ b/src/Microsoft.Health.Dicom.DynamicFhir.Web/Program.cs
@@ -1,0 +1,41 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Azure.KeyVault;
+using Microsoft.Azure.Services.AppAuthentication;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.AzureKeyVault;
+using Microsoft.Health.Fhir.Web;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Web
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            var host = WebHost.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration((hostContext, builder) =>
+                {
+                    var builtConfig = builder.Build();
+
+                    var keyVaultEndpoint = builtConfig["KeyVault:Endpoint"];
+                    if (!string.IsNullOrEmpty(keyVaultEndpoint))
+                    {
+                        var azureServiceTokenProvider = new AzureServiceTokenProvider();
+                        var keyVaultClient = new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(azureServiceTokenProvider.KeyVaultTokenCallback));
+                        builder.AddAzureKeyVault(keyVaultEndpoint, keyVaultClient, new DefaultKeyVaultSecretManager());
+                    }
+
+                    builder.AddDevelopmentAuthEnvironment(builtConfig["TestAuthEnvironment:FilePath"]);
+                })
+                .UseStartup<Startup>()
+                .Build();
+
+            host.Run();
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.DynamicFhir.Web/Properties/launchSettings.json
+++ b/src/Microsoft.Health.Dicom.DynamicFhir.Web/Properties/launchSettings.json
@@ -1,0 +1,38 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:53727/",
+      "sslPort": 44348
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "development",
+        "TestAuthEnvironment:FilePath": "..//..//testauthenvironment.json"
+      }
+    },
+    "Microsoft.Health.Dicom.DynamicFhir.Web": {
+      "commandName": "Project",
+      "launchBrowser": true,
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "development",
+            "TestAuthEnvironment:FilePath": "..//..//testauthenvironment.json"
+        },
+      "applicationUrl": "https://localhost:44348/"
+    },
+    "ExternallyDefinedAuth": {
+      "commandName": "Project",
+      "launchBrowser": true,
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "development"
+        },
+      "applicationUrl": "https://localhost:44348/"
+    }
+
+  }
+}

--- a/src/Microsoft.Health.Dicom.DynamicFhir.Web/Startup.cs
+++ b/src/Microsoft.Health.Dicom.DynamicFhir.Web/Startup.cs
@@ -1,0 +1,71 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Health.Dicom.DynamicFhir.Core;
+using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Web;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Web
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public virtual void ConfigureServices(IServiceCollection services)
+        {
+            services
+                .AddDevelopmentIdentityProvider(Configuration);
+
+            services
+                .AddFhirServer(Configuration)
+                .Services
+                    .ReplaceConfiguredConformanceProvider()
+                    .ReplaceResourceHandlers()
+                    .AddHealthChecks();
+
+            AddApplicationInsightsTelemetry(services);
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public virtual void Configure(IApplicationBuilder app)
+        {
+            app.UseFhirServer();
+
+            app.UseDevelopmentIdentityProvider();
+        }
+
+        /// <summary>
+        /// Adds ApplicationInsights for telemetry and logging.
+        /// </summary>
+        private void AddApplicationInsightsTelemetry(IServiceCollection services)
+        {
+            string instrumentationKey = Configuration["ApplicationInsights:InstrumentationKey"];
+
+            if (!string.IsNullOrWhiteSpace(instrumentationKey))
+            {
+                services.AddApplicationInsightsTelemetry(instrumentationKey);
+                services.AddLogging(loggingBuilder => loggingBuilder.AddApplicationInsights(instrumentationKey));
+            }
+        }
+
+        private void AddFhirDicomStore(IServiceCollection services)
+        {
+            services.Add<FhirDicomStore>()
+            .Scoped()
+            .AsSelf()
+            .AsImplementedInterfaces();
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.DynamicFhir.Web/appsettings.Development.json
+++ b/src/Microsoft.Health.Dicom.DynamicFhir.Web/appsettings.Development.json
@@ -1,0 +1,11 @@
+﻿{
+    "Logging": {
+        "IncludeScopes": false,
+        "LogLevel": {
+            "Default": "Debug",
+            "Microsoft.Health": "Debug",
+            "Microsoft": "Information",
+            "System": "Information"
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.DynamicFhir.Web/appsettings.json
+++ b/src/Microsoft.Health.Dicom.DynamicFhir.Web/appsettings.json
@@ -1,0 +1,90 @@
+﻿{
+    "FhirServer": {
+        "Conformance": {
+            "UseStrictConformance": true
+        },
+        "Security": {
+            "Enabled": true,
+            "EnableAadSmartOnFhirProxy": true,
+            "Authentication": {
+                "Audience": null,
+                "Authority": "https://localhost:44348"
+            },
+            "LastModifiedClaims": [
+                "oid"
+            ],
+            "Authorization": {
+                "Enabled": true
+            }
+        },
+        "Features": {
+            "SupportsUI": false,
+            "SupportsXml": true
+        },
+        "CosmosDb": {
+            "CollectionId": "fhir",
+            "InitialCollectionThroughput": null
+        },
+        "Cors": {
+            "Origins": [],
+            "Methods": [],
+            "Headers": [],
+            "MaxAge": null,
+            "AllowCredentials": false
+        },
+        "Operations": {
+            "Export": {
+                "Enabled": false,
+                "MaximumNumberOfConcurrentJobsAllowed": 1,
+                "JobHeartbeatTimeoutThreshold": "00:10:00",
+                "JobPollingFrequency": "00:00:10",
+                "SupportedDestinations": [ "" ]
+            }
+        }
+    },
+    "CosmosDb": {
+        "Host": null,
+        "Key": null,
+        "DatabaseId": "health",
+        "InitialDatabaseThroughput": null,
+        "ConnectionMode": "Direct",
+        "ConnectionProtocol": "Tcp",
+        "ContinuationTokenSizeLimitInKb": 2,
+        "DefaultConsistencyLevel": "Session",
+        "PreferredLocations": [],
+        "RetryOptions": {
+            "MaxNumberOfRetries": 3,
+            "MaxWaitTimeInSeconds": 5
+        }
+    },
+    "DicomWeb": {
+        "Enabled": true,
+        "BlobStore": {
+            "ContainerName": "dicomwebcontainer"
+        },
+        "CosmosDb": {
+            "CollectionId": "dicom",
+            "InitialCollectionThroughPut": null
+        }
+    },
+    "KeyVault": {
+        "Endpoint": null
+    },
+    "Logging": {
+        "IncludeScopes": false,
+        "LogLevel": {
+            "Default": "Warning"
+        },
+        "ApplicationInsights": {
+            "LogLevel": {
+                "Default": "Information",
+                "Microsoft.Health": "Information",
+                "Microsoft": "Warning",
+                "System": "Warning"
+            }
+        }
+    },
+    "ApplicationInsights": {
+        "InstrumentationKey": ""
+    }
+}

--- a/src/Microsoft.Health.Dicom.DynamicFhir.Web/runtimeconfig.template.json
+++ b/src/Microsoft.Health.Dicom.DynamicFhir.Web/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+    "applyPatches": false
+}

--- a/test/Configuration/corstestconfiguration.json
+++ b/test/Configuration/corstestconfiguration.json
@@ -1,0 +1,10 @@
+{
+    "FhirServer": {
+        "Cors": { 
+            "Origins": ["https://localhost:6001"],
+            "Methods": ["*"],
+            "Headers": ["*"],
+            "MaxAge": 1440 
+        }
+    }
+}

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/AssemblyInfo.cs
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Xunit;
+
+[assembly: TestFramework(typeName: "Microsoft.Health.Extensions.Xunit.FixtureArgumentSetsXunitTestFramework", assemblyName: "Microsoft.Health.Extensions.Xunit")]

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Common/Constants.cs
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Common/Constants.cs
@@ -1,0 +1,14 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Common
+{
+    public static class Constants
+    {
+        public const string SmartOAuthUriExtension = "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris";
+        public const string SmartOAuthUriExtensionToken = "token";
+        public const string SmartOAuthUriExtensionAuthorize = "authorize";
+    }
+}

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Common/FhirClient.cs
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Common/FhirClient.cs
@@ -1,0 +1,273 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using EnsureThat;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Rest;
+using Hl7.Fhir.Serialization;
+using Microsoft.Health.Fhir.Tests.E2E.Common;
+using Newtonsoft.Json.Linq;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Common
+{
+    public class FhirClient
+    {
+        private readonly ResourceFormat _format;
+        private readonly Dictionary<string, string> _bearerTokens = new Dictionary<string, string>();
+        private readonly string _contentType;
+
+        private readonly BaseFhirSerializer _serializer;
+        private readonly BaseFhirParser _parser;
+
+        private readonly Func<Base, SummaryType, string> _serialize;
+        private readonly Func<string, Resource> _deserialize;
+        private readonly MediaTypeWithQualityHeaderValue _mediaType;
+
+        public FhirClient(HttpClient httpClient, ResourceFormat format)
+        {
+            HttpClient = httpClient;
+            _format = format;
+
+            if (format == ResourceFormat.Json)
+            {
+                var jsonSerializer = new FhirJsonSerializer();
+
+                _serializer = jsonSerializer;
+                _serialize = (resource, summary) => jsonSerializer.SerializeToString(resource, summary);
+
+                var jsonParser = new FhirJsonParser();
+
+                _parser = jsonParser;
+                _deserialize = jsonParser.Parse<Resource>;
+
+                _contentType = ContentType.JSON_CONTENT_HEADER;
+            }
+            else if (format == ResourceFormat.Xml)
+            {
+                var xmlSerializer = new FhirXmlSerializer();
+
+                _serializer = xmlSerializer;
+                _serialize = (resource, summary) => xmlSerializer.SerializeToString(resource, summary);
+
+                var xmlParser = new FhirXmlParser();
+
+                _parser = xmlParser;
+                _deserialize = xmlParser.Parse<Resource>;
+
+                _contentType = ContentType.XML_CONTENT_HEADER;
+            }
+            else
+            {
+                throw new InvalidOperationException("Unsupported format.");
+            }
+
+            _mediaType = MediaTypeWithQualityHeaderValue.Parse(_contentType);
+            SetupAuthenticationAsync(TestApplications.ServiceClient).GetAwaiter().GetResult();
+        }
+
+        public (bool SecurityEnabled, string AuthorizeUrl, string TokenUrl) SecuritySettings { get; private set; }
+
+        public HttpClient HttpClient { get; }
+
+        public async Task RunAsUser(TestUser user, TestApplication clientApplication)
+        {
+            EnsureArg.IsNotNull(user, nameof(user));
+            EnsureArg.IsNotNull(clientApplication, nameof(clientApplication));
+            await SetupAuthenticationAsync(clientApplication, user);
+        }
+
+        public async Task RunAsClientApplication(TestApplication clientApplication)
+        {
+            EnsureArg.IsNotNull(clientApplication, nameof(clientApplication));
+            await SetupAuthenticationAsync(clientApplication);
+        }
+
+        public Task<FhirResponse<T>> CreateAsync<T>(T resource)
+            where T : Resource
+        {
+            return CreateAsync(resource.ResourceType.ToString(), resource);
+        }
+
+        public async Task<FhirResponse<T>> CreateAsync<T>(string uri, T resource)
+            where T : Resource
+        {
+            var message = new HttpRequestMessage(HttpMethod.Post, uri);
+            message.Headers.Accept.Add(_mediaType);
+            message.Content = CreateStringContent(resource);
+
+            HttpResponseMessage response = await HttpClient.SendAsync(message);
+
+            await EnsureSuccessStatusCodeAsync(response);
+
+            return await CreateResponseAsync<T>(response);
+        }
+
+        public Task<FhirResponse<T>> ReadAsync<T>(ResourceType resourceType, string resourceId)
+            where T : Resource
+        {
+            return ReadAsync<T>($"{resourceType}/{resourceId}");
+        }
+
+        public async Task<FhirResponse<T>> ReadAsync<T>(string uri)
+            where T : Resource
+        {
+            var message = new HttpRequestMessage(HttpMethod.Get, uri);
+            message.Headers.Accept.Add(_mediaType);
+
+            HttpResponseMessage response = await HttpClient.SendAsync(message);
+
+            await EnsureSuccessStatusCodeAsync(response);
+
+            return await CreateResponseAsync<T>(response);
+        }
+
+        public async Task ReadUntypedAsync(ResourceType resourceType, string resourceId)
+        {
+            var message = new HttpRequestMessage(HttpMethod.Get, $"{resourceType}/{resourceId}");
+            message.Headers.Accept.Add(_mediaType);
+
+            HttpResponseMessage response = await HttpClient.SendAsync(message);
+
+            await EnsureSuccessStatusCodeAsync(response);
+        }
+
+        public Task<FhirResponse<T>> VReadAsync<T>(ResourceType resourceType, string resourceId, string versionId)
+            where T : Resource
+        {
+            return ReadAsync<T>($"{resourceType}/{resourceId}/_history/{versionId}");
+        }
+
+        public async Task<FhirResponse<Bundle>> SearchAsync(string url)
+        {
+            var message = new HttpRequestMessage(HttpMethod.Get, url);
+            message.Headers.Accept.Add(_mediaType);
+
+            HttpResponseMessage response = await HttpClient.SendAsync(message);
+
+            await EnsureSuccessStatusCodeAsync(response);
+
+            return await CreateResponseAsync<Bundle>(response);
+        }
+
+        private StringContent CreateStringContent(Resource resource)
+        {
+            return new StringContent(_serialize(resource, SummaryType.False), Encoding.UTF8, _contentType);
+        }
+
+        private async Task EnsureSuccessStatusCodeAsync(HttpResponseMessage response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                FhirResponse<OperationOutcome> operationOutcome = await CreateResponseAsync<OperationOutcome>(response);
+
+                throw new FhirException(operationOutcome);
+            }
+        }
+
+        private async Task<FhirResponse<T>> CreateResponseAsync<T>(HttpResponseMessage response)
+            where T : Resource
+        {
+            string content = await response.Content.ReadAsStringAsync();
+
+            return new FhirResponse<T>(
+                response,
+                string.IsNullOrWhiteSpace(content) ? null : (T)_deserialize(content));
+        }
+
+        private async Task SetupAuthenticationAsync(TestApplication clientApplication, TestUser user = null)
+        {
+            await GetSecuritySettings("metadata");
+
+            if (SecuritySettings.SecurityEnabled)
+            {
+                var tokenKey = $"{clientApplication.ClientId}:{(user == null ? string.Empty : user.UserId)}";
+
+                if (!_bearerTokens.TryGetValue(tokenKey, out string bearerToken))
+                {
+                    bearerToken = await GetBearerToken(clientApplication, user);
+                    _bearerTokens[tokenKey] = bearerToken;
+                }
+
+                HttpClient.SetBearerToken(bearerToken);
+            }
+        }
+
+        private async Task<string> GetBearerToken(TestApplication clientApplication, TestUser user)
+        {
+            if (clientApplication.Equals(TestApplications.InvalidClient))
+            {
+                return null;
+            }
+
+            var formContent = new FormUrlEncodedContent(user == null ? GetAppSecuritySettings(clientApplication) : GetUserSecuritySettings(clientApplication, user));
+
+            HttpResponseMessage tokenResponse = await HttpClient.PostAsync(SecuritySettings.TokenUrl, formContent);
+
+            var tokenJson = JObject.Parse(await tokenResponse.Content.ReadAsStringAsync());
+
+            var bearerToken = tokenJson["access_token"].Value<string>();
+
+            return bearerToken;
+        }
+
+        private List<KeyValuePair<string, string>> GetAppSecuritySettings(TestApplication clientApplication)
+        {
+            string scope = clientApplication == TestApplications.WrongAudienceClient ? clientApplication.ClientId : AuthenticationSettings.Scope;
+            string resource = clientApplication == TestApplications.WrongAudienceClient ? clientApplication.ClientId : AuthenticationSettings.Resource;
+
+            return new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("client_id", clientApplication.ClientId),
+                new KeyValuePair<string, string>("client_secret", clientApplication.ClientSecret),
+                new KeyValuePair<string, string>("grant_type", clientApplication.GrantType),
+                new KeyValuePair<string, string>("scope", scope),
+                new KeyValuePair<string, string>("resource", resource),
+            };
+        }
+
+        private List<KeyValuePair<string, string>> GetUserSecuritySettings(TestApplication clientApplication, TestUser user)
+        {
+            return new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("client_id", clientApplication.ClientId),
+                new KeyValuePair<string, string>("client_secret", clientApplication.ClientSecret),
+                new KeyValuePair<string, string>("grant_type", user.GrantType),
+                new KeyValuePair<string, string>("scope", AuthenticationSettings.Scope),
+                new KeyValuePair<string, string>("resource", AuthenticationSettings.Resource),
+                new KeyValuePair<string, string>("username", user.UserId),
+                new KeyValuePair<string, string>("password", user.Password),
+            };
+        }
+
+        private async Task GetSecuritySettings(string fhirServerMetadataUrl)
+        {
+            FhirResponse<CapabilityStatement> readResponse = await ReadAsync<CapabilityStatement>(fhirServerMetadataUrl);
+            var metadata = readResponse.Resource;
+
+            foreach (var rest in metadata.Rest.Where(r => r.Mode == CapabilityStatement.RestfulCapabilityMode.Server))
+            {
+                var oauth = rest.Security?.GetExtension(Constants.SmartOAuthUriExtension);
+                if (oauth != null)
+                {
+                    var tokenUrl = oauth.GetExtensionValue<FhirUri>(Constants.SmartOAuthUriExtensionToken).Value;
+                    var authorizeUrl = oauth.GetExtensionValue<FhirUri>(Constants.SmartOAuthUriExtensionAuthorize).Value;
+
+                    SecuritySettings = (true, authorizeUrl, tokenUrl);
+                    return;
+                }
+            }
+
+            SecuritySettings = (false, null, null);
+        }
+    }
+}

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Microsoft.AspNetCore.Mvc.Testing.targets
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Microsoft.AspNetCore.Mvc.Testing.targets
@@ -1,0 +1,37 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!--
+    Work around https://github.com/NuGet/Home/issues/4412. MVC uses DependencyContext.Load() which looks next to a .dll
+    for a .deps.json. Information isn't available elsewhere. Need the .deps.json file for all web site applications.
+  -->
+  <PropertyGroup>
+    <!--
+      The functional tests act as the host application for all test websites. Since the CLI copies all reference
+      assembly dependencies in websites to their corresponding bin/{config}/refs folder we need to re-calculate
+      reference assemblies for this project so there's a corresponding refs folder in our output. Without it
+      our websites deps files will fail to find their assembly references.
+    -->
+
+    <PreserveCompilationContext>true</PreserveCompilationContext>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'netcoreapp2.2' ">
+    <!-- Work around https://github.com/dotnet/sdk/issues/926. Align with bitness of the web site projects. -->
+    <PlatformTarget>x86</PlatformTarget>
+
+    <!--
+      Work around https://github.com/Microsoft/vstest/issues/428 aka https://github.com/aspnet/Mvc/issues/5873.
+      Create the appropriate binding redirects.
+    -->
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
+
+  <Target Name="CopyAditionalFiles" AfterTargets="Build" Condition="'$(TargetFramework)'!=''">
+    <ItemGroup>
+      <DepsFilePaths Include="$([System.IO.Path]::ChangeExtension('%(_ResolvedProjectReferencePaths.FullPath)', '.deps.json'))" />
+    </ItemGroup>
+
+    <Copy SourceFiles="%(DepsFilePaths.FullPath)" DestinationFolder="$(OutputPath)" Condition="Exists('%(DepsFilePaths.FullPath)')" />
+  </Target>
+</Project>

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.csproj
@@ -1,0 +1,71 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\testauthenvironment.json" Link="testauthenvironment.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\configuration\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="..\configuration\exporttestconfiguration.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Health.Extensions.Xunit" Version="1.0.0-master-20190514-1" />
+    <PackageReference Include="Microsoft.Health.Fhir.Tests.Common" Version="1.0.0-master-20190514-1" />
+    <PackageReference Include="Microsoft.Health.Fhir.Tests.E2E" Version="1.0.0-master-20190514-1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="selenium.chrome.webdriver" Version="2.45.0" />
+    <PackageReference Include="selenium.webdriver" Version="3.141.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Health.Dicom.DynamicFhir.Web\Microsoft.Health.Dicom.DynamicFhir.Web.csproj" />
+    <ProjectReference Include="..\Microsoft.Health.Dicom.Web.Tests.E2E\Microsoft.Health.Dicom.Web.Tests.E2E.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <Import Project="Microsoft.AspNetCore.Mvc.Testing.targets" />
+
+  <Target Name="VerifyExactSdkVersion" BeforeTargets="Build">
+
+    <!--
+      Verify that the we are compiling with the exact version of the SDK that is specified in the global.json file.
+      If the version specified in the file is not installed on the system, dotnet uses the latest installed version instead.
+      We want to avoid that behavior because new SDK versions by default target the runtime version it is released with,
+      so the runtime behavior could be different depending on what SDK versions were installed on the machine that compiled
+      the code.
+    -->
+
+    <PropertyGroup>
+      <GlobalJsonPath>$([MSBuild]::GetPathOfFileAbove(global.json))</GlobalJsonPath>
+      <GlobalJsonContent>$([System.IO.File]::ReadAllText($(GlobalJsonPath)))</GlobalJsonContent>
+      <ParsedSdkVersion><![CDATA[$([System.Text.RegularExpressions.Regex]::Match($(GlobalJsonContent), '"version"\s*:\s*"(\d+.\d+.\d+)"').Groups[1].Value)]]></ParsedSdkVersion>
+    </PropertyGroup>
+  
+    <Error Condition="$(NETCoreSdkVersion) != $(ParsedSdkVersion)" Text="The .NET SDK version required by $(GlobalJsonPath) is $(ParsedSdkVersion) but that version does not seem to be installed. In order to ensure consistent behavior, please install version $(ParsedSdkVersion) of the .NET SDK from https://dotnet.microsoft.com/download." />
+  </Target>
+
+  <Target Name="AddRuntimeConfigFileToBuiltProjectOutputGroupOutput" Condition=" '$(GenerateRuntimeConfigurationFiles)' == 'true'" BeforeTargets="BuiltProjectOutputGroup">
+    <ItemGroup>
+      <BuiltProjectOutputGroupOutput Include="$(ProjectRuntimeConfigFilePath)" FinalOutputPath="$(ProjectRuntimeConfigFilePath)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/Audit/AuditEntry.cs
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/Audit/AuditEntry.cs
@@ -1,0 +1,40 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using Microsoft.Health.Fhir.Api.Features.Audit;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Rest.Audit
+{
+    public class AuditEntry
+    {
+        public AuditEntry(AuditAction auditAction, string action, string resourceType, Uri requestUri, HttpStatusCode? statusCode, string correlationId, IReadOnlyCollection<KeyValuePair<string, string>> claims)
+        {
+            AuditAction = auditAction;
+            Action = action;
+            ResourceType = resourceType;
+            RequestUri = requestUri;
+            StatusCode = statusCode;
+            CorrelationId = correlationId;
+            Claims = claims;
+        }
+
+        public AuditAction AuditAction { get; }
+
+        public string Action { get; }
+
+        public string ResourceType { get; }
+
+        public Uri RequestUri { get; }
+
+        public HttpStatusCode? StatusCode { get; }
+
+        public string CorrelationId { get; }
+
+        public IReadOnlyCollection<KeyValuePair<string, string>> Claims { get; }
+    }
+}

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/Audit/AuditTestFixture.cs
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/Audit/AuditTestFixture.cs
@@ -1,0 +1,34 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Api.Features.Audit;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Rest.Audit
+{
+    public class AuditTestFixture : DicomFhirIntegrationTestFixture<StartupWithTraceAuditLogger>
+    {
+        private TraceAuditLogger _auditLogger;
+
+        public AuditTestFixture(DataStore dataStore, Format format)
+            : base(dataStore, format)
+        {
+        }
+
+        public TraceAuditLogger AuditLogger
+        {
+            get
+            {
+                if (_auditLogger == null)
+                {
+                    _auditLogger = (TraceAuditLogger)FhirFixture.Server?.Host.Services.GetRequiredService<IAuditLogger>();
+                }
+
+                return _auditLogger;
+            }
+        }
+    }
+}

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/Audit/AuditTests.cs
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/Audit/AuditTests.cs
@@ -1,0 +1,286 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Rest;
+using Microsoft.Health.Fhir.Api.Features.Audit;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Tests.E2E.Common;
+using Xunit;
+using FhirClient = Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Common.FhirClient;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Rest.Audit
+{
+    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.Json)]
+    public class AuditTests : IClassFixture<AuditTestFixture>
+    {
+        private const string RequestIdHeaderName = "X-Request-Id";
+        private const string ExpectedClaimKey = "appid";
+
+        private readonly AuditTestFixture _fixture;
+        private readonly FhirClient _client;
+
+        private readonly TraceAuditLogger _auditLogger;
+
+        public AuditTests(AuditTestFixture fixture)
+        {
+            _fixture = fixture;
+            _client = fixture.FhirFixture.FhirClient;
+            _auditLogger = _fixture.AuditLogger;
+        }
+
+        [Fact]
+        public async Task GivenAnExistingResource_WhenRead_ThenAuditLogEntriesShouldBeCreated()
+        {
+            await ExecuteAndValidate(
+                async () =>
+                {
+                    var studyUid = await _fixture.PostNewSampleStudyAsync();
+                    return await _client.ReadAsync<ImagingStudy>(ResourceType.ImagingStudy, studyUid);
+                },
+                "read",
+                ResourceType.ImagingStudy,
+                p => $"ImagingStudy/{p.Id}",
+                HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task GivenANonExistingResource_WhenRead_ThenAuditLogEntriesShouldBeCreated()
+        {
+            // TODO: The resource type being logged here is incorrect. The issue is tracked by https://github.com/Microsoft/fhir-server/issues/334.
+            await ExecuteAndValidate(
+                async () =>
+                {
+                    FhirResponse<OperationOutcome> result = null;
+
+                    try
+                    {
+                        await _client.ReadAsync<Patient>(ResourceType.Patient, "123");
+                    }
+                    catch (FhirException ex)
+                    {
+                        result = ex.Response;
+                    }
+
+                    return result;
+                },
+                "read",
+                ResourceType.OperationOutcome,
+                _ => $"Patient/123",
+                HttpStatusCode.NotFound);
+        }
+
+        [Fact]
+        public async Task GivenARequest_WhenNoAuthorizationTokenIsSupplied_ThenAuditLogEntriesShouldBeCreated()
+        {
+            await ExecuteAndValidate(
+                client =>
+                {
+                    client.HttpClient.DefaultRequestHeaders.Authorization = null;
+
+                    return Task.CompletedTask;
+                },
+                HttpStatusCode.Unauthorized,
+                expectedAppId: null);
+        }
+
+        [Fact]
+        public async Task GivenARequest_WhenInvalidAuthorizationTokenIsSupplied_ThenAuditLogEntriesShouldBeCreated()
+        {
+            await ExecuteAndValidate(
+                client =>
+                {
+                    client.HttpClient.SetBearerToken("invalid");
+
+                    return Task.CompletedTask;
+                },
+                HttpStatusCode.Unauthorized,
+                expectedAppId: null);
+        }
+
+        [Fact]
+        public async Task GivenARequest_WhenValidAuthorizationTokenWithInvalidAudienceIsSupplied_ThenAuditLogEntriesShouldBeCreated()
+        {
+            await ExecuteAndValidate(
+                client => client.RunAsClientApplication(TestApplications.WrongAudienceClient),
+                HttpStatusCode.Unauthorized,
+                expectedAppId: null);
+        }
+
+        [Fact]
+        public async Task GivenASmartOnFhirRequest_WhenAuthorizeIsCalled_TheAuditLogEntriesShouldBeCreated()
+        {
+            const string pathSegment = "AadSmartOnFhirProxy/authorize?client_id=1234&response_type=json&redirect_uri=httptest&aud=localhost";
+            await ExecuteAndValidate(
+                async () => await _client.HttpClient.GetAsync(pathSegment),
+                "smart-on-fhir-authorize",
+                pathSegment,
+                HttpStatusCode.Redirect,
+                "1234",
+                "client_id");
+        }
+
+        [Fact]
+        public async Task GivenASmartOnFhirRequest_WhenCallbackIsCalled_TheAuditLogEntriesShouldBeCreated()
+        {
+            const string pathSegment = "AadSmartOnFhirProxy/callback/aHR0cHM6Ly9sb2NhbGhvc3Q=?code=1234&state=1234&session_state=1234";
+            await ExecuteAndValidate(
+                async () => await _client.HttpClient.GetAsync(pathSegment),
+                "smart-on-fhir-callback",
+                pathSegment,
+                HttpStatusCode.BadRequest,
+                null,
+                null);
+        }
+
+        [Fact]
+        public async Task GivenASmartOnFhirRequest_WhenTokenIsCalled_TheAuditLogEntriesShouldBeCreated()
+        {
+            const string pathSegment = "AadSmartOnFhirProxy/token";
+            var formFields = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("client_id", "1234"),
+                new KeyValuePair<string, string>("grant_type", "grantType"),
+                new KeyValuePair<string, string>("code", "code"),
+                new KeyValuePair<string, string>("redirect_uri", "redirectUri"),
+                new KeyValuePair<string, string>("client_secret", "client_secret"),
+            };
+
+            var content = new FormUrlEncodedContent(formFields);
+            await ExecuteAndValidate(
+                async () => await _client.HttpClient.PostAsync(pathSegment, content),
+                "smart-on-fhir-token",
+                pathSegment,
+                HttpStatusCode.BadRequest,
+                "1234",
+                "client_id");
+        }
+
+        [Fact]
+        public async Task GivenAResource_WhenNotAuthorized_ThenAuditLogEntriesShouldBeCreated()
+        {
+            await ExecuteAndValidate(
+                client => client.RunAsClientApplication(TestApplications.NativeClient),
+                HttpStatusCode.Forbidden,
+                expectedAppId: TestApplications.NativeClient.ClientId);
+        }
+
+        private async Task ExecuteAndValidate<T>(Func<Task<FhirResponse<T>>> action, string expectedAction, ResourceType expectedResourceType, Func<T, string> expectedPathGenerator, HttpStatusCode expectedStatusCode)
+            where T : Resource
+        {
+            if (!_fixture.FhirFixture.IsUsingInProcTestServer)
+            {
+                // This test only works with the in-proc server with customized middleware pipeline.
+                return;
+            }
+
+            FhirResponse<T> response = null;
+
+            response = await action();
+
+            string correlationId = response.Headers.GetValues(RequestIdHeaderName).FirstOrDefault();
+
+            Assert.NotNull(correlationId);
+
+            var expectedUri = new Uri($"http://localhost/{expectedPathGenerator(response.Resource)}");
+
+            string expectedAppId = TestApplications.ServiceClient.ClientId;
+
+            Assert.Collection(
+                _auditLogger.GetAuditEntriesByCorrelationId(correlationId),
+                ae => ValidateExecutingAuditEntry(ae, expectedAction, expectedUri, correlationId, expectedAppId, ExpectedClaimKey),
+                ae => ValidateExecutedAuditEntry(ae, expectedAction, expectedResourceType, expectedUri, expectedStatusCode, correlationId, expectedAppId, ExpectedClaimKey));
+        }
+
+        private async Task ExecuteAndValidate(Func<Task<HttpResponseMessage>> action, string expectedAction, string expectedPathSegment, HttpStatusCode expectedStatusCode, string expectedClaimValue, string expectedClaimKey)
+        {
+            if (!_fixture.FhirFixture.IsUsingInProcTestServer)
+            {
+                // This test only works with the in-proc server with customized middleware pipeline
+                return;
+            }
+
+            HttpResponseMessage response = await action();
+
+            string correlationId = response.Headers.GetValues(RequestIdHeaderName).FirstOrDefault();
+
+            Assert.NotNull(correlationId);
+
+            var expectedUri = new Uri($"http://localhost/{expectedPathSegment}");
+
+            Assert.Collection(
+                _auditLogger.GetAuditEntriesByCorrelationId(correlationId),
+                ae => ValidateExecutingAuditEntry(ae, expectedAction, expectedUri, correlationId, expectedClaimValue, expectedClaimKey),
+                ae => ValidateExecutedAuditEntry(ae, expectedAction, null, expectedUri, expectedStatusCode, correlationId, expectedClaimValue, expectedClaimKey));
+        }
+
+        private async Task ExecuteAndValidate(Func<FhirClient, Task> clientSetup, HttpStatusCode expectedStatusCode, string expectedAppId)
+        {
+            if (!_fixture.FhirFixture.IsUsingInProcTestServer || !_fixture.FhirFixture.FhirClient.SecuritySettings.SecurityEnabled)
+            {
+                // This test only works with the in-proc server with customized middleware pipeline and when security is enabled.
+                return;
+            }
+
+            const string url = "Patient/123";
+
+            // Create a new client with no token supplied.
+            var client = new FhirClient(_fixture.FhirFixture.CreateHttpClient(), ResourceFormat.Json);
+
+            await clientSetup(client);
+
+            FhirResponse<OperationOutcome> response = (await Assert.ThrowsAsync<FhirException>(() => client.ReadAsync<Patient>(url))).Response;
+
+            string correlationId = response.Headers.GetValues(RequestIdHeaderName).FirstOrDefault();
+
+            Assert.NotNull(correlationId);
+
+            var expectedUri = new Uri($"http://localhost/{url}");
+
+            Assert.Collection(
+                _auditLogger.GetAuditEntriesByCorrelationId(correlationId),
+                ae => ValidateExecutedAuditEntry(ae, "read", ResourceType.Patient, expectedUri, expectedStatusCode, correlationId, expectedAppId, ExpectedClaimKey));
+        }
+
+        private void ValidateExecutingAuditEntry(AuditEntry auditEntry, string expectedAction, Uri expectedUri, string expectedCorrelationId, string expectedClaimValue, string expectedClaimKey)
+        {
+            ValidateAuditEntry(auditEntry, AuditAction.Executing, expectedAction, null, expectedUri, null, expectedCorrelationId, expectedClaimValue, expectedClaimKey);
+        }
+
+        private void ValidateExecutedAuditEntry(AuditEntry auditEntry, string expectedAction, ResourceType? expectedResourceType, Uri expectedUri, HttpStatusCode? expectedStatusCode, string expectedCorrelationId, string expectedClaimValue, string expectedClaimKey)
+        {
+            ValidateAuditEntry(auditEntry, AuditAction.Executed, expectedAction, expectedResourceType, expectedUri, expectedStatusCode, expectedCorrelationId, expectedClaimValue, expectedClaimKey);
+        }
+
+        private void ValidateAuditEntry(AuditEntry auditEntry, AuditAction expectedAuditAction, string expectedAction, ResourceType? expectedResourceType, Uri expectedUri, HttpStatusCode? expectedStatusCode, string expectedCorrelationId, string expectedClaimValue, string expectedClaimKey)
+        {
+            Assert.NotNull(auditEntry);
+            Assert.Equal(expectedAuditAction, auditEntry.AuditAction);
+            Assert.Equal(expectedAction, auditEntry.Action);
+            Assert.Equal(expectedResourceType?.ToString(), auditEntry.ResourceType);
+            Assert.Equal(expectedUri, auditEntry.RequestUri);
+            Assert.Equal(expectedStatusCode, auditEntry.StatusCode);
+            Assert.Equal(expectedCorrelationId, auditEntry.CorrelationId);
+
+            if (expectedClaimValue != null)
+            {
+                Assert.Equal(1, auditEntry.Claims.Count);
+                Assert.Equal(expectedClaimKey, auditEntry.Claims.Single().Key);
+                Assert.Equal(expectedClaimValue, auditEntry.Claims.Single().Value);
+            }
+            else
+            {
+                Assert.Empty(auditEntry.Claims);
+            }
+        }
+    }
+}

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/Audit/StartupWithTraceAuditLogger.cs
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/Audit/StartupWithTraceAuditLogger.cs
@@ -1,0 +1,28 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Health.Dicom.DynamicFhir.Web;
+using Microsoft.Health.Fhir.Api.Features.Audit;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Rest.Audit
+{
+    public class StartupWithTraceAuditLogger : Startup
+    {
+        public StartupWithTraceAuditLogger(IConfiguration configuration)
+            : base(configuration)
+        {
+        }
+
+        public override void ConfigureServices(IServiceCollection services)
+        {
+            base.ConfigureServices(services);
+
+            services.Replace(new ServiceDescriptor(typeof(IAuditLogger), typeof(TraceAuditLogger), ServiceLifetime.Singleton));
+        }
+    }
+}

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/Audit/TraceAuditLogger.cs
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/Audit/TraceAuditLogger.cs
@@ -1,0 +1,29 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using Microsoft.Health.Fhir.Api.Features.Audit;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Rest.Audit
+{
+    public class TraceAuditLogger : IAuditLogger
+    {
+        private BlockingCollection<AuditEntry> _auditEntries = new BlockingCollection<AuditEntry>();
+
+        public void LogAudit(AuditAction auditAction, string action, string resourceType, Uri requestUri, HttpStatusCode? statusCode, string correlationId, IReadOnlyCollection<KeyValuePair<string, string>> claims)
+        {
+            _auditEntries.Add(new AuditEntry(auditAction, action, resourceType, requestUri, statusCode, correlationId, claims));
+        }
+
+        public IReadOnlyList<AuditEntry> GetAuditEntriesByCorrelationId(string correlationId)
+        {
+            return _auditEntries.Where(ae => ae.CorrelationId == correlationId).ToList();
+        }
+    }
+}

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/BasicAuthTests.cs
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/BasicAuthTests.cs
@@ -1,0 +1,94 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Net;
+using System.Net.Http;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Tests.E2E.Common;
+using Xunit;
+using FhirClient = Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Common.FhirClient;
+using FhirStartup = Microsoft.Health.Dicom.DynamicFhir.Web.Startup;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Rest
+{
+    /// <summary>
+    /// NOTE: These tests will fail if security is disabled..
+    /// </summary>
+    [Trait(Traits.Category, Categories.Authorization)]
+    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.Json)]
+    public class BasicAuthTests : IClassFixture<DicomFhirIntegrationTestFixture<FhirStartup>>
+    {
+        private const string ForbiddenMessage = "Forbidden: Authorization failed.";
+        private const string UnauthorizedMessage = "Unauthorized: Authentication failed.";
+        private const string Invalidtoken = "eyJhbGciOiJSUzI1NiIsImtpZCI6ImNmNWRmMGExNzY5ZWIzZTFkOGRiNWIxMGZiOWY3ZTk0IiwidHlwIjoiSldUIn0.eyJuYmYiOjE1NDQ2ODQ1NzEsImV4cCI6MTU0NDY4ODE3MSwiaXNzIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6NDQzNDgiLCJhdWQiOlsiaHR0cHM6Ly9sb2NhbGhvc3Q6NDQzNDgvcmVzb3VyY2VzIiwiZmhpci1haSJdLCJjbGllbnRfaWQiOiJzZXJ2aWNlY2xpZW50Iiwicm9sZXMiOiJhZG1pbiIsImFwcGlkIjoic2VydmljZWNsaWVudCIsInNjb3BlIjpbImZoaXItYWkiXX0.SKSvy6Jxzwsv1ZSi0PO4Pdq6QDZ6mBJIRxUPgoPlz2JpiB6GMXu5u0n1IpS6zOXihGkGhegjtcqj-6TKE6Ou5uhQ0VTnmf-NxcYKFl48aDihcGem--qa2V8GC7na549Ctj1PLXoYUbovV4LB27Kj3X83sZVnWdHqg_G0AKo4xm7hr23VUvJ1D73lEcYaGd5K9GXHNgUrJO5v288y0uCXZ5ByNDJ-K6Xi7_68dLdshlIiHaeIBuC3rhchSf2hdglkQgOyo4g4gT_HfKjwdrrpGzepNXOPQEwtUs_o2uriXAd7FfbL_Q4ORiDWPXkmwBXqo7uUfg-2SnT3DApc3PuA0";
+
+        public BasicAuthTests(DicomFhirIntegrationTestFixture<FhirStartup> fixture)
+        {
+            Client = fixture.FhirFixture.FhirClient;
+            Fixture = fixture;
+        }
+
+        protected FhirClient Client { get; set; }
+
+        public DicomFhirIntegrationTestFixture<FhirStartup> Fixture { get; set; }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenReadingAResource_GivenAUserWithNoReadPermissions_TheServerShouldReturnForbidden()
+        {
+            var resourceId = await Fixture.PostNewSampleStudyAsync();
+
+            await Client.RunAsUser(TestUsers.WriteOnlyUser, TestApplications.NativeClient);
+            FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.ReadAsync<ImagingStudy>(ResourceType.ImagingStudy, resourceId));
+            Assert.Equal(ForbiddenMessage, fhirException.Message);
+            Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenCreatingAResource_GivenAUserWithNoCreatePermissions_TheServerShouldReturnForbidden()
+        {
+            await Client.RunAsUser(TestUsers.ReadOnlyUser, TestApplications.NativeClient);
+            FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.CreateAsync(Samples.GetDefaultPatient()));
+            Assert.Equal(ForbiddenMessage, fhirException.Message);
+            Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenCreatingAResource_GivenAClientWithNoAuthToken_TheServerShouldReturnUnauthorized()
+        {
+            await Client.RunAsClientApplication(TestApplications.InvalidClient);
+
+            FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.CreateAsync(Samples.GetDefaultObservation()));
+            Assert.Equal(UnauthorizedMessage, fhirException.Message);
+            Assert.Equal(HttpStatusCode.Unauthorized, fhirException.StatusCode);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenCreatingAResource_GivenAClientWithInvalidAuthToken_TheServerShouldReturnUnauthorized()
+        {
+            await Client.RunAsClientApplication(TestApplications.InvalidClient);
+            Client.HttpClient.SetBearerToken(Invalidtoken);
+            FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.CreateAsync(Samples.GetDefaultObservation()));
+            Assert.Equal(UnauthorizedMessage, fhirException.Message);
+            Assert.Equal(HttpStatusCode.Unauthorized, fhirException.StatusCode);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenCreatingAResource_GivenAClientWithWrongAudience_TheServerShouldReturnUnauthorized()
+        {
+            await Client.RunAsClientApplication(TestApplications.WrongAudienceClient);
+            FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.CreateAsync(Samples.GetDefaultObservation()));
+            Assert.Equal(UnauthorizedMessage, fhirException.Message);
+            Assert.Equal(HttpStatusCode.Unauthorized, fhirException.StatusCode);
+        }
+    }
+}

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/CorsTests.cs
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/CorsTests.cs
@@ -1,0 +1,59 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Common;
+using Microsoft.Health.Dicom.DynamicFhir.Web;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Net.Http.Headers;
+using Xunit;
+using HttpMethod = System.Net.Http.HttpMethod;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Rest
+{
+    [Trait(Traits.Category, Categories.Cors)]
+    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.Json)]
+    public class CorsTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
+    {
+        private readonly FhirClient _client;
+
+        public CorsTests(HttpIntegrationTestFixture<Startup> fixture)
+        {
+            _client = fixture.FhirClient;
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenGettingOptions_GivenAppropriateHeaders_TheServerShouldReturnTheAppropriateCorsHeaders()
+        {
+            var message = new HttpRequestMessage
+            {
+                Method = HttpMethod.Options,
+            };
+
+            message.Headers.Add(HeaderNames.Origin, "https://localhost:6001");
+            message.Headers.Add(HeaderNames.AccessControlRequestMethod, "PUT");
+            message.Headers.Add(HeaderNames.AccessControlRequestHeaders, "authorization");
+            message.Headers.Add(HeaderNames.AccessControlRequestHeaders, "content-type");
+            message.RequestUri = new Uri(_client.HttpClient.BaseAddress, "/patient");
+
+            HttpResponseMessage response = await _client.HttpClient.SendAsync(message);
+
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+            Assert.Contains("https://localhost:6001", response.Headers.GetValues(HeaderNames.AccessControlAllowOrigin));
+
+            Assert.Contains("PUT", response.Headers.GetValues(HeaderNames.AccessControlAllowMethods));
+
+            Assert.Contains("authorization,content-type", response.Headers.GetValues(HeaderNames.AccessControlAllowHeaders));
+
+            Assert.Equal("1440", response.Headers.GetValues(HeaderNames.AccessControlMaxAge).First());
+        }
+    }
+}

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/CreateTests.cs
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/CreateTests.cs
@@ -1,0 +1,36 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Dicom.DynamicFhir.Web;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Tests.E2E.Common;
+using Xunit;
+using FhirClient = Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Common.FhirClient;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Rest
+{
+    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.Json | Format.Xml)]
+    public class CreateTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
+    {
+        public CreateTests(HttpIntegrationTestFixture<Startup> fixture)
+        {
+            Client = fixture.FhirClient;
+        }
+
+        protected FhirClient Client { get; set; }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenPostingToHttp_GivenAResource_TheServerShouldRespondMethodNotAllowed()
+        {
+            FhirException ex = await Assert.ThrowsAsync<FhirException>(
+                () => Client.CreateAsync(Samples.GetDefaultPatient()));
+
+            Assert.Equal(System.Net.HttpStatusCode.MethodNotAllowed, ex.StatusCode);
+        }
+    }
+}

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/DicomFhirIntegrationTestFixture.cs
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/DicomFhirIntegrationTestFixture.cs
@@ -1,0 +1,57 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Health.Dicom.Web.Tests.E2E.Clients;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using DicomStartup = Microsoft.Health.Dicom.Web.Startup;
+using DicomTestFixture = Microsoft.Health.Dicom.Web.Tests.E2E.Rest;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Rest
+{
+    public class DicomFhirIntegrationTestFixture<TStartup> : IDisposable
+    {
+        private DicomTestFixture.HttpIntegrationTestFixture<DicomStartup> _dicomFixture;
+        private HttpIntegrationTestFixture<TStartup> _fhirFixture;
+        private DicomWebClient _dicomWebClient;
+        private const string _testResourceId = "42";
+
+        public DicomFhirIntegrationTestFixture(DataStore dataStore, Format format)
+        {
+            _dicomFixture = new DicomTestFixture.HttpIntegrationTestFixture<DicomStartup>();
+            _fhirFixture = new HttpIntegrationTestFixture<TStartup>(dataStore, format);
+            _dicomWebClient = new DicomWebClient(_dicomFixture.HttpClient);
+        }
+
+        public HttpIntegrationTestFixture<TStartup> FhirFixture
+        {
+            get { return _fhirFixture; }
+        }
+
+        public DicomTestFixture.HttpIntegrationTestFixture<DicomStartup> DicomFixture
+        {
+            get { return _dicomFixture; }
+        }
+
+        public DicomWebClient DicomClient
+        {
+            get { return _dicomWebClient; }
+        }
+
+        public Task<string> PostNewSampleStudyAsync()
+        {
+            return Task.FromResult(_testResourceId);
+        }
+
+        public void Dispose()
+        {
+            _dicomFixture?.Dispose();
+            _fhirFixture?.Dispose();
+            _dicomFixture = null;
+            _fhirFixture = null;
+        }
+    }
+}

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/ExceptionTests.cs
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/ExceptionTests.cs
@@ -1,0 +1,145 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Net;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Validation;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Health.Dicom.DynamicFhir.Web;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Tests.E2E.Common;
+using Xunit;
+using FhirClient = Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Common.FhirClient;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Rest
+{
+    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.Json | Format.Xml)]
+    public class ExceptionTests : IClassFixture<HttpIntegrationTestFixture<ExceptionTests.StartupWithThrowingMiddleware>>
+    {
+        private readonly HttpIntegrationTestFixture<StartupWithThrowingMiddleware> _fixture;
+
+        public ExceptionTests(HttpIntegrationTestFixture<StartupWithThrowingMiddleware> fixture)
+        {
+            _fixture = fixture;
+            Client = fixture.FhirClient;
+        }
+
+        protected FhirClient Client { get; set; }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenPostingToHttp_GivenAnInternalThrowQuerystring_TheServerShouldReturnAnOperationOutcome()
+        {
+            if (!_fixture.IsUsingInProcTestServer)
+            {
+                // this test only works with the in-proc server with customized middleware pipeline
+                return;
+            }
+
+            var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.ReadAsync<OperationOutcome>("?throw=internal"));
+
+            Assert.Equal(HttpStatusCode.InternalServerError, fhirException.StatusCode);
+
+            var operationOutcome = fhirException.OperationOutcome;
+
+            Assert.NotNull(operationOutcome.Id);
+            Assert.NotEmpty(operationOutcome.Issue);
+            Assert.Equal(OperationOutcome.IssueType.Exception, operationOutcome.Issue[0].Code);
+            Assert.Equal(OperationOutcome.IssueSeverity.Error, operationOutcome.Issue[0].Severity);
+            TestHelper.AssertSecurityHeaders(fhirException.Headers);
+
+            DotNetAttributeValidation.Validate(operationOutcome, true);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenPostingToHttp_GivenAMiddlewareThrowQuerystring_TheServerShouldReturnAnOperationOutcome()
+        {
+            if (!_fixture.IsUsingInProcTestServer)
+            {
+                // this test only works with the in-proc server with customized middleware pipeline
+                return;
+            }
+
+            var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.ReadAsync<OperationOutcome>("?throw=middleware"));
+
+            Assert.Equal(HttpStatusCode.InternalServerError, fhirException.StatusCode);
+
+            var operationOutcome = fhirException.OperationOutcome;
+
+            Assert.NotNull(operationOutcome.Id);
+            Assert.NotEmpty(operationOutcome.Issue);
+            Assert.Equal(OperationOutcome.IssueType.Exception, operationOutcome.Issue[0].Code);
+            Assert.Equal(OperationOutcome.IssueSeverity.Fatal, operationOutcome.Issue[0].Severity);
+            TestHelper.AssertSecurityHeaders(fhirException.Headers);
+
+            DotNetAttributeValidation.Validate(operationOutcome, true);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenPostingToHttp_GivenAnUnknownRoute_TheServerShouldReturnAnOperationOutcome()
+        {
+            var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.ReadAsync<OperationOutcome>("unknownRoute"));
+
+            Assert.Equal(HttpStatusCode.NotFound, fhirException.StatusCode);
+
+            var operationOutcome = fhirException.OperationOutcome;
+
+            Assert.NotNull(operationOutcome.Id);
+            Assert.NotEmpty(operationOutcome.Issue);
+            Assert.Equal(OperationOutcome.IssueType.NotFound, operationOutcome.Issue[0].Code);
+            Assert.Equal(OperationOutcome.IssueSeverity.Error, operationOutcome.Issue[0].Severity);
+            TestHelper.AssertSecurityHeaders(fhirException.Headers);
+
+            DotNetAttributeValidation.Validate(operationOutcome, true);
+        }
+
+        public class StartupWithThrowingMiddleware : Startup
+        {
+            public StartupWithThrowingMiddleware(IConfiguration configuration)
+                : base(configuration)
+            {
+            }
+
+            public override void Configure(IApplicationBuilder app)
+            {
+                app.Use(async (context, next) =>
+                {
+                    const string internalExceptionThrown = "internalExceptionThrown";
+
+                    var throwValue = context.Request.Query["throw"];
+
+                    switch (throwValue)
+                    {
+                        // Internal is used to cause the ExceptionHandlerMiddleware logic to execute
+                        case "internal":
+                            // Only throw the error the first time that this path is executed.
+                            // This allows the ExceptionHandlerMiddleware to continue to the error page on the second execution of this path.
+                            if (!context.Items.ContainsKey(internalExceptionThrown))
+                            {
+                                context.Items[internalExceptionThrown] = true;
+                                throw new Exception("internal exception");
+                            }
+
+                            break;
+
+                        // Middleware is used to cause the BaseExceptionMiddleware logic to execute
+                        case "middleware":
+                            throw new Exception("middleware exception");
+                    }
+
+                    await next();
+                });
+
+                base.Configure(app);
+            }
+        }
+    }
+}

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/HealthTests.cs
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/HealthTests.cs
@@ -1,0 +1,33 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Health.Dicom.DynamicFhir.Web;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Xunit;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Rest
+{
+    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.Json)]
+    public class HealthTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
+    {
+        private readonly HttpClient _client;
+
+        public HealthTests(HttpIntegrationTestFixture<Startup> fixture)
+        {
+            _client = fixture.HttpClient;
+        }
+
+        [Fact]
+        public async Task WhenStartingTheFhirServer_GivenAHealthEndpoint_ThenTheHealthCheckIsOK()
+        {
+            var response = await _client.GetAsync("health/check");
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+    }
+}

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/HistoryTests.cs
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/HistoryTests.cs
@@ -1,0 +1,61 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Net;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Tests.E2E.Common;
+using Xunit;
+using FhirClient = Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Common.FhirClient;
+using FhirStartup = Microsoft.Health.Dicom.DynamicFhir.Web.Startup;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Rest
+{
+    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.Json | Format.Xml)]
+    public class HistoryTests : IClassFixture<DicomFhirIntegrationTestFixture<FhirStartup>>
+    {
+        public HistoryTests(DicomFhirIntegrationTestFixture<FhirStartup> fixture)
+        {
+            Client = fixture.FhirFixture.FhirClient;
+            Fixture = fixture;
+        }
+
+        protected FhirClient Client { get; set; }
+
+        public DicomFhirIntegrationTestFixture<FhirStartup> Fixture { get; set; }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenGettingResourceHistory_GivenAType_TheServerShouldReturnMethodNotAllowed()
+        {
+            FhirException ex = await Assert.ThrowsAsync<FhirException>(
+                () => Client.SearchAsync("Patient/_history"));
+            Assert.Equal(HttpStatusCode.MethodNotAllowed, ex.StatusCode);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenGettingResourceHistory_GivenATypeAndId_TheServerShouldReturnMethodNotAllowed()
+        {
+            var studyInstanceUid = await Fixture.PostNewSampleStudyAsync();
+
+            FhirException ex = await Assert.ThrowsAsync<FhirException>(
+                () => Client.SearchAsync($"Patient/{studyInstanceUid}/_history"));
+
+            Assert.Equal(HttpStatusCode.MethodNotAllowed, ex.StatusCode);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenGettingSystemHistory_GivenNoType_TheServerShouldReturnMethodNotAllowed()
+        {
+            FhirException ex = await Assert.ThrowsAsync<FhirException>(
+                () => Client.SearchAsync("_history"));
+
+            Assert.Equal(HttpStatusCode.MethodNotAllowed, ex.StatusCode);
+        }
+    }
+}

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/HttpIntegrationFixtureArgumentSetsAttribute.cs
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/HttpIntegrationFixtureArgumentSetsAttribute.cs
@@ -1,0 +1,25 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Health.Extensions.Xunit;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Rest
+{
+    /// <summary>
+    /// Indicates the combinations of data stores and response formats that tests should be verified with.
+    /// Must be placed on test classes where the class fixture is parameterized with DataStore and Format.
+    /// Can optionally be placed on individual methods to override the class-level behavior.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = false)]
+    public sealed class HttpIntegrationFixtureArgumentSetsAttribute : FixtureArgumentSetsAttribute
+    {
+        public HttpIntegrationFixtureArgumentSetsAttribute(DataStore dataStores = 0, Format formats = 0)
+            : base(dataStores, formats)
+        {
+        }
+    }
+}

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/HttpIntegrationTestFixture.cs
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/HttpIntegrationTestFixture.cs
@@ -1,0 +1,247 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Hl7.Fhir.Rest;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Web;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using FhirClient = Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Common.FhirClient;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Rest
+{
+    /// <summary>
+    /// A test fixture which hosts the target web project in an in-memory server.
+    /// Code adapted from https://docs.microsoft.com/en-us/aspnet/core/mvc/controllers/testing#integration-testing
+    /// </summary>
+    /// <typeparam name="TStartup">The target web project startup</typeparam>
+    public class HttpIntegrationTestFixture<TStartup> : IDisposable
+    {
+        private readonly DataStore _dataStore;
+        private readonly Format _format;
+        private string _environmentUrl;
+        private HttpMessageHandler _messageHandler;
+
+        public HttpIntegrationTestFixture(DataStore dataStore, Format format)
+            : this(Path.Combine("src"), dataStore, format)
+        {
+        }
+
+        protected HttpIntegrationTestFixture(string targetProjectParentDirectory, DataStore dataStore, Format format)
+        {
+            _dataStore = dataStore;
+            _format = format;
+
+            SetUpEnvironmentVariables();
+
+            string environmentUrl = Environment.GetEnvironmentVariable("TestEnvironmentUrl");
+
+            if (string.IsNullOrWhiteSpace(environmentUrl))
+            {
+                environmentUrl = "http://localhost/";
+
+                StartInMemoryServer(targetProjectParentDirectory);
+
+                _messageHandler = Server.CreateHandler();
+                IsUsingInProcTestServer = true;
+
+                // We need to suppress the execution context because there is no boundary between the client and server while using TestServer
+                _messageHandler = new SuppressExecutionContextHandler(_messageHandler);
+            }
+            else
+            {
+                if (environmentUrl.Last() != '/')
+                {
+                    environmentUrl = $"{environmentUrl}/";
+                }
+
+                _messageHandler = new HttpClientHandler();
+            }
+
+            _environmentUrl = environmentUrl;
+
+            HttpClient = CreateHttpClient();
+
+            switch (_format)
+            {
+                case Format.Json:
+                    FhirClient = new FhirClient(HttpClient, ResourceFormat.Json);
+                    break;
+                case Format.Xml:
+                    FhirClient = new FhirClient(HttpClient, ResourceFormat.Xml);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public bool IsUsingInProcTestServer { get; }
+
+        public HttpClient HttpClient { get; }
+
+        public FhirClient FhirClient { get; }
+
+        public TestServer Server { get; private set; }
+
+        public string GenerateFullUrl(string relativeUrl)
+        {
+            return $"{_environmentUrl}{relativeUrl}";
+        }
+
+        public HttpClient CreateHttpClient()
+            => new HttpClient(new SessionMessageHandler(_messageHandler)) { BaseAddress = new Uri(_environmentUrl) };
+
+        private void StartInMemoryServer(string targetProjectParentDirectory)
+        {
+            var contentRoot = GetProjectPath(targetProjectParentDirectory, typeof(TStartup));
+            var corsPath = Path.GetFullPath("corstestconfiguration.json");
+
+            var builder = WebHost.CreateDefaultBuilder()
+                .UseContentRoot(contentRoot)
+                .ConfigureAppConfiguration(configurationBuilder =>
+                {
+                    configurationBuilder.AddDevelopmentAuthEnvironment("testauthenvironment.json");
+                    configurationBuilder.AddJsonFile(corsPath);
+                })
+                .UseStartup(typeof(TStartup))
+                .ConfigureServices(serviceCollection =>
+                {
+                    // ensure that HttpClients
+                    // use a message handler for the test server
+                    serviceCollection
+                        .AddHttpClient(Options.DefaultName)
+                        .ConfigurePrimaryHttpMessageHandler(() => _messageHandler);
+
+                    serviceCollection.PostConfigure<JwtBearerOptions>(
+                        JwtBearerDefaults.AuthenticationScheme,
+                        options => options.BackchannelHttpHandler = _messageHandler);
+                });
+
+            Server = new TestServer(builder);
+        }
+
+        /// <summary>
+        /// Method to set up environment variables based on the project's defined environment variables.
+        /// These are used to target the http integration tests to a server that isn't hosted in memory.
+        /// For this method to function, the launchSettings.json file must be copied to the output directory of the project.
+        /// </summary>
+        private static void SetUpEnvironmentVariables()
+        {
+            var settingsPath = @"Properties\launchSettings.json";
+            if (File.Exists(settingsPath))
+            {
+                using (var file = File.OpenText(settingsPath))
+                {
+                    using (var jsonReader = new JsonTextReader(file))
+                    {
+                        var launchSettings = JObject.Load(jsonReader);
+                        var environmentVariables = (JObject)launchSettings.SelectToken("$.profiles.['Microsoft.Health.Fhir.Tests.Integration'].environmentVariables");
+
+                        if (environmentVariables != null)
+                        {
+                            foreach (var environmentVariable in environmentVariables)
+                            {
+                                Environment.SetEnvironmentVariable(environmentVariable.Key, environmentVariable.Value.ToString());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            HttpClient.Dispose();
+            Server?.Dispose();
+        }
+
+        /// <summary>
+        /// Gets the full path to the target project that we wish to test
+        /// </summary>
+        /// <param name="projectRelativePath">
+        /// The parent directory of the target project.
+        /// e.g. src, samples, test, or test/Websites
+        /// </param>
+        /// <param name="startupType">The startup type</param>
+        /// <returns>The full path to the target project.</returns>
+        private static string GetProjectPath(string projectRelativePath, Type startupType)
+        {
+            for (Type type = startupType; type != null; type = type.BaseType)
+            {
+                // Get name of the target project which we want to test
+                var projectName = type.GetTypeInfo().Assembly.GetName().Name;
+
+                // Get currently executing test project path
+                var applicationBasePath = System.AppContext.BaseDirectory;
+
+                // Find the path to the target project
+                var directoryInfo = new DirectoryInfo(applicationBasePath);
+                do
+                {
+                    directoryInfo = directoryInfo.Parent;
+
+                    var projectDirectoryInfo = new DirectoryInfo(Path.Combine(directoryInfo.FullName, projectRelativePath));
+                    if (projectDirectoryInfo.Exists)
+                    {
+                        var projectFileInfo = new FileInfo(Path.Combine(projectDirectoryInfo.FullName, projectName, $"{projectName}.csproj"));
+                        if (projectFileInfo.Exists)
+                        {
+                            return Path.Combine(projectDirectoryInfo.FullName, projectName);
+                        }
+                    }
+                }
+                while (directoryInfo.Parent != null);
+            }
+
+            throw new Exception($"Project root could not be located for startup type {startupType.FullName}");
+        }
+
+        /// <summary>
+        /// An <see cref="HttpMessageHandler"/> that maintains session consistency between requests.
+        /// </summary>
+        private class SessionMessageHandler : DelegatingHandler
+        {
+            private string _sessionToken;
+
+            public SessionMessageHandler(HttpMessageHandler innerHandler)
+                : base(innerHandler)
+            {
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                if (!string.IsNullOrEmpty(_sessionToken))
+                {
+                    request.Headers.TryAddWithoutValidation("x-ms-session-token", _sessionToken);
+                }
+
+                request.Headers.TryAddWithoutValidation("x-ms-consistency-level", "Session");
+
+                var response = await base.SendAsync(request, cancellationToken);
+
+                if (response.Headers.TryGetValues("x-ms-session-token", out var tokens))
+                {
+                    _sessionToken = tokens.SingleOrDefault();
+                }
+
+                return response;
+            }
+        }
+    }
+}

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/ReadTests.cs
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/ReadTests.cs
@@ -1,0 +1,55 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Tests.E2E.Common;
+using Xunit;
+using FhirClient = Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Common.FhirClient;
+using FhirStartup = Microsoft.Health.Dicom.DynamicFhir.Web.Startup;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Rest
+{
+    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.Json | Format.Xml)]
+    public class ReadTests : IClassFixture<DicomFhirIntegrationTestFixture<FhirStartup>>
+    {
+        public ReadTests(DicomFhirIntegrationTestFixture<FhirStartup> fixture)
+        {
+            FhirClient = fixture.FhirFixture.FhirClient;
+            Fixture = fixture;
+        }
+
+        protected FhirClient FhirClient { get; set; }
+
+        public DicomFhirIntegrationTestFixture<FhirStartup> Fixture { get; set; }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenGettingAResource_GivenAnId_TheServerShouldReturnTheAppropriateResourceSuccessfully()
+        {
+            var studyInstanceUid = await Fixture.PostNewSampleStudyAsync();
+
+            FhirResponse<ImagingStudy> readResponse = await FhirClient.ReadAsync<ImagingStudy>(ResourceType.ImagingStudy, studyInstanceUid);
+
+            ImagingStudy readResource = readResponse.Resource;
+
+            Assert.Equal(studyInstanceUid, readResource.Id);
+            TestHelper.AssertSecurityHeaders(readResponse.Headers);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenGettingAResource_GivenANonExistantId_TheServerShouldReturnANotFoundStatus()
+        {
+            FhirException ex = await Assert.ThrowsAsync<FhirException>(
+                () => FhirClient.ReadAsync<ImagingStudy>(ResourceType.ImagingStudy, Guid.NewGuid().ToString()));
+
+            Assert.Equal(System.Net.HttpStatusCode.NotFound, ex.StatusCode);
+        }
+    }
+}

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/SuppressExecutionContextHandler.cs
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/SuppressExecutionContextHandler.cs
@@ -1,0 +1,37 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Rest
+{
+    /// <summary>
+    /// An HTTP handler that suppresses the execution context flow.
+    /// Workaround from: https://github.com/aspnet/AspNetCore/issues/7975#issuecomment-481536061
+    /// </summary>
+    internal class SuppressExecutionContextHandler : DelegatingHandler
+    {
+        public SuppressExecutionContextHandler(HttpMessageHandler innerHandler)
+            : base(innerHandler)
+        {
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            // NOTE: We DO NOT want to 'await' the task inside this using. We're just suppressing execution context flow
+            // while the task itself is created (which is what would capture the context). After that we just return the
+            // (now detached task) to the caller.
+            Task<HttpResponseMessage> t;
+            using (ExecutionContext.SuppressFlow())
+            {
+                t = Task.Run(() => base.SendAsync(request, cancellationToken));
+            }
+
+            return t;
+        }
+    }
+}

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/TestHelper.cs
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/TestHelper.cs
@@ -1,0 +1,20 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Net.Http.Headers;
+using Xunit;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Rest
+{
+    internal static class TestHelper
+    {
+        internal static void AssertSecurityHeaders(HttpResponseHeaders headers)
+        {
+            Assert.True(headers.TryGetValues("X-Content-Type-Options", out IEnumerable<string> headerValue));
+            Assert.Contains("nosniff", headerValue);
+        }
+    }
+}

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/TypeTests.cs
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/TypeTests.cs
@@ -1,0 +1,66 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Tests.E2E.Common;
+using Xunit;
+using FhirClient = Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Common.FhirClient;
+using FhirStartup = Microsoft.Health.Dicom.DynamicFhir.Web.Startup;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Rest
+{
+    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.Json | Format.Xml)]
+    public class TypeTests : IClassFixture<DicomFhirIntegrationTestFixture<FhirStartup>>
+    {
+        public TypeTests(DicomFhirIntegrationTestFixture<FhirStartup> fixture)
+        {
+            FhirClient = fixture.FhirFixture.FhirClient;
+            Fixture = fixture;
+        }
+
+        protected FhirClient FhirClient { get; set; }
+
+        public DicomFhirIntegrationTestFixture<FhirStartup> Fixture { get; set; }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenReadingAnUnsupportedResourceType_TheServerShouldReturnMethodNotAllowed()
+        {
+            FhirResponse<CapabilityStatement> readResponse = await FhirClient.ReadAsync<CapabilityStatement>("metadata");
+            var capabilities = readResponse.Resource;
+
+            var readResources = capabilities.Rest.First().Resource.Where(
+                r => r.Interaction.First().Code == CapabilityStatement.TypeRestfulInteraction.Read)
+                    .Select(r => r.Type);
+
+            var allResources = ModelInfo.SupportedResources.Select(r => (ResourceType)Enum.Parse(typeof(ResourceType), r));
+
+            var unavailableResources = allResources.Where(r => !readResources.Contains(r));
+
+            foreach (var resource in unavailableResources)
+            {
+                FhirException ex = await Assert.ThrowsAsync<FhirException>(
+                () => FhirClient.ReadUntypedAsync(resource, "1"));
+
+                Assert.Equal(System.Net.HttpStatusCode.MethodNotAllowed, ex.StatusCode);
+            }
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenGettingAResource_GivenANonExistantId_TheServerShouldReturnANotFoundStatus()
+        {
+            FhirException ex = await Assert.ThrowsAsync<FhirException>(
+                () => FhirClient.ReadAsync<ImagingStudy>(ResourceType.ImagingStudy, Guid.NewGuid().ToString()));
+
+            Assert.Equal(System.Net.HttpStatusCode.NotFound, ex.StatusCode);
+        }
+    }
+}

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/VReadTests.cs
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/Rest/VReadTests.cs
@@ -1,0 +1,41 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Dicom.DynamicFhir.Web;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Tests.E2E.Common;
+using Xunit;
+using FhirClient = Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Common.FhirClient;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Dicom.DynamicFhir.Tests.E2E.Rest
+{
+    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.Json | Format.Xml)]
+    public class VReadTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
+    {
+        public VReadTests(HttpIntegrationTestFixture<Startup> fixture)
+        {
+            Client = fixture.FhirClient;
+        }
+
+        protected FhirClient Client { get; set; }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenGettingAResource_GivenAnIdAndVersionId_TheServerShouldReturnMethodNotAllowed()
+        {
+            FhirException ex = await Assert.ThrowsAsync<FhirException>(
+                () => Client.VReadAsync<Patient>(
+                ResourceType.Patient,
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString()));
+
+            Assert.Equal(System.Net.HttpStatusCode.MethodNotAllowed, ex.StatusCode);
+        }
+    }
+}

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/runtimeconfig.template.json
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+    "applyPatches": false
+}

--- a/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/xunit.runner.json
+++ b/test/Microsoft.Health.Dicom.DynamicFhir.Tests.E2E/xunit.runner.json
@@ -1,0 +1,4 @@
+﻿{
+    "parallelizeAssembly": false,
+    "parallelizeTestCollections": false
+}

--- a/testauthenvironment.json
+++ b/testauthenvironment.json
@@ -1,0 +1,122 @@
+{
+    "roles": [
+        {
+            "name": "clinician",
+            "resourcePermissions": [
+                {
+                    "actions": [
+                        "Read",
+                        "Write"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "officeassistant",
+            "resourcePermissions": [
+                {
+                    "actions": [
+                        "Write"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "researcher",
+            "resourcePermissions": [
+                {
+                    "actions": [
+                        "Read"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "mlresearcher",
+            "resourcePermissions": [
+                {
+                    "actions": [
+                        "Export"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "director",
+            "resourcePermissions": [
+                {
+                    "actions": [
+                        "HardDelete"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "admin",
+            "resourcePermissions": [
+                {
+                    "actions": [
+                        "Read",
+                        "Write",
+                        "HardDelete",
+                        "Export"
+                    ]
+                }
+            ]
+        }
+    ],
+    "users": [
+        {
+            "id": "john",
+            "roles": [
+                "researcher"
+            ]
+        },
+        {
+            "id": "sam",
+            "roles": [
+                "officeassistant"
+            ]
+        },
+        {
+            "id": "frank",
+            "roles": [
+                "clinician"
+            ]
+        },
+        {
+            "id": "steve",
+            "roles": [
+                "mlresearcher"
+            ]
+        },
+        {
+            "id": "doug",
+            "roles": [
+                "director"
+            ]
+        },
+        {
+            "id": "itguy",
+            "roles": [
+                "admin"
+            ]
+        }
+    ],
+    "clientApplications": [
+        {
+            "id": "serviceclient",
+            "roles": [
+                "admin"
+            ]
+        },
+        {
+            "id": "nativeclient",
+            "roles": []
+        },
+        {
+            "id": "wrongaudienceclient",
+            "roles": []
+        }
+    ]
+}


### PR DESCRIPTION
## Description
1. Add Microsoft.Health.Dicom.DynamicFhir.Core, Web & Tests.E2E
1. In Core add bare-bones implementations of an IRequestHandler to fetch a resource from a custom FhirDataStore
1. Add custom conformance provider and DefaultCapabilities limited to the resources we wish to serve from the Dicom.DynamicFhir server
1. Move over all relevant tests from the fhir-server and adapt to our usage

## Notes
The testing framework is set up to launch both Dicom and DynamicFhir web servers, but they have not yet been linked. A single ImagingStudy resource is served for testing.

## Testing
Added tests from fhir-server for:
1. Basic Auth
1. Cors
1. Create
1. Exception
1. Health
1. History
1. Read
1. VRead

Make sure we only serve defined resources TypeTests
