### PR TITLE
QueryParser code cleanup in-reaction to fix in fo-dicom

### DIFF
--- a/src/Microsoft.Health.Dicom.Core/Features/Query/QueryParser.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Query/QueryParser.cs
@@ -163,20 +163,12 @@ namespace Microsoft.Health.Dicom.Core.Features.Query
             return condition != null;
         }
 
-        private bool TryParseDicomAttributeId(string attributeId, out DicomTag dicomTag)
+        private static bool TryParseDicomAttributeId(string attributeId, out DicomTag dicomTag)
         {
             dicomTag = null;
 
             // Try Keyword match, returns null if not found
-            // fo-dicom github bug throwing nullreference https://github.com/fo-dicom/fo-dicom/issues/996
-            try
-            {
-                dicomTag = DicomDictionary.Default[attributeId];
-            }
-            catch (NullReferenceException e)
-            {
-                _logger.LogDebug(e, $"DicomDictionary.Default[attributeId] threw exception for {attributeId}");
-            }
+            dicomTag = DicomDictionary.Default[attributeId];
 
             if (dicomTag == null)
             {


### PR DESCRIPTION
## Description
fo-dicom 4.0.5 version has the fix to https://github.com/fo-dicom/fo-dicom/issues/996
Removing the workaround, since it is not needed anymore.

## Related issues
Addresses [issue #].

## Testing
Existing tests passing. Manual validation of invalid tags