### PR TITLE
Address task await issue in cleanup worker.

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Features/BackgroundServices/DeletedInstanceCleanupWorker.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/BackgroundServices/DeletedInstanceCleanupWorker.cs
@@ -39,6 +39,8 @@ namespace Microsoft.Health.Dicom.Api.Features.BackgroundServices
             {
                 try
                 {
+                    await Task.Delay(_pollingInterval, stoppingToken);
+
                     bool success;
                     int retrievedInstanceCount;
                     do
@@ -46,13 +48,11 @@ namespace Microsoft.Health.Dicom.Api.Features.BackgroundServices
                         (success, retrievedInstanceCount) = await _deleteService.CleanupDeletedInstancesAsync(stoppingToken);
                     }
                     while (success && retrievedInstanceCount == _batchSize);
-
-                    await Task.Delay(_pollingInterval, stoppingToken);
                 }
                 catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
                 {
                     // Cancel requested.
-                    break;
+                    throw;
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Description
Previously, if the cleanup worker experienced an exception in something like `_deleteService CleanupDeletedInstancesAsync` it would have been immediately retried. This would have caused an endless loop of failing calls which could cause issues with log size and requests to the underlying services. 

To address this, the `_pollingInterval` delay has been moved to the top of the loop so that it will be executed every loop regardless of any exceptions encountered.

Also, in the case of an `OperationCanceledException` the exception will be re-thrown instead of swallowed.

## Related issues
Addresses [AB#74065](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/74065).

## Testing
Existing tests continue to pass.
