### PR TITLE
Fixed exception logging.

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Health.Dicom.Api.Features.Exceptions
                     statusCode = HttpStatusCode.InternalServerError;
                     break;
                 case DicomServerException _:
-                    _logger.LogWarning("Service exception: {0}", exception);
+                    _logger.LogWarning(exception, "Service exception.");
                     statusCode = HttpStatusCode.ServiceUnavailable;
                     break;
             }
@@ -100,7 +100,7 @@ namespace Microsoft.Health.Dicom.Api.Features.Exceptions
             {
                 // In the case of InternalServerError, make sure to overwrite the message to
                 // avoid internal message.
-                _logger.LogCritical("Unhandled exception: {0}", exception);
+                _logger.LogCritical(exception, "Unhandled exception.");
                 message = DicomApiResource.InternalServerError;
             }
 


### PR DESCRIPTION
## Description
Unhandled exceptions are logged under traces instead of exceptions in AI. This is because the exception is not being passed in to logger as exception.

## Related issues
Addresses [AB#75004](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/75004).

## Testing
Manual.
