### PR TITLE
Update to the latest release of fo-dicom to fix the bug #74085

### DIFF
--- a/src/Microsoft.Health.Dicom.Client/Microsoft.Health.Dicom.Client.csproj
+++ b/src/Microsoft.Health.Dicom.Client/Microsoft.Health.Dicom.Client.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="9.2.0" />
-    <PackageReference Include="fo-dicom" Version="4.0.5" NoWarn="NU1701" />
-    <PackageReference Include="fo-dicom.json" Version="4.0.5" NoWarn="NU1701" />
+    <PackageReference Include="fo-dicom" Version="4.0.6" NoWarn="NU1701" />
+    <PackageReference Include="fo-dicom.json" Version="4.0.6" NoWarn="NU1701" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.5.0" />
     <PackageReference Include="Microsoft.Health.Client" Version="1.0.0-master-20200629-1" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.5.1" />

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Serialization/JsonDicomConverterExtendedTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Serialization/JsonDicomConverterExtendedTests.cs
@@ -120,5 +120,20 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Serialization
             ";
             Assert.Throws<JsonReaderException>(() => JsonConvert.DeserializeObject<DicomDataset>(json, new JsonDicomConverter()));
         }
+
+        [Fact]
+        public static void GivenDicomJsonDatasetWithFloatingVRContainsNAN_WhenDeserialized_IsSuccessful()
+        {
+            const string json = @"
+            {
+                ""00720076"": {
+                    ""vr"": ""FL"",
+                     ""Value"": [""NaN""]
+                 }
+            } ";
+
+            DicomDataset tagValue = JsonConvert.DeserializeObject<DicomDataset>(json, new JsonDicomConverter());
+            Assert.NotNull(tagValue.GetDicomItem<DicomFloatingPointSingle>(DicomTag.SelectorFLValue));
+        }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Microsoft.Health.Dicom.Core.csproj
+++ b/src/Microsoft.Health.Dicom.Core/Microsoft.Health.Dicom.Core.csproj
@@ -6,9 +6,9 @@
 
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="9.2.0" />
-    <PackageReference Include="fo-dicom" Version="4.0.5" />
+    <PackageReference Include="fo-dicom" Version="4.0.6" />
     <PackageReference Include="fo-dicom.Codecs" Version="5.0.0-beta2" />
-    <PackageReference Include="fo-dicom.json" Version="4.0.5" NoWarn="NU1701" />
+    <PackageReference Include="fo-dicom.json" Version="4.0.6" NoWarn="NU1701" />
     <PackageReference Include="MediatR" Version="7.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.5" />

--- a/src/Microsoft.Health.Dicom.Metadata/Microsoft.Health.Dicom.Metadata.csproj
+++ b/src/Microsoft.Health.Dicom.Metadata/Microsoft.Health.Dicom.Metadata.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="fo-dicom" Version="4.0.5" />
+    <PackageReference Include="fo-dicom" Version="4.0.6" />
     <PackageReference Include="Microsoft.Health.Blob" Version="1.0.0-master-20200716-1" />
     <PackageReference Include="Polly" Version="7.2.0" />
   </ItemGroup>

--- a/src/Microsoft.Health.Dicom.Tests.Common/Microsoft.Health.Dicom.Tests.Common.csproj
+++ b/src/Microsoft.Health.Dicom.Tests.Common/Microsoft.Health.Dicom.Tests.Common.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="fo-dicom" Version="4.0.5" />
+    <PackageReference Include="fo-dicom" Version="4.0.6" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />


### PR DESCRIPTION
## Description
There was a issue with fo-dicom deserialization. The issue has been fixed with the latest fo-dicom nuget release.  The Nuget version has been updated in this PR. 

## Related issues
Addresses [Bug # 74085](https://microsofthealth.visualstudio.com/Health/_workitems/edit/74085)

## Testing
Unit Test has been added. Manual testing has been done with the dicom file reported in this bug.
