### PR TITLE
Fixed the slow issue with metadata store retrieving the files.

### DIFF
--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/DataStoreTestsFixture.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/DataStoreTestsFixture.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             jsonSerializer.Converters.Add(new JsonDicomConverter());
 
             FileStore = new BlobFileStore(_blobClient, optionsMonitor);
-            MetadataStore = new BlobMetadataStore(_blobClient, jsonSerializer, optionsMonitor);
+            MetadataStore = new BlobMetadataStore(_blobClient, jsonSerializer, optionsMonitor, RecyclableMemoryStreamManager);
         }
 
         public async Task DisposeAsync()


### PR DESCRIPTION
## Description
Fixed the issue where retrieving metadata was taking really long. Before the fix, it took over 30 seconds to retrieve 100 metadata blobs. After the fix, it took 114 ms.

There is no max limit built with this code change, so the maximum it will try to download is 100 at any given request. Of course the actual number of connection will depend on the thread pool size and the IO pool size. Consider the metadata file is small, I don't think this is an issue right now but could be a problem when we have large number of simultaneous requests. We can then consider build some global limit.

## Related issues
Addresses [AB#74134](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/74134).

## Testing
Did quick bench mark of before and after. Ran the existing tests.
