### PR TITLE
Change the max content length for IIS.

### DIFF
--- a/src/Microsoft.Health.Dicom.Web/web.config
+++ b/src/Microsoft.Health.Dicom.Web/web.config
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
+    </handlers>
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" hostingModel="inprocess" />
+    <security>
+      <requestFiltering>
+        <!-- When the process is hosted in IIS, change the following limit to increase maximum content length allowed. -->
+        <!-- Set to 1GB by default. -->
+        <requestLimits maxAllowedContentLength="1073741824" />
+      </requestFiltering>
+    </security>
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
## Description
When the .NET Core process is hosted within IIS (e.g., Web App), IIS rejects request bigger than 30MB even if the .NET Core app itself allows large body size.

The solution seems to be setting the `maxAllowedContentLength` in the web.config file. I tried to see if there is a way to programmatically set this value within the code so that all of the configuration can be read from single appsettings.config file but it doesn't seem to be the case.

We might be able to use some "transform" process to read the value from appsettings.config and update the web.config file during build or something, but I am considering just check in a hard coded value for now.

Alternatively, I will also look into Web app settings to see if we can hose the .NET Core process without using IIS.

## Related issues
Addresses [AB#74871](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/74871).

## Testing
Manually tested. 
