### PR TITLE
Add Postman collection export

### DIFF
--- a/docs/users/Conformance-as-Postman.postman_collection.json
+++ b/docs/users/Conformance-as-Postman.postman_collection.json
@@ -1,0 +1,781 @@
+{
+	"info": {
+		"_postman_id": "952e62f2-7734-4041-9be3-b3018e4069f3",
+		"name": "Conformance-as-Postman",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Store-instances-using-multipart/related",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "684d82bf-239b-4337-abb0-41062cf284d3",
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true,
+					"content-type": true,
+					"user-agent": true,
+					"accept-encoding": true,
+					"connection": true
+				}
+			},
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/dicom+json",
+						"type": "text"
+					},
+					{
+						"key": "Content-Type",
+						"value": "multipart/related;boundary=ABCD1234",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "file",
+							"contentType": "application/dicom",
+							"type": "file",
+							"src": "/C:/githealth/dicom-samples/visus.com/case1/dicomfile"
+						}
+					],
+					"options": {
+						"raw": {
+							"language": "text"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{baseUrl}}/studies",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"studies"
+					]
+				},
+				"description": "This request intends to demonstrate how to upload DICOM files using multipart/related. However, it will not work in Postman.\r\n\r\n| NOTE: Postman cannot be used to upload DICOM files in a way that complies with the DICOM standard. This is due to a Postman limitation. Instead, consider using cURL or programatically uploading the file using Python, C# or another full featured language.\r\n\r\n_Details:_\r\nPath: ../studies\r\nMethod: POST\r\nHeaders:\r\n    `Accept: application/dicom+json`\r\n    `Content-Type: multipart/related; type=\"application/dicom\"`\r\nBody:\r\n    `Content-Type: application/dicom` for each file uploaded, separated by a boundary value\r\n\r\n| Some programming languages and tools behave differently. For instance, some require you to define your own boundary. For those, you may need to use a slightly modified Content-Type header. The following have been used successfully.\r\n    `Content-Type: multipart/related; type=\"application/dicom\"; boundary=ABCD1234`\r\n    `Content-Type: multipart/related; boundary=ABCD1234`\r\n    `Content-Type: multipart/related`\r\n\r\nIf using Postman, please consider using Store-single-instance. This is a non-standard API that allows the upload of a single DICOM file without the need to configure the POST for multipart/related."
+			},
+			"response": []
+		},
+		{
+			"name": "Store-single-instance",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "855fa304-6be9-49e9-a2cb-4621bcedfd39",
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true,
+					"content-type": true,
+					"user-agent": true,
+					"accept-encoding": true,
+					"connection": true
+				}
+			},
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/dicom+json",
+						"type": "text"
+					},
+					{
+						"key": "Content-Type",
+						"value": "multipart/related;boundary=ABCD1234",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "file",
+							"contentType": "application/dicom",
+							"type": "file",
+							"src": "/C:/githealth/dicom-samples/visus.com/case1/dicomfile"
+						}
+					],
+					"options": {
+						"raw": {
+							"language": "text"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{baseUrl}}/studies",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"studies"
+					]
+				},
+				"description": "| NOTE: This is a non-standard API that allows the upload of a single DICOM file without the need to configure the POST for multipart/related. It allows the use of Postman to upload files to the DICOMweb service.\r\n\r\nThe following is required to upload a single DICOM file.\r\n\r\nPath: ../studies\r\nMethod: POST\r\nHeaders:\r\n    `Accept: application/dicom+json`\r\n    `Content-Type: application/dicom`\r\nBody:\r\n    Contains the DICOM file as a bytes.\r\n\r\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Store-instances-for-a-specific-study",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "formdata",
+					"formdata": []
+				},
+				"url": {
+					"raw": "{{baseUrl}}/studies/{{study1}}",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"studies",
+						"{{study1}}"
+					]
+				},
+				"description": "This request intends to demonstrate how to upload DICOM files using multipart/related to a designated study. However, it will not work in Postman.\r\n\r\n| NOTE: Postman cannot be used to upload DICOM files in a way that complies with the DICOM standard. This is due to a Postman limitation. Instead, consider using cURL or programatically uploading the file using Python, C# or another full featured language.\r\n\r\n_Details:_\r\nPath: ../studies/{study}\r\nMethod: POST\r\nHeaders:\r\n    `Accept: application/dicom+json`\r\n    `Content-Type: multipart/related; type=\"application/dicom\"`\r\nBody:\r\n    `Content-Type: application/dicom` for each file uploaded, separated by a boundary value\r\n\r\n| Some programming languages and tools behave differently. For instance, some require you to define your own boundary. For those, you may need to use a slightly modified Content-Type header. The following have been used successfully.\r\n    `Content-Type: multipart/related; type=\"application/dicom\"; boundary=ABCD1234`\r\n    `Content-Type: multipart/related; boundary=ABCD1234`\r\n    `Content-Type: multipart/related`\r\n\r\nIf using Postman, please consider using Store-single-instance. This is a non-standard API that allows the upload of a single DICOM file without the need to configure the POST for multipart/related."
+			},
+			"response": []
+		},
+		{
+			"name": "Retrieve-all-instances-within-a-study",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "cb7ea544-e203-4315-b704-72be4d775122",
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true
+				}
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "multipart/related; type=\"application/dicom\"; transfer-syntax=*",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{baseUrl}}/studies/{{study1}}",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"studies",
+						"{{study1}}"
+					]
+				},
+				"description": "This request retrieves all instances within a single study.\r\n\r\n_Details:_\r\nPath: ../studies/{study}\r\nMethod: GET\r\nHeaders:\r\n    `Accept: multipart/related; type=\"application/dicom\"; transfer-syntax=*`\r\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Retrieve-metadata-of-all-instances-in-study",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "c1da3890-2a5a-4f3b-98bc-e95f925ca9fa",
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});\r",
+							"\r",
+							"let seriesid = pm.variables.get(\"series1\");\r",
+							"pm.test(\"Series in returned metadata\", function () {\r",
+							"    pm.expect(pm.response.text()).to.include(seriesid);\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true
+				}
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/dicom+json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{baseUrl}}/studies/{{study1}}/metadata",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"studies",
+						"{{study1}}",
+						"metadata"
+					]
+				},
+				"description": "This request retrieves the metadata for all instances within a single study.\r\n\r\n_Details:_\r\nPath: ../studies/{study}/metadata\r\nMethod: GET\r\nHeaders:\r\n    `Accept: application/dicom+json`\r\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Retrieve-all-instances-within-a-series",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "6e257662-2155-479a-be78-039264908531",
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200);\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true
+				}
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "multipart/related; type=\"application/dicom\"; transfer-syntax=*",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{baseUrl}}/studies/{{study1}}/series/{{series1}}",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"studies",
+						"{{study1}}",
+						"series",
+						"{{series1}}"
+					]
+				},
+				"description": "This request retrieves all instances within a single series.\r\n\r\n_Details:_\r\nPath: ../studies/{study}/series{series}\r\nMethod: GET\r\nHeaders:\r\n    `Accept: multipart/related; type=\"application/dicom\"; transfer-syntax=*`\r\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Retrieve-metadata-of-all-instances-within-a-series",
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true
+				}
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/dicom+json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{baseUrl}}/studies/{{study1}}/series/{{series1}}/metadata",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"studies",
+						"{{study1}}",
+						"series",
+						"{{series1}}",
+						"metadata"
+					]
+				},
+				"description": "This RESTful call will retrieve the metadata for all\r\ninstances within a series of a study.\r\n\r\nThis request retrieves the metadata for all instances within a single series.\r\n\r\n_Details:_\r\nPath: ../studies/{study}/series/{series}/metadata\r\nMethod: GET\r\nHeaders:\r\n    `Accept: application/dicom+json`\r\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Retrieve-a-single-instance-within-a-series-of-a-study",
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true
+				}
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/dicom; transfer-syntax=*",
+						"type": "text"
+					},
+					{
+						"key": "",
+						"value": "",
+						"type": "text",
+						"disabled": true
+					}
+				],
+				"url": {
+					"raw": "{{baseUrl}}/studies/{{study1}}/series/{{series1}}/instances/{{instance1}}",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"studies",
+						"{{study1}}",
+						"series",
+						"{{series1}}",
+						"instances",
+						"{{instance1}}"
+					]
+				},
+				"description": "This RESTful call will retrieve a single instance within a\r\nseries of a study."
+			},
+			"response": []
+		},
+		{
+			"name": "Retrieve-metadata-of-a-single-instance-within-a-series-of-a-study",
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true
+				}
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/dicom+json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{baseUrl}}/studies/{{study1}}/series/{{series1}}/instances/{{instance1}}/metadata",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"studies",
+						"{{study1}}",
+						"series",
+						"{{series1}}",
+						"instances",
+						"{{instance1}}",
+						"metadata"
+					]
+				},
+				"description": "This RESTful call will retrieve metadat of a single instance\r\nwithin a series of a study."
+			},
+			"response": []
+		},
+		{
+			"name": "Retrieve-one-or-more-frames-from-a-single-instance",
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true
+				}
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "multipart/related; type=\"application/octet-stream\"; transfer-syntax=1.2.840.10008.1.2.1",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{baseUrl}}/studies/{{study1}}/series/{{series1}}/instances/{{instance1}}/frames/1",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"studies",
+						"{{study1}}",
+						"series",
+						"{{series1}}",
+						"instances",
+						"{{instance1}}",
+						"frames",
+						"1"
+					]
+				},
+				"description": "This RESTful call will one or more frames from a single\r\ninstance of a series within a study"
+			},
+			"response": []
+		},
+		{
+			"name": "Search-for-studies",
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true
+				}
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/dicom+json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{baseUrl}}/studies?StudyInstanceUID={{study1}}",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"studies"
+					],
+					"query": [
+						{
+							"key": "StudyInstanceUID",
+							"value": "{{study1}}"
+						}
+					]
+				},
+				"description": "This RESTful call will search studies"
+			},
+			"response": []
+		},
+		{
+			"name": "Search-for-series",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/dicom+json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{baseUrl}}/series?SeriesInstanceUID={{series1}}",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"series"
+					],
+					"query": [
+						{
+							"key": "SeriesInstanceUID",
+							"value": "{{series1}}"
+						}
+					]
+				},
+				"description": "This RESTful call will search studies"
+			},
+			"response": []
+		},
+		{
+			"name": "Search-for-series-within-a-study",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/dicom+json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{baseUrl}}/studies/{{study1}}/series?SeriesInstanceUID={{series1}}",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"studies",
+						"{{study1}}",
+						"series"
+					],
+					"query": [
+						{
+							"key": "SeriesInstanceUID",
+							"value": "{{series1}}"
+						}
+					]
+				},
+				"description": "This RESTful call will search studies"
+			},
+			"response": []
+		},
+		{
+			"name": "Search-for-instances",
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true
+				}
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/dicom+json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{baseUrl}}/instances?SOPInstanceUID={{instance1}}",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"instances"
+					],
+					"query": [
+						{
+							"key": "SOPInstanceUID",
+							"value": "{{instance1}}"
+						}
+					]
+				},
+				"description": "This RESTful call will search instances for given set of\r\nparameters."
+			},
+			"response": []
+		},
+		{
+			"name": "Search-for-instances-in-a-study",
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true
+				}
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/dicom+json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{baseUrl}}/studies/{{study1}}/instances?SOPInstanceUID={{instance1}}",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"studies",
+						"{{study1}}",
+						"instances"
+					],
+					"query": [
+						{
+							"key": "SOPInstanceUID",
+							"value": "{{instance1}}"
+						}
+					]
+				},
+				"description": "This RESTful call will search instances for given set of\r\nparameters."
+			},
+			"response": []
+		},
+		{
+			"name": "Search-for-instances-in-a-series",
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true
+				}
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/dicom+json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{baseUrl}}/studies/{{study1}}/series/{{series1}}/instances?SOPInstanceUID={{instance1}}",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"studies",
+						"{{study1}}",
+						"series",
+						"{{series1}}",
+						"instances"
+					],
+					"query": [
+						{
+							"key": "SOPInstanceUID",
+							"value": "{{instance1}}"
+						}
+					]
+				},
+				"description": "This RESTful call will search instances for given set of\r\nparameters."
+			},
+			"response": []
+		},
+		{
+			"name": "Delete-a-specific-instance-within-a-series",
+			"request": {
+				"method": "DELETE",
+				"header": [],
+				"url": {
+					"raw": "{{baseUrl}}/studies/{{study1}}/series/{{series1}}/instances/{{instance1}}",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"studies",
+						"{{study1}}",
+						"series",
+						"{{series1}}",
+						"instances",
+						"{{instance1}}"
+					]
+				},
+				"description": "This RESTful call will delete all instances for a specific\r\nstudy of a patient."
+			},
+			"response": []
+		},
+		{
+			"name": "Delete-all-instances-for-a-specific-series-within-a-study",
+			"request": {
+				"method": "DELETE",
+				"header": [],
+				"url": {
+					"raw": "{{baseUrl}}/studies/{{study1}}/series/{{series1}}/",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"studies",
+						"{{study1}}",
+						"series",
+						"{{series1}}",
+						""
+					]
+				},
+				"description": "This RESTful call will delete all instances for a specific\r\nstudy of a patient."
+			},
+			"response": []
+		},
+		{
+			"name": "Delete-all-instances-for-a-specific-study",
+			"request": {
+				"method": "DELETE",
+				"header": [],
+				"url": {
+					"raw": "{{baseUrl}}/studies/{{study1}}",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"studies",
+						"{{study1}}"
+					]
+				},
+				"description": "This RESTful call will delete all instances for a specific\r\nstudy of a patient."
+			},
+			"response": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "51a1cedd-d84d-43c6-8952-166f3a4262c1",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "2a90d325-3343-46f3-8251-85c3f20d38fc",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"id": "56511da8-43ba-47de-9496-7b0181e65273",
+			"key": "baseUrl",
+			"value": "http://sjbpostman.azurewebsites.net"
+		},
+		{
+			"id": "9539f6ea-0511-4c90-a919-f50942276922",
+			"key": "study1",
+			"value": "1.2.276.0.50.192168001099.7810872.14547392.270"
+		},
+		{
+			"id": "372cd467-5a0d-435c-8e79-d02c51c19d9d",
+			"key": "study2",
+			"value": "1.2.276.0.50.192168001099.9140875.14547392.277"
+		},
+		{
+			"id": "fbf4eac7-f22e-4daa-91b1-5ce9087af261",
+			"key": "series1",
+			"value": "1.2.276.0.50.192168001099.7810872.14547392.458"
+		},
+		{
+			"id": "70bb6a29-386c-4a5c-bad8-2982a09f5534",
+			"key": "instance1",
+			"value": "1.2.276.0.50.192168001099.7810872.14547392.467"
+		},
+		{
+			"id": "88af0341-e695-49b1-b67c-67313aa2239c",
+			"key": "instance2",
+			"value": "1.2.276.0.50.192168001099.9140875.14547392.276"
+		},
+		{
+			"id": "cf33483d-0d73-4643-9840-4832d2e04692",
+			"key": "b64encodeddicom",
+			"value": ""
+		}
+	],
+	"protocolProfileBehavior": {}
+}


### PR DESCRIPTION
## Description
Adding Conformance-as-Postman collection export, allowing users of the API to import examples of API access using Postman..

## Related issues
Addresses #75027

## Testing
Tested in Postman by importing collection
