### PR TITLE
Update IDicomWebClient extensions, fix DicomWebClient Issue

### DIFF
--- a/src/Microsoft.Health.Dicom.Client/DicomWebClient.cs
+++ b/src/Microsoft.Health.Dicom.Client/DicomWebClient.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Health.Dicom.Client
 
         public void SetBearerToken(string token)
         {
-            EnsureArg.IsNotEmptyOrWhitespace(token);
+            EnsureArg.IsNotNullOrWhiteSpace(token, nameof(token));
 
             var decodedToken = new JsonWebToken(token);
             TokenExpiration = decodedToken.ValidTo;

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Clients/TestDicomWebClient.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Clients/TestDicomWebClient.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Clients
 
         private async Task SetupAuthenticationAsync(TestApplication clientApplication, TestUser user = null)
         {
-            if (SecurityEnabled == true && clientApplication != TestApplications.InvalidClient)
+            if (SecurityEnabled && clientApplication != TestApplications.InvalidClient)
             {
                 var tokenKey = $"{clientApplication.ClientId}:{(user == null ? string.Empty : user.UserId)}";
 
@@ -35,7 +35,8 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Clients
                         clientApplication.ClientId,
                         clientApplication.ClientSecret,
                         AuthenticationSettings.Resource,
-                        AuthenticationSettings.Scope);
+                        AuthenticationSettings.Scope,
+                        cancellationToken: default);
 
                     _bearerTokens[tokenKey] = HttpClient.DefaultRequestHeaders?.Authorization?.Parameter;
 


### PR DESCRIPTION
## Description
This PR updates the DicomWebClientAuthExtensions to add `CancellationToken` support, change extension type to `IDicomWebClient` and fix use of `IsNotEmptyOrWhitespace` -> `IsNotNullOrWhiteSpace`.

## Related issues
Addresses [AB#74008](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/74008).

## Testing
Existing tests continue to pass.
