### PR TITLE
Fixed a Flaky Retrievemetadata transaction test 

### DIFF
--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/DicomRetrieveMetadataTransactionTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/DicomRetrieveMetadataTransactionTests.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
                 return;
             }
 
-            Assert.False(true, "Retrieved dataset doesnot match to stored datset");
+            Assert.False(true, "Retrieved dataset doesnot match the stored dataset");
         }
 
         private static void ValidateResponseMetadataDataset(DicomDataset storedDataset, DicomDataset retrievedDataset)


### PR DESCRIPTION
## Description
E2E test failure was happening inconsistently in CI build because the order in which the metadata gets retrieved is not consistent. Now its been updated such that it is not dependent on retrieval order.

## Related issues
Addresses [Bug # 73761](https://microsofthealth.visualstudio.com/Health/_workitems/edit/73761)

## Testing
Updated the test
