### PR TITLE
Still seeing jsontextwriter dispose failing with sync write.

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Features/Formatters/DicomJsonOutputFormatter.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Formatters/DicomJsonOutputFormatter.cs
@@ -71,7 +71,6 @@ namespace Microsoft.Health.Dicom.Api.Features.Formatters
             EnsureArg.IsNotNull(selectedEncoding, nameof(selectedEncoding));
 
             HttpResponse response = context.HttpContext.Response;
-
             await using var fileBufferingWriteStream = new FileBufferingWriteStream();
 
             await using (TextWriter textWriter = context.WriterFactory(fileBufferingWriteStream, selectedEncoding))


### PR DESCRIPTION
## Description
FlushASync() did make the E2E test pass, but I was still seeing issues in imstest3 with below stack.

Unhandled exception: System.InvalidOperationException: Synchronous operations are disallowed. Call WriteAsync or set AllowSynchronousIO to true instead.
   at Microsoft.AspNetCore.Server.IIS.Core.HttpResponseStream.Write(Byte[] buffer, Int32 offset, Int32 count)
   at Microsoft.AspNetCore.Server.IIS.Core.WrappingStream.Write(Byte[] buffer, Int32 offset, Int32 count)
   at Microsoft.AspNetCore.WebUtilities.HttpResponseStreamWriter.FlushInternal(Boolean flushEncoder)
   at Microsoft.AspNetCore.WebUtilities.HttpResponseStreamWriter.Dispose(Boolean disposing)
   at System.IO.TextWriter.Close()
   at Newtonsoft.Json.JsonTextWriter.CloseBufferAndWriter()
   at Newtonsoft.Json.JsonTextWriter.Close()
   at Newtonsoft.Json.JsonWriter.Dispose(Boolean disposing)
   at Newtonsoft.Json.JsonWriter.System.IDisposable.Dispose()
   at Microsoft.Health.Dicom.Api.Features.Formatters.DicomJsonOutputFormatter.WriteResponseBodyAsync(OutputFormatterWriteContext context, Encoding selectedEncoding) in D:\a\1\s\src\Microsoft.Health.Dicom.Api\Features\Formatters\DicomJsonOutputFormatter.cs:line 61
 
So I have updated the logic to base of https://github.com/dotnet/aspnetcore/blob/master/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonOutputFormatter.cs

Basically set CloseOutput = false on JsonTextWriter and use our own filestreamwriter for response body.

## Related issues
Addresses [issue #].

## Testing
Existing tests passing. Validated on imstest3 running some Qido queries.
