### PR TITLE
Remove Microsoft.VisualStudio.Web.CodeGeneration.Design

### DIFF
--- a/src/Microsoft.Health.Dicom.Web/Microsoft.Health.Dicom.Web.csproj
+++ b/src/Microsoft.Health.Dicom.Web/Microsoft.Health.Dicom.Web.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.9.1" />
     <PackageReference Include="Microsoft.Health.Development.IdentityProvider" Version="1.0.0-master-20200427-1" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
This package isn't needed and should be removed.

## Related issues
Addresses [AB#73844](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/73844).

## Testing
All existing tests continue to pass. 
