### PR TITLE
Fix documentation and launch settings for development identity provider

### DIFF
--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -23,19 +23,17 @@ The current authentication settings exposed in configuration are the following:
 ## Development Identity Provider
 For the F5 experience and test environments, an in-process identity provider is included that can act as the authentication provider for the DicomWeb API. 
 
-### Enabling DevelopmentIdentityProvider
-Set DicomServer:Security:Enabled to `true` in [appsettings.json](../src/Microsoft.Health.Dicom.Web/appsettings.json)
-
-[TestAuthEnvironment.json](../TestAuthEnvironment.json) file is used to configure the users and applications for Dicom API.
-
 ### TestAuthEnvironment.json
 The `testauthenvironment.json` file located in the root directory holds the configuration used for the server. **This file is meant only for local and test environments.** The items represented in this file include the roles available for the API as well as users and client applications that have access to the API. During the F5 experience and local testing, the password/secret for both users and client applications is the same as the id of the item. 
+
+### Enabling Development Identity Provider for testing
+[Launch settings](../src/Microsoft.Health.Dicom.Web/Properties/launchSettings.json) has `DicomWebSecurityEnabled` profile that has pre-set settings used to enable development identity provider.
 
 ### Authenticating using built in IdentityServer
 To obtain a token issue the following command.
 ```
 POST /connect/token HTTP/1.1
-Host: https://localhost:44348
+Host: https://localhost:63838
 Content-Type: application/x-www-form-urlencoded
 
 client_id=globalAdminServicePrincipal&client_secret=globalAdminServicePrincipal&grant_type=client_credentials&scope=health-api

--- a/src/Microsoft.Health.Dicom.Web/Properties/launchSettings.json
+++ b/src/Microsoft.Health.Dicom.Web/Properties/launchSettings.json
@@ -13,6 +13,9 @@
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "Development",
                 "DicomServer:Security:Enabled": true,
+                "DicomServer:Security:Authentication:Audience": "health-api",
+                "DicomServer:Security:Authentication:Authority": "https://localhost:63838/",
+
                 "TestAuthEnvironment:FilePath": "..//..//testauthenvironment.json"
             },
             "applicationUrl": "https://localhost:63838/"


### PR DESCRIPTION
## Description
Fix documentation and launch settings for development identity provider

## Related issues
Addresses [AB#73712](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/73712)

## Testing
Manual re-run the documentation steps and validate locally