### PR TITLE
Added the base deployment template file.

### DIFF
--- a/samples/templates/default-azuredeploy.json
+++ b/samples/templates/default-azuredeploy.json
@@ -42,29 +42,6 @@
             ],
             "defaultValue": "S1"
         },
-        "repositoryUrl": {
-            "type": "string",
-            "defaultValue": "https://github.com/microsoft/dicom-server",
-            "metadata": {
-                "description": "Respository to pull source code from. If blank, source code will not be deployed."
-            }
-        },
-        "repositoryBranch": {
-            "type": "string",
-            "defaultValue": "master",
-            "metadata": {
-                "description": "Source code branch to deploy."
-            }
-        },
-        "cosmosDbAccountConsistencyPolicy": {
-            "type": "object",
-            "defaultValue": {
-                "defaultConsistencyLevel": "Strong"
-            },
-            "metadata": {
-                "description": "An object representing the default consistency policy for the Cosmos DB account. See https://docs.microsoft.com/en-us/azure/templates/microsoft.documentdb/databaseaccounts#ConsistencyPolicy"
-            }
-        },
         "storageAccountSku": {
             "type": "string",
             "allowedValues": [
@@ -106,9 +83,22 @@
                 "description": "Additional configuration properties for the DICOM server. In the form {\"path1\":\"value1\",\"path2\":\"value2\"}"
             }
         },
