### PR TITLE
Removed extra entry on VR types from the retrieve metadata conformance document 

### DIFF
--- a/docs/users/Conformance.md
+++ b/docs/users/Conformance.md
@@ -177,7 +177,6 @@ OB|Other Byte
 OD|Other Double
 OF|Other Float
 OL|Other Long
-OV|Other Long
 OV|Other 64-Bit Very Long
 OW|Other Word
 UN|Unkown


### PR DESCRIPTION
## Description
Removed extra entry on VR types from the retrieve metadata conformance document  

## Related issues
Addresses [Bug#73876](https://microsofthealth.visualstudio.com/Health/_workitems/edit/73876)

## Testing

