### PR TITLE
Fixed the issue with invalid UID value causing 500 error.

### DIFF
--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/StoreResponseBuilderTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/StoreResponseBuilderTests.cs
@@ -199,5 +199,30 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Store
             Assert.Equal(3, response.Dataset.Count());
             Assert.Equal("1", response.Dataset.GetSingleValueOrDefault<string>(DicomTag.RetrieveURL));
         }
+
+        [Fact]
+        public void GivenInvalidUidValue_WhenResponseIsBuilt_ThenItShouldNotThrowException()
+        {
+            // Create a DICOM dataset with invalid UID value.
+            var dicomDataset = new DicomDataset()
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                AutoValidate = false,
+#pragma warning restore CS0618 // Type or member is obsolete
+            };
+
+            dicomDataset.Add(DicomTag.SOPClassUID, "invalid");
+
+            _storeResponseBuilder.AddFailure(dicomDataset, failureReasonCode: 500);
+
+            StoreResponse response = _storeResponseBuilder.BuildResponse(studyInstanceUid: null);
+
+            Assert.NotNull(response);
+            Assert.NotNull(response.Dataset);
+
+            ValidationHelpers.ValidateFailedSopSequence(
+                response.Dataset,
+                (null, "invalid", 500));
+        }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Store/StoreResponseBuilder.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Store/StoreResponseBuilder.cs
@@ -102,6 +102,12 @@ namespace Microsoft.Health.Dicom.Core.Features.Store
                 { DicomTag.FailureReason, failureReasonCode },
             };
 
+            // We want to turn off auto validation for FailedSOPSequence item
+            // because the failure might be caused by invalid UID value.
+#pragma warning disable CS0618 // Type or member is obsolete
+            failedSop.AutoValidate = false;
+#pragma warning restore CS0618 // Type or member is obsolete
+
             failedSop.AddValueIfNotNull(
                 DicomTag.ReferencedSOPClassUID,
                 dicomDataset?.GetSingleValueOrDefault<string>(DicomTag.SOPClassUID));


### PR DESCRIPTION
## Description
We do validations on the incoming DICOM file and if the file fails, we create a new entry in FailedSOPSequence to indicate that the instance could not be stored. 

As part of creating the entry in FailedSOPSequence, we copy the SOPClassUID and SOPInstanceUID from the incoming DICOM file.

However, the problem is that if the UID is an invalid value, fo-dicom throws exception when we try to copy the UID value.

The fix is to turn off the fo-dicom validation specifically for the DicomDataset used by the FailedSOPSequence so that we can copy the value.

## Related issues
Addresses [AB#73926](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/73926).

## Testing
Added unit test.