+        "sqlAdminPassword": {
+            "type": "securestring",
+            "metadata": {
+                "description": "The password for the sql admin user if using SQL server."
+            }
+        },
+        "sqlLocation": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "An override location for the sql server database."
+            }
+        },
         "solutionType": {
             "type": "string",
-            "defaultValue": "DicomServerCosmosDB",
+            "defaultValue": "DicomServerSqlServer",
             "metadata": {
                 "description": "The type of the solution"
             }
@@ -117,61 +107,45 @@
     "variables": {
         "isMAG": "[or(contains(resourceGroup().location,'usgov'),contains(resourceGroup().location,'usdod'))]",
         "serviceName": "[toLower(parameters('serviceName'))]",
-        "keyVaultEndpoint": "[if(variables('isMAG'), concat('https://', variables('serviceName'), '.vault.usgovcloudapi.net/'), concat('https://', variables('serviceName'), '.vault.azure.net/'))]",
         "appServicePlanResourceGroup": "[if(empty(parameters('appServicePlanResourceGroup')), resourceGroup().name, parameters('appServicePlanResourceGroup'))]",
         "appServicePlanName": "[if(empty(parameters('appServicePlanName')),concat(variables('serviceName'),'-asp'),parameters('appServicePlanName'))]",
+        "appServicePlanResourceId": "[resourceId(variables('appServicePlanResourceGroup'), 'Microsoft.Web/serverfarms/', variables('appServicePlanName'))]",
         "appServiceResourceId": "[resourceId('Microsoft.Web/sites', variables('serviceName'))]",
-        "deploySourceCode": "[and(not(empty(parameters('repositoryUrl'))),not(empty(parameters('repositoryBranch'))))]",
         "deployAppInsights": "[and(parameters('deployApplicationInsights'),not(variables('isMAG')))]",
         "appInsightsName": "[concat('AppInsights-', variables('serviceName'))]",
-        "storageAccountName": "[concat(substring(replace(variables('serviceName'), '-', ''), 0, min(11, length(variables('serviceName')))), uniquestring(resourceGroup().id))]",
         "staticDicomServerConfigProperties": {
             "APPINSIGHTS_PORTALINFO": "ASP.NETCORE",
             "APPINSIGHTS_PROFILERFEATURE_VERSION": "1.0.0",
             "APPINSIGHTS_SNAPSHOTFEATURE_VERSION": "1.0.0",
             "WEBSITE_NODE_DEFAULT_VERSION": "6.9.4",
             "KeyVault:Endpoint": "[variables('keyVaultEndpoint')]",
-            "CosmosDb:ContinuationTokenSizeLimitInKb": "1",
-            "WEBSITE_RUN_FROM_PACKAGE": "1"
+            "SqlServer:Initialize": "true",
+            "DataStore": "SqlServer",
         },
-        "emptyDicomServerConfigProperties": {},
-        "kuduDicomServerConfigProperties": {
-            "PROJECT": "[concat('src/Microsoft.Health.Dicom.Web/Microsoft.Health.Dicom.Web.csproj')]"
-        },
-        "combinedDicomServerConfigProperties": "[union(variables('staticDicomServerConfigProperties'), parameters('additionalDicomServerConfigProperties'), if(variables('deploySourceCode'), variables('kuduDicomServerConfigProperties'), variables('emptyDicomServerConfigProperties')))]"
+        "combinedDicomServerConfigProperties": "[union(variables('staticDicomServerConfigProperties'), parameters('additionalDicomServerConfigProperties'))]",
+        "sqlServerResourceId": "[resourceId('Microsoft.Sql/servers/', variables('serviceName'))]",
+        "dicomDatabaseName": "Dicom",
+        "storageAccountName": "[concat(substring(replace(variables('serviceName'), '-', ''), 0, min(11, length(variables('serviceName')))), uniquestring(resourceGroup().id))]",
+        "storageResourceId": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+        "keyVaultEndpoint": "[if(variables('isMAG'), concat('https://', variables('serviceName'), '.vault.usgovcloudapi.net/'), concat('https://', variables('serviceName'), '.vault.azure.net/'))]",
+        "keyVaultResourceId": "[resourceId('Microsoft.KeyVault/vaults', variables('serviceName'))]"
     },
     "resources": [
         {
             "condition": "[empty(parameters('appServicePlanResourceGroup'))]",
-            "apiVersion": "2017-05-10",
-            "name": "nestedTemplate",
-            "type": "Microsoft.Resources/deployments",
-            "properties": {
-                "mode": "Incremental",
-                "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-                    "contentVersion": "1.0.0.0",
-                    "parameters": {},
-                    "variables": {},
-                    "resources": [
-                        {
-                            "apiVersion": "2015-08-01",
-                            "name": "[variables('appServicePlanName')]",
-                            "type": "Microsoft.Web/serverfarms",
-                            "tags": {
-                                "DicomServerSolution": "[parameters('solutionType')]"
-                            },
-                            "location": "[resourceGroup().location]",
-                            "sku": {
-                                "name": "[parameters('appServicePlanSku')]"
-                            },
-                            "properties": {
-                                "name": "[variables('appServicePlanName')]"
-                            }
-                        }
-                    ]
-                }
-            }
+	    "apiVersion": "2015-08-01",
+	    "name": "[variables('appServicePlanName')]",
+	    "type": "Microsoft.Web/serverfarms",
+	    "tags": {
+	        "DicomServerSolution": "[parameters('solutionType')]"
+	    },
+	    "location": "[resourceGroup().location]",
+	    "sku": {
+	        "name": "[parameters('appServicePlanSku')]"
+	    },
+	    "properties": {
+	        "name": "[variables('appServicePlanName')]"
+	    }
         },
         {
             "apiVersion": "2015-08-01",
@@ -186,19 +160,10 @@
             },
             "properties": {
                 "clientAffinityEnabled": false,
-                "serverFarmId": "[resourceId(variables('appServicePlanResourceGroup'), 'Microsoft.Web/serverfarms/', variables('appServicePlanName'))]",
-                "siteConfig": {
-                    "use32BitWorkerProcess": "false",
-                    "metadata": [
-                        {
-                            "name": "CURRENT_STACK",
-                            "value": "dotnetcore"
-                        }
-                    ]
-                }
+                "serverFarmId": "[variables('appServicePlanResourceId')]"
             },
             "dependsOn": [
-                "nestedTemplate"
+                "[if(empty(parameters('appServicePlanResourceGroup')), variables('appServicePlanResourceId'), variables('sqlServerResourceId'))]"
             ],
             "resources": [
                 {
@@ -230,40 +195,70 @@
                 "ApplicationId": "[variables('serviceName')]"
             }
         },
-        {
-            "apiVersion": "2015-04-08",
-            "type": "Microsoft.DocumentDB/databaseAccounts",
-            "tags": {
-                "DicomServerSolution": "[parameters('solutionType')]"
-            },
+	{
             "name": "[variables('serviceName')]",
-            "location": "[resourceGroup().location]",
+            "type": "Microsoft.Sql/servers",
+            "apiVersion": "2015-05-01-preview",
+            "location": "[parameters('sqlLocation')]",
+            "tags": {
+                "FhirServerSolution": "[parameters('solutionType')]"
+            },
             "properties": {
-                "name": "[variables('serviceName')]",
-                "databaseAccountOfferType": "Standard",
-                "consistencyPolicy": "[parameters('cosmosDbAccountConsistencyPolicy')]",
-                "locations": [
-                    {
-                        "locationName": "[resourceGroup().location]",
-                        "failoverPriority": 0
-                    }
-                ]
-            }
+                "administratorLogin": "dicomAdmin",
+                "administratorLoginPassword": "[parameters('sqlAdminPassword')]",
+                "version": "12.0"
+            },
+            "resources": [
+                {
+                    "apiVersion": "2017-10-01-preview",
+                    "dependsOn": [
+                        "[variables('serviceName')]"
+                    ],
+                    "location": "[parameters('sqlLocation')]",
+                    "tags": {
+                        "FhirServerSolution": "[parameters('solutionType')]"
+                    },
+                    "name": "[variables('dicomDatabaseName')]",
+                    "properties": {
+                        "collation": "SQL_Latin1_General_CP1_CI_AS"
+                    },
+                    "sku": {
+                        "name": "Standard",
+                        "tier": "Standard",
+                        "capacity": 20
+                      },
+                    "type": "databases"
+                },
+                {
+                    "apiVersion": "2014-04-01",
+                    "dependsOn": [
+                        "[variables('serviceName')]"
+                    ],
+                    "location": "[resourceGroup().location]",
+                    "name": "AllowAllWindowsAzureIps",
+                    "properties": {
+                        "endIpAddress": "0.0.0.0",
+                        "startIpAddress": "0.0.0.0"
+                    },
+                    "type": "firewallrules"
+                }
+            ]
         },
         {
-            "apiVersion": "2019-04-01",
             "type": "Microsoft.Storage/storageAccounts",
+            "name": "[variables('storageAccountName')]",
+            "apiVersion": "2019-04-01",
             "tags": {
                 "DicomServerSolution": "[parameters('solutionType')]"
             },
-            "name": "[variables('storageAccountName')]",
             "location": "[resourceGroup().location]",
             "kind": "StorageV2",
             "sku": {
                 "name": "[parameters('storageAccountSku')]"
             },
             "properties": {
-                "accessTier": "Hot"
+                "accessTier": "Hot",
+            "supportsHttpsTrafficOnly": "true"
             }
         },
         {
@@ -301,28 +296,15 @@
         },
         {
             "type": "Microsoft.KeyVault/vaults/secrets",
-            "name": "[concat(variables('serviceName'), '/CosmosDb--Host')]",
+            "name": "[concat(variables('serviceName'), '/SqlServer--ConnectionString')]",
             "apiVersion": "2015-06-01",
             "properties": {
                 "contentType": "text/plain",
-                "value": "[reference(concat('Microsoft.DocumentDb/databaseAccounts/', variables('serviceName'))).documentEndpoint]"
+                "value":  "[concat('Server=tcp:', reference(variables('sqlServerResourceId'), '2015-05-01-preview').fullyQualifiedDomainName,',1433;Initial Catalog=', variables('dicomDatabaseName'), ';Persist Security Info=False;User ID=', reference(variables('sqlServerResourceId'), '2015-05-01-preview').administratorLogin,';Password=',parameters('sqlAdminPassword'),';MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;')]"
             },
             "dependsOn": [
-                "[resourceId('Microsoft.KeyVault/vaults', variables('serviceName'))]",
-                "[resourceId('Microsoft.DocumentDb/databaseAccounts', variables('serviceName'))]"
-            ]
-        },
-        {
-            "type": "Microsoft.KeyVault/vaults/secrets",
-            "name": "[concat(variables('serviceName'), '/CosmosDb--Key')]",
-            "apiVersion": "2015-06-01",
-            "properties": {
-                "contentType": "text/plain",
-                "value": "[listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', variables('serviceName')), '2015-04-08').primaryMasterKey]"
-            },
-            "dependsOn": [
-                "[resourceId('Microsoft.KeyVault/vaults', variables('serviceName'))]",
-                "[resourceId('Microsoft.DocumentDb/databaseAccounts', variables('serviceName'))]"
+                "[variables('keyVaultResourceId')]",
+                "[variables('sqlServerResourceId')]"
             ]
         },
         {
@@ -331,11 +313,11 @@
             "apiVersion": "2015-06-01",
             "properties": {
                 "contentType": "text/plain",
-                "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, ';')]"
+                "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=', listKeys(variables('storageResourceId'), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, ';')]"
             },
             "dependsOn": [
-                "[resourceId('Microsoft.KeyVault/vaults', variables('serviceName'))]",
-                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+                "[variables('keyVaultResourceId')]",
+                "[variables('storageResourceId')]"
             ]
         }
     ]


### PR DESCRIPTION
## Description
Added the base deployment template file for the DICOM server.

Even though there is a configuration section about the source control, because our repo is private, we cannot use it yet. For now, you can use the template to provision all required Azure resources and setup the proper ACL/access to access the secrets but you will need to run separate commands to deploy the binary to the app service.

### To deploy the template

```
$parameter = @{"serviceName" = "dicomtest"}
New-AzResourceGroup -Name dicomtest -Location westus2
New-AzResourceGroupDeployment -Name dicomtest -ResourceGroupName dicomtest -TemplateFile .\samples\templates\default-azuredeploy.json -TemplateParameterObject $parameter
```

Change the serviceName accordingly.

Once the resources are created, you can then build and deploy your code.

```
dotnet publish -r win10-x64 -o c:\git\dicom-server\.web
Compress-Archive -Path .\.web\* -DestinationPath Microsoft.Health.Dicom.Web.zip

Publish-AzWebApp -ArchivePath .\Microsoft.Health.Dicom.Web.zip -ResourceGroupName dicomtest -Name dicomtest
```

## Testing
Deployed the template a few times.
