### PR TITLE
Adding locking on insert and delete

### DIFF
--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/1.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/1.sql
@@ -755,7 +755,7 @@ AS
 
     -- Insert Study
     SELECT @studyKey = StudyKey
-    FROM dbo.Study
+    FROM dbo.Study WITH(UPDLOCK)
     WHERE StudyInstanceUid = @studyInstanceUid
 
     IF @@ROWCOUNT = 0
@@ -777,7 +777,7 @@ AS
 
     -- Insert Series
     SELECT @seriesKey = SeriesKey
-    FROM dbo.Series
+    FROM dbo.Series WITH(UPDLOCK)
     WHERE StudyKey = @studyKey
     AND SeriesInstanceUid = @seriesInstanceUid
 
@@ -1005,7 +1005,7 @@ AS
 
     -- If this is the last instance for a series, remove the series
     IF NOT EXISTS ( SELECT  *
-                    FROM    dbo.Instance WITH(UPDLOCK)
+                    FROM    dbo.Instance WITH(HOLDLOCK, UPDLOCK)
                     WHERE   StudyKey = @studyKey
                     AND     SeriesInstanceUid = ISNULL(@seriesInstanceUid, SeriesInstanceUid))
     BEGIN
@@ -1017,7 +1017,7 @@ AS
 
     -- If we've removing the series, see if it's the last for a study and if so, remove the study
     IF NOT EXISTS ( SELECT  *
-                    FROM    dbo.Series WITH(UPDLOCK)
+                    FROM    dbo.Series WITH(HOLDLOCK, UPDLOCK)
                     WHERE   Studykey = @studyKey)
     BEGIN
         DELETE


### PR DESCRIPTION
## Description
Add UPDLOCK on AddInstance on selects of study and series key.
This will make sure the if there is a existing study/series row that matches the UID, it won't get deleted/update before
update runs.
Adding HOLDLOCK on DeleteInstance selects so that no new rows matching the UIDS exist before the delete run.

## Related issues
[AB#75011](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/75011)

## Testing
Ran my example files multiple times.
