### PR TITLE
Parallel tasks to retrieve instances in GetMetadata and ChangeFeed

### DIFF
--- a/src/Microsoft.Health.Dicom.Core/Features/ChangeFeed/ChangeFeedService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ChangeFeed/ChangeFeedService.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -47,10 +48,7 @@ namespace Microsoft.Health.Dicom.Core.Features.ChangeFeed
                 return changeFeedEntries;
             }
 
-            foreach (ChangeFeedEntry entry in changeFeedEntries)
-            {
-                await PopulateMetadata(entry, cancellationToken);
-            }
+            await PopulateMetadata(changeFeedEntries, cancellationToken);
 
             return changeFeedEntries;
         }
@@ -70,6 +68,13 @@ namespace Microsoft.Health.Dicom.Core.Features.ChangeFeed
             }
 
             return result;
+        }
+
+        private async Task PopulateMetadata(IReadOnlyCollection<ChangeFeedEntry> changeFeedEntries, CancellationToken cancellationToken)
+        {
+            await Task.WhenAll(
+                        changeFeedEntries
+                        .Select(x => PopulateMetadata(x, cancellationToken)));
         }
 
         private async Task PopulateMetadata(ChangeFeedEntry entry, CancellationToken cancellationToken)

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveMetadataService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveMetadataService.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Dicom;
@@ -69,15 +70,11 @@ namespace Microsoft.Health.Dicom.Core.Features.Retrieve
 
         private async Task<RetrieveMetadataResponse> RetrieveMetadata(IEnumerable<VersionedInstanceIdentifier> instancesToRetrieve, CancellationToken cancellationToken)
         {
-            var dataset = new List<DicomDataset>();
+            IEnumerable<DicomDataset> instanceMetadata = await Task.WhenAll(
+                        instancesToRetrieve
+                        .Select(x => _metadataStore.GetInstanceMetadataAsync(x, cancellationToken)));
 
-            foreach (VersionedInstanceIdentifier versionedInstanceIdentifier in instancesToRetrieve)
-            {
-                DicomDataset ds = await _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifier, cancellationToken);
-                dataset.Add(ds);
-            }
-
-            return new RetrieveMetadataResponse(dataset);
+            return new RetrieveMetadataResponse(instanceMetadata);
         }
     }
 }


### PR DESCRIPTION
## Description
Generate a list of Tasks to retrieve metadata blob and
await on Task.All  to parallelize retrieval.

## Related issues
[AB#74491](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/74491)

## Testing
Existing tests are passing