### PR TITLE
Limit CI trigger to actual CI builds.

### DIFF
--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -1,5 +1,9 @@
 # DESCRIPTION: 
 # Builds, tests and packages the solution for the CI build configuration.
+trigger:
+    - master
+
+pr: none
 
 name: $(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:-r)
 variables:


### PR DESCRIPTION
Updates the CI build to trigger only on merges to the master branch and to stop PRs from triggering the CI build.