### PR TITLE
Add Download Maximum concurrency config setting allowed in the new blob sdk

### DIFF
--- a/src/Microsoft.Health.Dicom.Web/appsettings.json
+++ b/src/Microsoft.Health.Dicom.Web/appsettings.json
@@ -51,7 +51,8 @@
         "RequestOptions": {
             "ExponentialRetryBackoffDeltaInSeconds": 4,
             "ExponentialRetryMaxAttempts": 6,
-            "ServerTimeoutInMinutes": 2
+            "ServerTimeoutInMinutes": 2,
+            "DownloadMaximumConcurrency": 2
         }
     },
     "SqlServer": {


### PR DESCRIPTION
## Description
Replacing the parallelThreadCount with MaximumConcurrenct as mention. Currently will be only used in entire dcm file download.

https://github.com/Azure/azure-sdk-for-net/issues/12445

## Related issues
[AB#74219](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/74219)

## Testing
Existing tests passing. Not done extensive testing on the right number. Hopefully scale testing will help us learn more.