### PR TITLE
Fix #73081 Search fails on Instance level

### DIFF
--- a/src/Microsoft.Health.Dicom.SqlServer.UnitTests/Features/Query/SqlQueryGeneratorTests.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer.UnitTests/Features/Query/SqlQueryGeneratorTests.cs
@@ -113,6 +113,39 @@ AND i.SopInstanceUid=@p2";
             Assert.DoesNotContain("CROSS APPLY", stringBuilder.ToString());
         }
 
+        [Fact]
+        public void GivenNonUidFilter_WhenIELevelInstance_ValidateDistinctInstances()
+        {
+            var stringBuilder = new IndentedStringBuilder(new StringBuilder());
+            var includeField = new DicomQueryIncludeField(false, new List<DicomTag>());
+            var filters = new List<DicomQueryFilterCondition>()
+            {
+                new StringSingleValueMatchCondition(DicomTag.Modality, "123"),
+            };
+            var query = new DicomQueryExpression(QueryResource.AllInstances, includeField, false, 0, 0, filters);
+
+            var parm = new SqlQueryParameterManager(CreateSqlParameterCollection());
+            new SqlQueryGenerator(stringBuilder, query, parm);
+
+            string expectedDistinctSelect = @"SELECT DISTINCT
+st.StudyInstanceUid
+,se.SeriesInstanceUid
+,i.SopInstanceUid
+,i.Watermark
+FROM dicom.StudyMetadataCore st
+INNER JOIN dicom.SeriesMetadataCore se
+ON se.ID = st.ID
+INNER JOIN dicom.Instance i
+ON i.StudyInstanceUid = st.StudyInstanceUid
+AND i.SeriesInstanceUid = se.SeriesInstanceUid";
+
+            string expectedFilters = @"AND se.Modality=@p0";
+
+            Assert.Contains(expectedDistinctSelect, stringBuilder.ToString());
+            Assert.Contains(expectedFilters, stringBuilder.ToString());
+            Assert.DoesNotContain("CROSS APPLY", stringBuilder.ToString());
+        }
+
         private SqlParameterCollection CreateSqlParameterCollection()
         {
             return (SqlParameterCollection)typeof(SqlParameterCollection).GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, Type.EmptyTypes, null).Invoke(null);

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Query/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Query/SqlQueryGenerator.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Query
 
                 if (_queryExpression.IsInstanceIELevel())
                 {
-                    _stringBuilder.Append(",").AppendLine(VLatest.Instance.StudyInstanceUid, InstanceTableAlias);
+                    _stringBuilder.Append(",").AppendLine(VLatest.Instance.SopInstanceUid, InstanceTableAlias);
                     _stringBuilder.Append(",").AppendLine(VLatest.Instance.Watermark, InstanceTableAlias);
                 }
 


### PR DESCRIPTION
## Description
There was copy paste error on the select when IELevel = instance. Instead of SopInstanceUid I had copied StudyInstanceUid

## Related issues
[AB#73081](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/73081)

## Testing
Unit test
Postmen test on instance level resources