### PR TITLE
Bugfix: Reporting correct Status Code when auditing exceptions.

### DIFF
--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Exceptions/ExceptionHandlingHelperTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Exceptions/ExceptionHandlingHelperTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Health.Dicom.Api.UnitTests.Features.Exceptions
             yield return new object[] { new UnsupportedMediaTypeException("Media type is not supported."), HttpStatusCode.UnsupportedMediaType };
             yield return new object[] { new ServiceUnavailableException(), HttpStatusCode.ServiceUnavailable };
             yield return new object[] { new ItemNotFoundException(new Exception()), HttpStatusCode.InternalServerError };
-            yield return new object[] { new CustomServerException(), HttpStatusCode.ServiceUnavailable };
+            yield return new object[] { new CustomServerException(), HttpStatusCode.InternalServerError };
         }
 
         [Theory]

--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Exceptions/ExceptionHandlingHelperTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Exceptions/ExceptionHandlingHelperTests.cs
@@ -1,0 +1,61 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using Microsoft.Health.Abstractions.Exceptions;
+using Microsoft.Health.Api.Features.Audit;
+using Microsoft.Health.Dicom.Api.Features.Exceptions;
+using Microsoft.Health.Dicom.Core.Exceptions;
+using Xunit;
+using NotSupportedException = Microsoft.Health.Dicom.Core.Exceptions.NotSupportedException;
+
+namespace Microsoft.Health.Dicom.Api.UnitTests.Features.Exceptions
+{
+    public class ExceptionHandlingHelperTests
+    {
+        public static IEnumerable<object[]> GetExceptionToStatusCodeMapping()
+        {
+            yield return new object[] { new CustomValidationException(), HttpStatusCode.BadRequest };
+            yield return new object[] { new NotSupportedException("Not supported."), HttpStatusCode.BadRequest };
+            yield return new object[] { new AuditHeaderCountExceededException(AuditConstants.MaximumNumberOfCustomHeaders + 1), HttpStatusCode.BadRequest };
+            yield return new object[] { new AuditHeaderTooLargeException("TestHeader", AuditConstants.MaximumLengthOfCustomHeader + 1), HttpStatusCode.BadRequest };
+            yield return new object[] { new ResourceNotFoundException("Resource not found."), HttpStatusCode.NotFound };
+            yield return new object[] { new TranscodingException(), HttpStatusCode.NotAcceptable };
+            yield return new object[] { new DataStoreException("Something went wrong."), HttpStatusCode.ServiceUnavailable };
+            yield return new object[] { new InstanceAlreadyExistsException(), HttpStatusCode.Conflict };
+            yield return new object[] { new UnsupportedMediaTypeException("Media type is not supported."), HttpStatusCode.UnsupportedMediaType };
+            yield return new object[] { new ServiceUnavailableException(), HttpStatusCode.ServiceUnavailable };
+            yield return new object[] { new ItemNotFoundException(new Exception()), HttpStatusCode.InternalServerError };
+            yield return new object[] { new CustomServerException(), HttpStatusCode.ServiceUnavailable };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetExceptionToStatusCodeMapping))]
+        public void GivenAnException_WhenGetStatusCodeIsCalled_ThenCorrectStatusCodeShouldBeReturned(Exception exception, HttpStatusCode expectedStatusCode)
+        {
+            HttpStatusCode actualStatusCode = ExceptionHandlingHelper.GetStatusCode(exception);
+
+            Assert.Equal(expectedStatusCode, actualStatusCode);
+        }
+
+        private class CustomValidationException : ValidationException
+        {
+            public CustomValidationException()
+                : base("Validation exception.")
+            {
+            }
+        }
+
+        private class CustomServerException : DicomServerException
+        {
+            public CustomServerException()
+                : base("Server exception.")
+            {
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Exceptions/ExceptionHandlingMiddlewareTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Exceptions/ExceptionHandlingMiddlewareTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Health.Dicom.Api.UnitTests.Features.Exceptions
             yield return new object[] { new UnsupportedMediaTypeException("Media type is not supported."), HttpStatusCode.UnsupportedMediaType };
             yield return new object[] { new ServiceUnavailableException(), HttpStatusCode.ServiceUnavailable };
             yield return new object[] { new ItemNotFoundException(new Exception()), HttpStatusCode.InternalServerError };
-            yield return new object[] { new CustomServerException(), HttpStatusCode.ServiceUnavailable };
+            yield return new object[] { new CustomServerException(), HttpStatusCode.InternalServerError };
         }
 
         [Theory]

--- a/src/Microsoft.Health.Dicom.Api/Features/Audit/AuditLoggingFilterAttribute.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Audit/AuditLoggingFilterAttribute.cs
@@ -8,6 +8,7 @@ using EnsureThat;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Health.Api.Features.Audit;
 using Microsoft.Health.Core.Features.Security;
+using Microsoft.Health.Dicom.Api.Features.Exceptions;
 
 namespace Microsoft.Health.Dicom.Api.Features.Audit
 {
@@ -27,6 +28,7 @@ namespace Microsoft.Health.Dicom.Api.Features.Audit
 
             if (context.Exception != null)
             {
+                context.HttpContext.Response.StatusCode = (int)ExceptionHandlingHelper.GetStatusCode(context.Exception);
                 AuditHelper.LogExecuted(context.HttpContext, ClaimsExtractor);
             }
 

--- a/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingHelper.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingHelper.cs
@@ -1,0 +1,63 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Net;
+using Microsoft.Health.Abstractions.Exceptions;
+using Microsoft.Health.Api.Features.Audit;
+using Microsoft.Health.Dicom.Core.Exceptions;
+using NotSupportedException = Microsoft.Health.Dicom.Core.Exceptions.NotSupportedException;
+
+namespace Microsoft.Health.Dicom.Api.Features.Exceptions
+{
+    public static class ExceptionHandlingHelper
+    {
+        /// <summary>
+        /// Given the exception, get the appropriate HttpStatusCode.
+        /// </summary>
+        /// <param name="exception">Exception.</param>
+        /// <returns>HttpStatusCode.</returns>
+        public static HttpStatusCode GetStatusCode(Exception exception)
+        {
+            HttpStatusCode statusCode = HttpStatusCode.InternalServerError;
+
+            switch (exception)
+            {
+                case ValidationException _:
+                case NotSupportedException _:
+                case AuditHeaderCountExceededException _:
+                case AuditHeaderTooLargeException _:
+                    statusCode = HttpStatusCode.BadRequest;
+                    break;
+                case ResourceNotFoundException _:
+                    statusCode = HttpStatusCode.NotFound;
+                    break;
+                case NotAcceptableException _:
+                case TranscodingException _:
+                    statusCode = HttpStatusCode.NotAcceptable;
+                    break;
+                case DataStoreException _:
+                    statusCode = HttpStatusCode.ServiceUnavailable;
+                    break;
+                case InstanceAlreadyExistsException _:
+                    statusCode = HttpStatusCode.Conflict;
+                    break;
+                case UnsupportedMediaTypeException _:
+                    statusCode = HttpStatusCode.UnsupportedMediaType;
+                    break;
+                case ServiceUnavailableException _:
+                    statusCode = HttpStatusCode.ServiceUnavailable;
+                    break;
+                case ItemNotFoundException _:
+                case DicomServerException _:
+                    // One of the required resources is missing.
+                    statusCode = HttpStatusCode.InternalServerError;
+                    break;
+            }
+
+            return statusCode;
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
@@ -11,10 +11,6 @@ using EnsureThat;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using Microsoft.Health.Abstractions.Exceptions;
-using Microsoft.Health.Api.Features.Audit;
-using Microsoft.Health.Dicom.Core.Exceptions;
-using NotSupportedException = Microsoft.Health.Dicom.Core.Exceptions.NotSupportedException;
 
 namespace Microsoft.Health.Dicom.Api.Features.Exceptions
 {
@@ -60,45 +56,8 @@ namespace Microsoft.Health.Dicom.Api.Features.Exceptions
 
         private IActionResult MapExceptionToResult(Exception exception)
         {
-            HttpStatusCode statusCode = HttpStatusCode.InternalServerError;
+            HttpStatusCode statusCode = ExceptionHandlingHelper.GetStatusCode(exception);
             string message = exception.Message;
-
-            switch (exception)
-            {
-                case ValidationException _:
-                case NotSupportedException _:
-                case AuditHeaderCountExceededException _:
-                case AuditHeaderTooLargeException _:
-                    statusCode = HttpStatusCode.BadRequest;
-                    break;
-                case ResourceNotFoundException _:
-                    statusCode = HttpStatusCode.NotFound;
-                    break;
-                case NotAcceptableException _:
-                case TranscodingException _:
-                    statusCode = HttpStatusCode.NotAcceptable;
-                    break;
-                case DataStoreException _:
-                    statusCode = HttpStatusCode.ServiceUnavailable;
-                    break;
-                case InstanceAlreadyExistsException _:
-                    statusCode = HttpStatusCode.Conflict;
-                    break;
-                case UnsupportedMediaTypeException _:
-                    statusCode = HttpStatusCode.UnsupportedMediaType;
-                    break;
-                case ServiceUnavailableException _:
-                    statusCode = HttpStatusCode.ServiceUnavailable;
-                    break;
-                case ItemNotFoundException _:
-                    // One of the required resources is missing.
-                    statusCode = HttpStatusCode.InternalServerError;
-                    break;
-                case DicomServerException _:
-                    _logger.LogWarning(exception, "Service exception.");
-                    statusCode = HttpStatusCode.ServiceUnavailable;
-                    break;
-            }
 
             if (statusCode == HttpStatusCode.InternalServerError)
             {


### PR DESCRIPTION
## Description
Fixed status code when auditing exceptions.

**Context:**
Correct status code was not getting logged in cases of exceptions. This was happening because exceptions were logged in `OnActionExecuted` method whereas HttpStatusCode were determined after this call. To get around this problem, `ExceptionHandlingHelper` is created such that it can map exceptions and get us respective status code. This status code is then set as the response status code when logging exceptions.

## Related issues
[AB#75611](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/75611).

## Testing
- Added unit tests to test the newly introduced class.
- All the existing tests are passing.
