### PR TITLE
Removed runtime from the build package.

### DIFF
--- a/build/package.yml
+++ b/build/package.yml
@@ -7,7 +7,7 @@ steps:
     inputs:
       command: publish
       projects: '**/Microsoft.Health.Dicom.Web.csproj'
-      arguments: '--runtime win10-x64 --output $(build.artifactStagingDirectory)/web --configuration $(buildConfiguration) --version-suffix $(build.buildnumber)'
+      arguments: '--output $(build.artifactStagingDirectory)/web --configuration $(buildConfiguration) --version-suffix $(build.buildnumber)'
       publishWebProjects: false
 
   - task: DotNetCoreCLI@2


### PR DESCRIPTION
## Description
Remove the runtime flag from the build.

### To deploy the Azure resources

1. Create the resource group by `New-AzResourceGroup -Name jackliu-dicom-1 -Location westus2`

2. Deploy using ARM template:

```
$parameter = @{"serviceName" = "jackliu-dicom-1"}
New-AzResourceGroupDeployment -name jackliu-dicom-1 -ResourceGroupName jackliu-dicom-1 -TemplateParameterObject $parameter -TemplateFile .\samples\templates\default-azuredeploy.json
```

3. Download the Microsoft.Health.Dicom.Web.zip package from CI build.

4. Deploy the package by `Publish-AzWebApp -ResourceGroupName jackliu-dicom-1 -Name jackliu-dicom-1 -ArchivePath C:\users\ryuka\Desktop\Microsoft.Health.Dicom.Web.zip`

Alternatively, instead of downloading the package from the CI build, you can also run `dotnet publish .\src\Microsoft.Health.Dicom.Web\Microsoft.Health.Dicom.Web.csproj --output .web --configuration Release` to create the package then zip it by `Compress-Archive .web\* Microsoft.Health.Dicom.Web.zip`

