### PR TITLE
Fixed the VS warning.

### DIFF
--- a/Microsoft.Health.Dicom.sln
+++ b/Microsoft.Health.Dicom.sln
@@ -4,10 +4,10 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 16.0.28729.10
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{404C6C33-DB00-4182-BD90-F10A8B17C321}"
-    ProjectSection(SolutionItems) = preProject
-        Directory.Build.props = Directory.Build.props
-        global.json = global.json
-    EndProjectSection
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+		global.json = global.json
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Dicom.Web", "src\Microsoft.Health.Dicom.Web\Microsoft.Health.Dicom.Web.csproj", "{BFB96311-9B1A-41C1-ABF1-4F6522660084}"
 EndProject


### PR DESCRIPTION
## Description
Fixed the VS warning "Some of the properties associated with the solution could not be read." when opening the solution. Apparently the number of spaces matters.
