### PR TITLE
Switch to Efferent Transcoder

### DIFF
--- a/src/Microsoft.Health.Dicom.Web/appsettings.json
+++ b/src/Microsoft.Health.Dicom.Web/appsettings.json
@@ -10,8 +10,7 @@
         },
         "Features": {
             "EnableOhifViewer": false,
-            "EnableFullDicomItemValidation": false,
-            "TranscoderType": "Efferent"
+            "EnableFullDicomItemValidation": false
         },
         "Services": {
             "DeletedInstanceCleanup": {


### PR DESCRIPTION

## Description
Switch to Efferent Transcoder from FoDicom.

1. Change TranscoderType in appsettings.json to Efferent
2. Update default-azuredeploy.json:
	- disable use32BitWorkerProcess, since Efferent doesn't provide 32bits native dll
	- Use 64bits AspNetCoreRunTime instead of 32bits.

## Related issues
Addresses [Switch to Efferent Transcoder](https://microsofthealth.visualstudio.com/Health/_workitems/edit/75183)

## Testing
1.  Deployed  updated ARM template and code, able to open website, and test frame.

## Notes
1. When both 32bits & 64bits AspNetCoreRunTime exist, service won't start

