### PR TITLE
Consolidate authentication configuration in security module

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Controllers/DicomDeleteController.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/DicomDeleteController.cs
@@ -7,7 +7,6 @@ using System.Net;
 using System.Threading.Tasks;
 using EnsureThat;
 using MediatR;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Dicom.Api.Features.Routing;
@@ -16,7 +15,6 @@ using Microsoft.Health.Dicom.Core.Messages.Delete;
 
 namespace Microsoft.Health.Dicom.Api.Controllers
 {
-    [Authorize]
     public class DicomDeleteController : Controller
     {
         private readonly IMediator _mediator;

--- a/src/Microsoft.Health.Dicom.Api/Controllers/DicomQueryController.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/DicomQueryController.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Dicom;
 using EnsureThat;
 using MediatR;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Dicom.Api.Features.Filters;
@@ -21,7 +20,6 @@ using Microsoft.Health.Dicom.Core.Web;
 
 namespace Microsoft.Health.Dicom.Api.Controllers
 {
-    [Authorize]
     public class DicomQueryController : Controller
     {
         private readonly IMediator _mediator;

--- a/src/Microsoft.Health.Dicom.Api/Controllers/DicomRetrieveController.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/DicomRetrieveController.cs
@@ -12,7 +12,6 @@ using System.Threading.Tasks;
 using Dicom;
 using EnsureThat;
 using MediatR;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Dicom.Api.Features.Filters;
@@ -25,7 +24,6 @@ using Microsoft.Health.Dicom.Core.Web;
 
 namespace Microsoft.Health.Dicom.Api.Controllers
 {
-    [Authorize]
     public class DicomRetrieveController : Controller
     {
         private const string TransferSyntaxHeaderName = "transfer-syntax";

--- a/src/Microsoft.Health.Dicom.Api/Controllers/DicomStoreController.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/DicomStoreController.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Dicom;
 using EnsureThat;
 using MediatR;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Dicom.Api.Features.Filters;
@@ -19,7 +18,6 @@ using Microsoft.Health.Dicom.Core.Web;
 
 namespace Microsoft.Health.Dicom.Api.Controllers
 {
-    [Authorize]
     public class DicomStoreController : Controller
     {
         private readonly IMediator _mediator;

--- a/src/Microsoft.Health.Dicom.Api/Modules/SecurityModule.cs
+++ b/src/Microsoft.Health.Dicom.Api/Modules/SecurityModule.cs
@@ -5,6 +5,8 @@
 
 using EnsureThat;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Health.Dicom.Api.Configs;
 using Microsoft.Health.Dicom.Core.Configs;
@@ -39,6 +41,16 @@ namespace Microsoft.Health.Dicom.Api.Modules
                     options.Authority = _securityConfiguration.Authentication.Authority;
                     options.Audience = _securityConfiguration.Authentication.Audience;
                     options.RequireHttpsMetadata = true;
+                    options.Challenge = $"Bearer authorization_uri=\"{_securityConfiguration.Authentication.Authority}\", resource_id=\"{_securityConfiguration.Authentication.Audience}\", realm=\"{_securityConfiguration.Authentication.Audience}\"";
+                });
+
+                services.AddControllers(mvcOptions =>
+                {
+                    var policy = new AuthorizationPolicyBuilder()
+                        .RequireAuthenticatedUser()
+                        .Build();
+
+                    mvcOptions.Filters.Add(new AuthorizeFilter(policy));
                 });
             }
         }

--- a/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
@@ -8,7 +8,6 @@ using System.Reflection;
 using Dicom.Serialization;
 using EnsureThat;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -65,12 +64,6 @@ namespace Microsoft.AspNetCore.Builder
                 options.EnableEndpointRouting = false;
                 options.RespectBrowserAcceptHeader = true;
                 options.OutputFormatters.Insert(0, new DicomJsonOutputFormatter());
-
-                if (!dicomServerConfiguration.Security.Enabled)
-                {
-                    // Removes Authentication Requirements for all endpoints
-                    options.Filters.Add(new AllowAnonymousFilter());
-                }
             });
 
             services.AddSingleton<IUrlResolver, UrlResolver>();


### PR DESCRIPTION
## Description
Currently it is implemented as
- Authorize filter on each controller
- Service configured to allow anonymous if security is disabled

This is changed to
- Configure authorize with authenticated user policy for all mvc actions if security is enabled.

Following similar pattern in FHIR

## Related issues
[AB#73573](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/73573)

## Testing
Manual testing with security config disabled. 
Enabled with and without valid token.
User stories attached to feature 72440 to support authentication testing in dev, PR and CI.

