### PR TITLE
Remove rendered frame and instance client api which we do not support yet

### DIFF
--- a/src/Microsoft.Health.Dicom.Client/DicomWebClient.cs
+++ b/src/Microsoft.Health.Dicom.Client/DicomWebClient.cs
@@ -62,26 +62,6 @@ namespace Microsoft.Health.Dicom.Client
         /// </summary>
         public Func<MemoryStream> GetMemoryStream { get; set; }
 
-        public async Task<DicomWebResponse<IReadOnlyList<Stream>>> RetrieveFramesRenderedAsync(
-            Uri requestUri,
-            string format = null,
-            CancellationToken cancellationToken = default)
-        {
-            using (var request = new HttpRequestMessage(HttpMethod.Get, requestUri))
-            {
-                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(format));
-
-                using (HttpResponseMessage response = await HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken))
-                {
-                    await EnsureSuccessStatusCodeAsync(response);
-
-                    return new DicomWebResponse<IReadOnlyList<Stream>>(
-                        response,
-                        (await ReadMultipartResponseAsStreamsAsync(response.Content, cancellationToken)).ToList());
-                }
-            }
-        }
-
         public async Task<DicomWebResponse<IReadOnlyList<Stream>>> RetrieveFramesAsync(
             Uri requestUri,
             string dicomTransferSyntax,
@@ -92,26 +72,6 @@ namespace Microsoft.Health.Dicom.Client
                 request.Headers.TryAddWithoutValidation(
                     "Accept",
                     CreateAcceptHeader(CreateMultipartMediaTypeHeader(ApplicationOctetStreamContentType), dicomTransferSyntax));
-
-                using (HttpResponseMessage response = await HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken))
-                {
-                    await EnsureSuccessStatusCodeAsync(response);
-
-                    return new DicomWebResponse<IReadOnlyList<Stream>>(
-                        response,
-                        (await ReadMultipartResponseAsStreamsAsync(response.Content, cancellationToken)).ToList());
-                }
-            }
-        }
-
-        public async Task<DicomWebResponse<IReadOnlyList<Stream>>> RetrieveInstancesRenderedAsync(
-            Uri requestUri,
-            string format = null,
-            CancellationToken cancellationToken = default)
-        {
-            using (var request = new HttpRequestMessage(HttpMethod.Get, requestUri))
-            {
-                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(format));
 
                 using (HttpResponseMessage response = await HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken))
                 {

--- a/src/Microsoft.Health.Dicom.Client/DicomWebClientExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Client/DicomWebClientExtensions.cs
@@ -92,25 +92,6 @@ namespace Microsoft.Health.Dicom.Client
                 cancellationToken);
         }
 
-        public static Task<DicomWebResponse<IReadOnlyList<Stream>>> RetrieveInstanceRenderedAsync(
-            this IDicomWebClient dicomWebClient,
-            string studyInstanceUid,
-            string seriesInstanceUid,
-            string sopInstanceUId,
-            string format = null,
-            bool thumbnail = false,
-            CancellationToken cancellationToken = default)
-        {
-            EnsureArg.IsNotNull(dicomWebClient, nameof(dicomWebClient));
-
-            string urlFormat = thumbnail ? DicomWebConstants.BaseRetrieveInstanceThumbnailUriFormat : DicomWebConstants.BaseRetrieveInstanceRenderedUriFormat;
-
-            return dicomWebClient.RetrieveInstancesRenderedAsync(
-                new Uri(string.Format(urlFormat, studyInstanceUid, seriesInstanceUid, sopInstanceUId), UriKind.Relative),
-                format,
-                cancellationToken);
-        }
-
         public static Task<DicomWebResponse<IReadOnlyList<DicomDataset>>> RetrieveInstanceMetadataAsync(
             this IDicomWebClient dicomWebClient,
             string studyInstanceUid,
@@ -125,25 +106,6 @@ namespace Microsoft.Health.Dicom.Client
                 new Uri(string.Format(DicomWebConstants.BaseRetrieveInstanceMetadataUriFormat, studyInstanceUid, seriesInstanceUid, sopInstanceUid), UriKind.Relative),
                 ifNoneMatch,
                 cancellationToken);
-        }
-
-        public static Task<DicomWebResponse<IReadOnlyList<Stream>>> RetrieveFramesRenderedAsync(
-            this IDicomWebClient dicomWebClient,
-            string studyInstanceUid,
-            string seriesInstanceUid,
-            string sopInstanceUid,
-            string format = null,
-            bool thumbnail = false,
-            int[] frames = null,
-            CancellationToken cancellationToken = default)
-        {
-            EnsureArg.IsNotNull(dicomWebClient, nameof(dicomWebClient));
-
-            var uriString = thumbnail ? DicomWebConstants.BaseRetrieveFramesThumbnailUriFormat : DicomWebConstants.BaseRetrieveFramesRenderedUriFormat;
-
-            var requestUri = new Uri(string.Format(uriString, studyInstanceUid, seriesInstanceUid, sopInstanceUid, string.Join(",", frames)), UriKind.Relative);
-
-            return dicomWebClient.RetrieveFramesRenderedAsync(requestUri, format, cancellationToken);
         }
 
         public static Task<DicomWebResponse<IReadOnlyList<Stream>>> RetrieveFramesAsync(

--- a/src/Microsoft.Health.Dicom.Client/IDicomWebClient.cs
+++ b/src/Microsoft.Health.Dicom.Client/IDicomWebClient.cs
@@ -32,11 +32,7 @@ namespace Microsoft.Health.Dicom.Client
 
         Task<DicomWebResponse<IReadOnlyList<Stream>>> RetrieveFramesAsync(Uri requestUri, string dicomTransferSyntax = DicomWebConstants.OriginalDicomTransferSyntax, CancellationToken cancellationToken = default);
 
-        Task<DicomWebResponse<IReadOnlyList<Stream>>> RetrieveFramesRenderedAsync(Uri requestUri, string format = null, CancellationToken cancellationToken = default);
-
         Task<DicomWebResponse<IReadOnlyList<DicomFile>>> RetrieveInstancesAsync(Uri requestUri, bool singleInstance = false, string dicomTransferSyntax = DicomWebConstants.OriginalDicomTransferSyntax, CancellationToken cancellationToken = default);
-
-        Task<DicomWebResponse<IReadOnlyList<Stream>>> RetrieveInstancesRenderedAsync(Uri requestUri, string format = null, CancellationToken cancellationToken = default);
 
         Task<DicomWebResponse<IReadOnlyList<DicomDataset>>> RetrieveMetadataAsync(Uri requestUri, string ifNoneMatch = null, CancellationToken cancellationToken = default);
 


### PR DESCRIPTION
## Description
Seems to be there since the E2E test times where we had this supported before.

## Related issues

## Testing
Existing tests are passing
