### PR TITLE
Update electron max content default to 2 GB.

### DIFF
--- a/tools/dicom-web-electron/main.js
+++ b/tools/dicom-web-electron/main.js
@@ -41,7 +41,7 @@ async function createWindow() {
     const httpsAgent = new https.Agent({ rejectUnauthorized: false });
 
     // Set the maximum content length size in bytes and megabytes
-    const maxSizeMegabytes = 10;
+    const maxSizeMegabytes = 2048;
     const maxSizeBytes = maxSizeMegabytes * 1024 * 1024;
 
     ipcMain.on("postFile", (event, args) => {


### PR DESCRIPTION
## Description
Updating the electron max content size to 2 GBs. During testing on the previous PR I updated it to 10 MBs and forgot to revert that part of the change.

## Related issues
Addresses [AB#75766](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/75766)

## Testing
Manual testing.
