### PR TITLE
Disable DicomValidation by default on client

### DIFF
--- a/src/Microsoft.Health.Dicom.Client/DicomWebClient.cs
+++ b/src/Microsoft.Health.Dicom.Client/DicomWebClient.cs
@@ -37,17 +37,21 @@ namespace Microsoft.Health.Dicom.Client
         private const string TransferSyntaxHeaderName = "transfer-syntax";
         private readonly JsonSerializerSettings _jsonSerializerSettings;
 
+        static DicomWebClient()
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+
+            // Disable global DicomValidation to solve bug https://microsofthealth.visualstudio.com/Health/_workitems/edit/75104 until fodicom issue https://github.com/fo-dicom/fo-dicom/issues/974 is solved
+            DicomValidation.AutoValidation = false;
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
         public DicomWebClient(HttpClient httpClient)
         {
             HttpClient = httpClient;
             _jsonSerializerSettings = new JsonSerializerSettings();
             _jsonSerializerSettings.Converters.Add(new JsonDicomConverter(writeTagsAsKeywords: true));
             GetMemoryStream = () => new MemoryStream();
-#pragma warning disable CS0618 // Type or member is obsolete
-
-            // Disable global DicomValidation to solve bug https://microsofthealth.visualstudio.com/Health/_workitems/edit/75104 until fodicom issue https://github.com/fo-dicom/fo-dicom/issues/974 is solved
-            DicomValidation.AutoValidation = false;
-#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         public HttpClient HttpClient { get; }


### PR DESCRIPTION

## Description
Disable fo-dicom validation on dicom client 

### Open Question
- Should we do partial validation on client side like [PR](https://github.com/microsoft/dicom-server/pull/183)?
personal idea is not, reason is:
1. Bring the validation from [PR](https://github.com/microsoft/dicom-server/pull/183) make client code complicated
2. If we already validate when store dicom file, this validation should be redundant. 

### Notes
- RetrieveMetadataAsync, QueryAsync should have similar problems, this should also fix that.

## Related issues
Addresses[ \[Disable fo-dicom validation on dicom client\]](https://microsofthealth.visualstudio.com/Health/_workitems/edit/75104).

## Testing
TODO: need to add tests
