### PR TITLE
Add Python, cURL and Postman documentation for single file upload

### DIFF
--- a/docs/resources/Conformance-as-Postman.postman_collection.json
+++ b/docs/resources/Conformance-as-Postman.postman_collection.json
@@ -6,6 +6,189 @@
 	},
 	"item": [
 		{
+			"name": "Store-single-instance",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "855fa304-6be9-49e9-a2cb-4621bcedfd39",
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true,
+					"accept-encoding": true,
+					"connection": true,
+					"content-type": true,
+					"user-agent": true
+				}
+			},
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Accept",
+						"type": "text",
+						"value": "application/dicom+json"
+					},
+					{
+						"key": "Content-Type",
+						"type": "text",
+						"value": "application/dicom"
+					}
+				],
+				"body": {
+					"mode": "file",
+					"file": {
+						"src": "/C:/githealth/dicom-server/docs/dcms/red-triangle.dcm"
+					},
+					"options": {
+						"raw": {
+							"language": "text"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{baseUrl}}/studies",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"studies"
+					]
+				},
+				"description": "For the body of the request, select the red-triangle.dcm file located in the GitHub repo at ../docs/dcms.  Ensure you attach the file as `binary`.\r\n\r\n> NOTE: This is a non-standard API that allows the upload of a single DICOM file without the need to configure the POST for multipart/related. It allows the use of Postman to upload files to the DICOMweb service.\r\n\r\nThe following is required to upload a single DICOM file.\r\n\r\n* Path: ../studies\r\n* Method: POST\r\n* Headers:\r\n   *  `Accept: application/dicom+json`\r\n   *  `Content-Type: application/dicom`\r\n* Body:\r\n    * Contains the DICOM file as a bytes.\r\n\r\n> This API is currently not implemented\r\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Store-single-instance (green-square.dcm)",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "56e8a470-994f-4e29-ae98-c31a6a3b939a",
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true,
+					"accept-encoding": true,
+					"connection": true,
+					"content-type": true,
+					"user-agent": true
+				}
+			},
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Accept",
+						"type": "text",
+						"value": "application/dicom+json"
+					},
+					{
+						"key": "Content-Type",
+						"type": "text",
+						"value": "application/dicom"
+					}
+				],
+				"body": {
+					"mode": "file",
+					"file": {
+						"src": "/C:/githealth/dicom-server/docs/dcms/green-square.dcm"
+					},
+					"options": {
+						"raw": {
+							"language": "text"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{baseUrl}}/studies",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"studies"
+					]
+				},
+				"description": "This upload is simply to ensure the remaining requests succeed. Ideally, red-triangle.dcm, blue-cirle.dcm, and green-square.dcm are all uploaded.\r\n\r\nFor the body of the request, select the green-square.dcm file located in the GitHub repo at ../docs/dcms.  Ensure you attach the file as `binary`.\r\n\r\n> NOTE: This is a non-standard API that allows the upload of a single DICOM file without the need to configure the POST for multipart/related. It allows the use of Postman to upload files to the DICOMweb service.\r\n\r\nThe following is required to upload a single DICOM file.\r\n\r\n* Path: ../studies\r\n* Method: POST\r\n* Headers:\r\n   *  `Accept: application/dicom+json`\r\n   *  `Content-Type: application/dicom`\r\n* Body:\r\n    * Contains the DICOM file as a bytes.\r\n\r\n> This API is currently not implemented\r\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Store-single-instance (blue-circle.dcm)",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "daaf4159-f132-4e6f-8b6a-6608dba620f3",
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true,
+					"accept-encoding": true,
+					"connection": true,
+					"content-type": true,
+					"user-agent": true
+				}
+			},
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Accept",
+						"type": "text",
+						"value": "application/dicom+json"
+					},
+					{
+						"key": "Content-Type",
+						"type": "text",
+						"value": "application/dicom"
+					}
+				],
+				"body": {
+					"mode": "file",
+					"file": {
+						"src": "/C:/githealth/dicom-server/docs/dcms/blue-circle.dcm"
+					},
+					"options": {
+						"raw": {
+							"language": "text"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{baseUrl}}/studies",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"studies"
+					]
+				},
+				"description": "This upload is simply to ensure the remaining requests succeed. Ideally, red-triangle.dcm, blue-cirle.dcm, and green-square.dcm are all uploaded.\r\n\r\nFor the body of the request, select the blue-circle.dcm file located in the GitHub repo at ../docs/dcms.  Ensure you attach the file as `binary`.\r\n\r\n> NOTE: This is a non-standard API that allows the upload of a single DICOM file without the need to configure the POST for multipart/related. It allows the use of Postman to upload files to the DICOMweb service.\r\n\r\nThe following is required to upload a single DICOM file.\r\n\r\n* Path: ../studies\r\n* Method: POST\r\n* Headers:\r\n   *  `Accept: application/dicom+json`\r\n   *  `Content-Type: application/dicom`\r\n* Body:\r\n    * Contains the DICOM file as a bytes.\r\n\r\n> This API is currently not implemented\r\n"
+			},
+			"response": []
+		},
+		{
 			"name": "[will not work - see description] Store-instances-using-multipart/related",
 			"event": [
 				{
@@ -91,67 +274,6 @@
 					]
 				},
 				"description": "This request intends to demonstrate how to upload DICOM files using multipart/related to a designated study. However, it will not work in Postman.\r\n\r\n> NOTE: Postman cannot be used to upload DICOM files in a way that complies with the DICOM standard. This is due to a Postman limitation. Instead, consider using cURL or programatically uploading the file using Python, C# or another full featured language.\r\n\r\n_Details:_\r\n* Path: ../studies/{study}\r\n* Method: POST\r\n* Headers:\r\n    * `Accept: application/dicom+json`\r\n    * `Content-Type: multipart/related; type=\"application/dicom\"`\r\n* Body:\r\n    * `Content-Type: application/dicom` for each file uploaded, separated by a boundary value\r\n\r\n> Some programming languages and tools behave differently. For instance, some require you to define your own boundary. For those, you may need to use a slightly modified Content-Type header. The following have been used successfully.\r\n > * `Content-Type: multipart/related; type=\"application/dicom\"; boundary=ABCD1234`\r\n > * `Content-Type: multipart/related; boundary=ABCD1234`\r\n > * `Content-Type: multipart/related`\r\n\r\nIf using Postman, please consider using Store-single-instance. This is a non-standard API that allows the upload of a single DICOM file without the need to configure the POST for multipart/related."
-			},
-			"response": []
-		},
-		{
-			"name": "[will not work - see description] Store-single-instance",
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"id": "855fa304-6be9-49e9-a2cb-4621bcedfd39",
-						"exec": [
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"protocolProfileBehavior": {
-				"disabledSystemHeaders": {
-					"accept": true,
-					"accept-encoding": true,
-					"connection": true,
-					"content-type": true,
-					"user-agent": true
-				}
-			},
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Accept",
-						"type": "text",
-						"value": "application/dicom+json"
-					},
-					{
-						"key": "Content-Type",
-						"type": "text",
-						"value": "application/dicom"
-					}
-				],
-				"body": {
-					"mode": "file",
-					"file": {
-						"src": "/C:/githealth/dicom-samples/visus.com/case1/case1_008.dcm"
-					},
-					"options": {
-						"raw": {
-							"language": "text"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/studies",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"studies"
-					]
-				},
-				"description": "> NOTE: This is a non-standard API that allows the upload of a single DICOM file without the need to configure the POST for multipart/related. It allows the use of Postman to upload files to the DICOMweb service.\r\n\r\nThe following is required to upload a single DICOM file.\r\n\r\n* Path: ../studies\r\n* Method: POST\r\n* Headers:\r\n   *  `Accept: application/dicom+json`\r\n   *  `Content-Type: application/dicom`\r\n* Body:\r\n    * Contains the DICOM file as a bytes.\r\n\r\n> This API is currently not implemented\r\n"
 			},
 			"response": []
 		},
@@ -736,27 +858,27 @@
 	],
 	"variable": [
 		{
-			"id": "3e481f3c-c4bf-462e-8ba5-8e82e4108126",
+			"id": "195d429b-8341-43de-9694-10c686612653",
 			"key": "baseUrl",
-			"value": "http://{service-name}.azurewebsites.net"
+			"value": "http://sjbdicomtest.azurewebsites.net"
 		},
 		{
-			"id": "139741df-2175-4388-9979-c8cfc6eb96d1",
+			"id": "919e2ffd-e824-46ec-a4b9-282e7cf2c4ff",
 			"key": "study1",
 			"value": "1.2.826.0.1.3680043.8.498.13230779778012324449356534479549187420"
 		},
 		{
-			"id": "5312a524-65b2-404a-8a8a-df529acd09ef",
+			"id": "d923ca04-35f4-46c3-9b24-263333f17e6c",
 			"key": "series1",
 			"value": "1.2.826.0.1.3680043.8.498.45787841905473114233124723359129632652"
 		},
 		{
-			"id": "4da3f371-f7d6-4cac-86bf-ad17c3393aa0",
+			"id": "2031f78b-8259-49e2-b0e9-1fe2e348feda",
 			"key": "instance1",
 			"value": "1.2.826.0.1.3680043.8.498.47359123102728459884412887463296905395"
 		},
 		{
-			"id": "7f3ddf94-7da3-4c3f-9edc-e4b05447f7c7",
+			"id": "99a4561f-ca42-4777-85ce-a2051b10a074",
 			"key": "instance2",
 			"value": "1.2.826.0.1.3680043.8.498.12714725698140337137334606354172323212\n"
 		}

--- a/docs/resources/Conformance-as-Postman.postman_collection.json
+++ b/docs/resources/Conformance-as-Postman.postman_collection.json
@@ -860,7 +860,7 @@
 		{
 			"id": "195d429b-8341-43de-9694-10c686612653",
 			"key": "baseUrl",
-			"value": "http://sjbdicomtest.azurewebsites.net"
+			"value": "http://{service-name}.azurewebsites.net"
 		},
 		{
 			"id": "919e2ffd-e824-46ec-a4b9-282e7cf2c4ff",

--- a/docs/resources/use-dicom-web-standard-apis-with-python.ipynb
+++ b/docs/resources/use-dicom-web-standard-apis-with-python.ipynb
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,20 +82,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'https://{server-name}.azurewebsites.net'"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "dicom_server_name = \"{server-name}\"\n",
     "path_to_dicoms_dir = \"{path to the folder that includes green-square.dcm and other dcm files}\"\n",
@@ -106,7 +95,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dicom_server_name = \"sjbdicomtest\"\n",
+    "path_to_dicoms_dir = \"c:\\\\githealth\\\\dicom-server\\\\docs\\\\dcms\\\\\"\n",
+    "\n",
+    "base_url = f\"https://{dicom_server_name}.azurewebsites.net\"\n",
+    "base_url"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -151,7 +153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,25 +179,26 @@
     "\n",
     "_Details:_\n",
     "\n",
-    "* POST /studies\n"
+    "* Path: ../studies\n",
+    "* Method: POST\n",
+    "* Headers:\n",
+    "    * `Accept: application/dicom+json`\n",
+    "    * `Content-Type: multipart/related; type=\"application/dicom\"`\n",
+    "* Body:\n",
+    "    * `Content-Type: application/dicom` for each file uploaded, separated by a boundary value\n",
+    "\n",
+    "> Some programming languages and tools behave differently. For instance, some require you to define your own boundary. For those, you may need to use a slightly modified Content-Type header. The following have been used successfully.\n",
+    " > * `Content-Type: multipart/related; type=\"application/dicom\"; boundary=ABCD1234`\n",
+    " > * `Content-Type: multipart/related; boundary=ABCD1234`\n",
+    " > * `Content-Type: multipart/related`\n",
+    "\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Response [200]>"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#upload blue-circle.dcm\n",
     "filepath = Path(path_to_dicoms_dir).joinpath('blue-circle.dcm')\n",
@@ -226,26 +229,20 @@
     "By passing an array of files to the fields parameter of `encode_multipart_related`, multiple files can be uploaded in a single POST. This is sometimes used to upload a complete Series or Study. \n",
     "\n",
     "_Details:_\n",
-    "\n",
-    "* POST /studies/{study}\n"
+    "* Path: ../studies/{study}\n",
+    "* Method: POST\n",
+    "* Headers:\n",
+    "    * `Accept: application/dicom+json`\n",
+    "    * `Content-Type: multipart/related; type=\"application/dicom\"`\n",
+    "* Body:\n",
+    "    * `Content-Type: application/dicom` for each file uploaded, separated by a boundary value\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Response [200]>"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "\n",
     "filepath_red = Path(path_to_dicoms_dir).joinpath('red-triangle.dcm')\n",
@@ -276,20 +273,36 @@
    "source": [
     "### Store single instance (non-standard)\n",
     "\n",
-    "This demonstrates how to upload a single DICOM file. This non-standard API endpoint simplifies uploading a single file as a byte array stored in the body of a reque\n",
+    "This demonstrates how to upload a single DICOM file. This non-standard API endpoint simplifies uploading a single file as a byte array stored in the body of a request.\n",
     "\n",
     "_Details:_\n",
-    "\n",
-    "* POST /studies"
+    "* Path: ../studies\n",
+    "* Method: POST\n",
+    "* Headers:\n",
+    "   *  `Accept: application/dicom+json`\n",
+    "   *  `Content-Type: application/dicom`\n",
+    "* Body:\n",
+    "    * Contains a single DICOM file as binary bytes."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# This is currently not implemented"
+    "#upload blue-circle.dcm\n",
+    "filepath = Path(path_to_dicoms_dir).joinpath('blue-circle.dcm')\n",
+    "\n",
+    "# Hack. Need to open up and read through file and load bytes into memory \n",
+    "with open(filepath,'rb') as reader:\n",
+    "    body = reader.read()\n",
+    "\n",
+    "headers = {'Accept':'application/dicom+json', 'Content-Type':'application/dicom'}\n",
+    "\n",
+    "url = f'{base_url}/studies'\n",
+    "response = client.post(url, body, headers=headers, verify=False)\n",
+    "response  # response should be a 409 Conflict if the file was already uploaded abovin the above request"
    ]
   },
   {
@@ -310,28 +323,19 @@
     "This retrieves all instances within a single study.\n",
     "\n",
     "_Details:_\n",
-    "\n",
-    "* GET /studies/{study}\n",
+    "* Path: ../studies/{study}\n",
+    "* Method: GET\n",
+    "* Headers:\n",
+    "   * `Accept: multipart/related; type=\"application/dicom\"; transfer-syntax=*`\n",
     "\n",
     "All three of the dcm files that we uploaded previously are part of the same study so the response should return all 3 instances. Validate that the response has a status code of OK and that all three instances are returned.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Response [200]>"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "url = f'{base_url}/studies/{study_uid}'\n",
     "headers = {'Accept':'multipart/related; type=\"application/dicom\"; transfer-syntax=*'}\n",
@@ -342,7 +346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -358,160 +362,19 @@
     "This request retrieves the metadata for all instances within a single study.\n",
     "\n",
     "_Details:_\n",
-    "\n",
-    "* GET /studies/{study}/metadata\n",
+    "* Path: ../studies/{study}/metadata\n",
+    "* Method: GET\n",
+    "* Headers:\n",
+    "   * `Accept: application/dicom+json`\n",
     "\n",
     "All three of the dcm files that we uploaded previously are part of the same study so the response should return the metadata for all 3 instances. Validate that the response has a status code of OK and that all the metadata is returned."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<Response [200]>\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[{'00080005': {'vr': 'CS', 'Value': ['ISO_IR 192']},\n",
-       "  '00080008': {'vr': 'CS', 'Value': ['DERIVED', 'SECONDARY', 'OTHER']},\n",
-       "  '00080016': {'vr': 'UI', 'Value': ['1.2.840.10008.5.1.4.1.1.7']},\n",
-       "  '00080018': {'vr': 'UI',\n",
-       "   'Value': ['1.2.826.0.1.3680043.8.498.12714725698140337137334606354172323212']},\n",
-       "  '00080020': {'vr': 'DA', 'Value': ['20200922']},\n",
-       "  '00080023': {'vr': 'DA'},\n",
-       "  '0008002A': {'vr': 'DT'},\n",
-       "  '00080030': {'vr': 'TM', 'Value': ['120000']},\n",
-       "  '00080033': {'vr': 'TM'},\n",
-       "  '00080050': {'vr': 'SH'},\n",
-       "  '00080060': {'vr': 'CS', 'Value': ['OT']},\n",
-       "  '00080064': {'vr': 'CS', 'Value': ['SYN']},\n",
-       "  '00080090': {'vr': 'PN', 'Value': [{'Alphabetic': 'Doctor Doc'}]},\n",
-       "  '00100010': {'vr': 'PN', 'Value': [{'Alphabetic': 'Anony Mous'}]},\n",
-       "  '00100020': {'vr': 'LO', 'Value': ['ID1']},\n",
-       "  '00100030': {'vr': 'DA'},\n",
-       "  '00100040': {'vr': 'CS', 'Value': ['F']},\n",
-       "  '00101010': {'vr': 'AS', 'Value': ['024Y']},\n",
-       "  '00185100': {'vr': 'CS'},\n",
-       "  '0020000D': {'vr': 'UI',\n",
-       "   'Value': ['1.2.826.0.1.3680043.8.498.13230779778012324449356534479549187420']},\n",
-       "  '0020000E': {'vr': 'UI',\n",
-       "   'Value': ['1.2.826.0.1.3680043.8.498.45787841905473114233124723359129632652']},\n",
-       "  '00200010': {'vr': 'SH', 'Value': ['1']},\n",
-       "  '00200011': {'vr': 'IS', 'Value': [1]},\n",
-       "  '00200013': {'vr': 'IS', 'Value': [2]},\n",
-       "  '00200020': {'vr': 'CS'},\n",
-       "  '00200060': {'vr': 'CS'},\n",
-       "  '00204000': {'vr': 'LT', 'Value': ['Fake DICOM - Green Square']},\n",
-       "  '00280002': {'vr': 'US', 'Value': [3]},\n",
-       "  '00280004': {'vr': 'CS', 'Value': ['RGB']},\n",
-       "  '00280006': {'vr': 'US', 'Value': [0]},\n",
-       "  '00280010': {'vr': 'US', 'Value': [979]},\n",
-       "  '00280011': {'vr': 'US', 'Value': [985]},\n",
-       "  '00280030': {'vr': 'DS', 'Value': [1, 1]},\n",
-       "  '00280100': {'vr': 'US', 'Value': [8]},\n",
-       "  '00280101': {'vr': 'US', 'Value': [8]},\n",
-       "  '00280102': {'vr': 'US', 'Value': [7]},\n",
-       "  '00280103': {'vr': 'US', 'Value': [0]},\n",
-       "  '00280106': {'vr': 'US', 'Value': [0]},\n",
-       "  '00280107': {'vr': 'US', 'Value': [255]}},\n",
-       " {'00080005': {'vr': 'CS', 'Value': ['ISO_IR 192']},\n",
-       "  '00080008': {'vr': 'CS', 'Value': ['DERIVED', 'SECONDARY', 'OTHER']},\n",
-       "  '00080016': {'vr': 'UI', 'Value': ['1.2.840.10008.5.1.4.1.1.7']},\n",
-       "  '00080018': {'vr': 'UI',\n",
-       "   'Value': ['1.2.826.0.1.3680043.8.498.47359123102728459884412887463296905395']},\n",
-       "  '00080020': {'vr': 'DA', 'Value': ['20200922']},\n",
-       "  '00080023': {'vr': 'DA'},\n",
-       "  '0008002A': {'vr': 'DT'},\n",
-       "  '00080030': {'vr': 'TM', 'Value': ['120000']},\n",
-       "  '00080033': {'vr': 'TM'},\n",
-       "  '00080050': {'vr': 'SH'},\n",
-       "  '00080060': {'vr': 'CS', 'Value': ['OT']},\n",
-       "  '00080064': {'vr': 'CS', 'Value': ['SYN']},\n",
-       "  '00080090': {'vr': 'PN', 'Value': [{'Alphabetic': 'Doctor Doc'}]},\n",
-       "  '00100010': {'vr': 'PN', 'Value': [{'Alphabetic': 'Anony Mous'}]},\n",
-       "  '00100020': {'vr': 'LO', 'Value': ['ID1']},\n",
-       "  '00100030': {'vr': 'DA'},\n",
-       "  '00100040': {'vr': 'CS', 'Value': ['F']},\n",
-       "  '00101010': {'vr': 'AS', 'Value': ['024Y']},\n",
-       "  '00185100': {'vr': 'CS'},\n",
-       "  '0020000D': {'vr': 'UI',\n",
-       "   'Value': ['1.2.826.0.1.3680043.8.498.13230779778012324449356534479549187420']},\n",
-       "  '0020000E': {'vr': 'UI',\n",
-       "   'Value': ['1.2.826.0.1.3680043.8.498.45787841905473114233124723359129632652']},\n",
-       "  '00200010': {'vr': 'SH', 'Value': ['1']},\n",
-       "  '00200011': {'vr': 'IS', 'Value': [1]},\n",
-       "  '00200013': {'vr': 'IS', 'Value': [1]},\n",
-       "  '00200020': {'vr': 'CS'},\n",
-       "  '00200060': {'vr': 'CS'},\n",
-       "  '00204000': {'vr': 'LT', 'Value': ['Fake DICOM - Red Triangle']},\n",
-       "  '00280002': {'vr': 'US', 'Value': [3]},\n",
-       "  '00280004': {'vr': 'CS', 'Value': ['RGB']},\n",
-       "  '00280006': {'vr': 'US', 'Value': [0]},\n",
-       "  '00280010': {'vr': 'US', 'Value': [979]},\n",
-       "  '00280011': {'vr': 'US', 'Value': [985]},\n",
-       "  '00280030': {'vr': 'DS', 'Value': [1, 1]},\n",
-       "  '00280100': {'vr': 'US', 'Value': [8]},\n",
-       "  '00280101': {'vr': 'US', 'Value': [8]},\n",
-       "  '00280102': {'vr': 'US', 'Value': [7]},\n",
-       "  '00280103': {'vr': 'US', 'Value': [0]},\n",
-       "  '00280106': {'vr': 'US', 'Value': [0]},\n",
-       "  '00280107': {'vr': 'US', 'Value': [255]}},\n",
-       " {'00080005': {'vr': 'CS', 'Value': ['ISO_IR 192']},\n",
-       "  '00080008': {'vr': 'CS', 'Value': ['DERIVED', 'SECONDARY', 'OTHER']},\n",
-       "  '00080016': {'vr': 'UI', 'Value': ['1.2.840.10008.5.1.4.1.1.7']},\n",
-       "  '00080018': {'vr': 'UI',\n",
-       "   'Value': ['1.2.826.0.1.3680043.8.498.13273713909719068980354078852867170114']},\n",
-       "  '00080020': {'vr': 'DA', 'Value': ['20200922']},\n",
-       "  '00080023': {'vr': 'DA'},\n",
-       "  '0008002A': {'vr': 'DT'},\n",
-       "  '00080030': {'vr': 'TM', 'Value': ['120000']},\n",
-       "  '00080033': {'vr': 'TM'},\n",
-       "  '00080050': {'vr': 'SH'},\n",
-       "  '00080060': {'vr': 'CS', 'Value': ['OT']},\n",
-       "  '00080064': {'vr': 'CS', 'Value': ['SYN']},\n",
-       "  '00080090': {'vr': 'PN', 'Value': [{'Alphabetic': 'Doctor Doc'}]},\n",
-       "  '00100010': {'vr': 'PN', 'Value': [{'Alphabetic': 'Anony Mous'}]},\n",
-       "  '00100020': {'vr': 'LO', 'Value': ['ID1']},\n",
-       "  '00100030': {'vr': 'DA'},\n",
-       "  '00100040': {'vr': 'CS', 'Value': ['F']},\n",
-       "  '00101010': {'vr': 'AS', 'Value': ['024Y']},\n",
-       "  '00185100': {'vr': 'CS'},\n",
-       "  '0020000D': {'vr': 'UI',\n",
-       "   'Value': ['1.2.826.0.1.3680043.8.498.13230779778012324449356534479549187420']},\n",
-       "  '0020000E': {'vr': 'UI',\n",
-       "   'Value': ['1.2.826.0.1.3680043.8.498.77033797676425927098669402985243398207']},\n",
-       "  '00200010': {'vr': 'SH', 'Value': ['1']},\n",
-       "  '00200011': {'vr': 'IS', 'Value': [2]},\n",
-       "  '00200013': {'vr': 'IS', 'Value': [1]},\n",
-       "  '00200020': {'vr': 'CS'},\n",
-       "  '00200060': {'vr': 'CS'},\n",
-       "  '00204000': {'vr': 'LT', 'Value': ['Fake DICOM - Blue Circle']},\n",
-       "  '00280002': {'vr': 'US', 'Value': [3]},\n",
-       "  '00280004': {'vr': 'CS', 'Value': ['RGB']},\n",
-       "  '00280006': {'vr': 'US', 'Value': [0]},\n",
-       "  '00280010': {'vr': 'US', 'Value': [979]},\n",
-       "  '00280011': {'vr': 'US', 'Value': [985]},\n",
-       "  '00280030': {'vr': 'DS', 'Value': [1, 1]},\n",
-       "  '00280100': {'vr': 'US', 'Value': [8]},\n",
-       "  '00280101': {'vr': 'US', 'Value': [8]},\n",
-       "  '00280102': {'vr': 'US', 'Value': [7]},\n",
-       "  '00280103': {'vr': 'US', 'Value': [0]},\n",
-       "  '00280106': {'vr': 'US', 'Value': [0]},\n",
-       "  '00280107': {'vr': 'US', 'Value': [255]}}]"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "url = f'{base_url}/studies/{study_uid}/metadata'\n",
     "headers = {'Accept':'application/dicom+json'}\n",
@@ -530,8 +393,10 @@
     "This retrieves all instances within a single series.\n",
     "\n",
     "_Details:_\n",
-    "\n",
-    "* GET /studies/{study}/series{series}\n",
+    "* Path: ../studies/{study}/series/{series}\n",
+    "* Method: GET\n",
+    "* Headers:\n",
+    "   * `Accept: multipart/related; type=\"application/dicom\"; transfer-syntax=*`\n",
     "\n",
     "This series has 2 instances (green-square and red-triangle), so the response should return both instances. Validate that the response has a status code of OK and that both instances are returned.\n",
     "\n"
@@ -539,20 +404,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Response [200]>"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "url = f'{base_url}/studies/{study_uid}/series/{series_uid}'\n",
     "headers = {'Accept':'multipart/related; type=\"application/dicom\"; transfer-syntax=*'}\n",
@@ -570,118 +424,19 @@
     "This request retrieves the metadata for all instances within a single series.\n",
     "\n",
     "_Details:_\n",
-    "\n",
-    "* GET /studies/{study}/metadata\n",
+    "* Path: ../studies/{study}/series/{series}/metadata\n",
+    "* Method: GET\n",
+    "* Headers:\n",
+    "   * `Accept: application/dicom+json`\n",
     "\n",
     "This series has 2 instances (green-square and red-triangle), so the response should return metatdata for both instances. Validate that the response has a status code of OK and that both instances metadata are returned.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<Response [200]>\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[{'00080005': {'vr': 'CS', 'Value': ['ISO_IR 192']},\n",
-       "  '00080008': {'vr': 'CS', 'Value': ['DERIVED', 'SECONDARY', 'OTHER']},\n",
-       "  '00080016': {'vr': 'UI', 'Value': ['1.2.840.10008.5.1.4.1.1.7']},\n",
-       "  '00080018': {'vr': 'UI',\n",
-       "   'Value': ['1.2.826.0.1.3680043.8.498.12714725698140337137334606354172323212']},\n",
-       "  '00080020': {'vr': 'DA', 'Value': ['20200922']},\n",
-       "  '00080023': {'vr': 'DA'},\n",
-       "  '0008002A': {'vr': 'DT'},\n",
-       "  '00080030': {'vr': 'TM', 'Value': ['120000']},\n",
-       "  '00080033': {'vr': 'TM'},\n",
-       "  '00080050': {'vr': 'SH'},\n",
-       "  '00080060': {'vr': 'CS', 'Value': ['OT']},\n",
-       "  '00080064': {'vr': 'CS', 'Value': ['SYN']},\n",
-       "  '00080090': {'vr': 'PN', 'Value': [{'Alphabetic': 'Doctor Doc'}]},\n",
-       "  '00100010': {'vr': 'PN', 'Value': [{'Alphabetic': 'Anony Mous'}]},\n",
-       "  '00100020': {'vr': 'LO', 'Value': ['ID1']},\n",
-       "  '00100030': {'vr': 'DA'},\n",
-       "  '00100040': {'vr': 'CS', 'Value': ['F']},\n",
-       "  '00101010': {'vr': 'AS', 'Value': ['024Y']},\n",
-       "  '00185100': {'vr': 'CS'},\n",
-       "  '0020000D': {'vr': 'UI',\n",
-       "   'Value': ['1.2.826.0.1.3680043.8.498.13230779778012324449356534479549187420']},\n",
-       "  '0020000E': {'vr': 'UI',\n",
-       "   'Value': ['1.2.826.0.1.3680043.8.498.45787841905473114233124723359129632652']},\n",
-       "  '00200010': {'vr': 'SH', 'Value': ['1']},\n",
-       "  '00200011': {'vr': 'IS', 'Value': [1]},\n",
-       "  '00200013': {'vr': 'IS', 'Value': [2]},\n",
-       "  '00200020': {'vr': 'CS'},\n",
-       "  '00200060': {'vr': 'CS'},\n",
-       "  '00204000': {'vr': 'LT', 'Value': ['Fake DICOM - Green Square']},\n",
-       "  '00280002': {'vr': 'US', 'Value': [3]},\n",
-       "  '00280004': {'vr': 'CS', 'Value': ['RGB']},\n",
-       "  '00280006': {'vr': 'US', 'Value': [0]},\n",
-       "  '00280010': {'vr': 'US', 'Value': [979]},\n",
-       "  '00280011': {'vr': 'US', 'Value': [985]},\n",
-       "  '00280030': {'vr': 'DS', 'Value': [1, 1]},\n",
-       "  '00280100': {'vr': 'US', 'Value': [8]},\n",
-       "  '00280101': {'vr': 'US', 'Value': [8]},\n",
-       "  '00280102': {'vr': 'US', 'Value': [7]},\n",
-       "  '00280103': {'vr': 'US', 'Value': [0]},\n",
-       "  '00280106': {'vr': 'US', 'Value': [0]},\n",
-       "  '00280107': {'vr': 'US', 'Value': [255]}},\n",
-       " {'00080005': {'vr': 'CS', 'Value': ['ISO_IR 192']},\n",
-       "  '00080008': {'vr': 'CS', 'Value': ['DERIVED', 'SECONDARY', 'OTHER']},\n",
-       "  '00080016': {'vr': 'UI', 'Value': ['1.2.840.10008.5.1.4.1.1.7']},\n",
-       "  '00080018': {'vr': 'UI',\n",
-       "   'Value': ['1.2.826.0.1.3680043.8.498.47359123102728459884412887463296905395']},\n",
-       "  '00080020': {'vr': 'DA', 'Value': ['20200922']},\n",
-       "  '00080023': {'vr': 'DA'},\n",
-       "  '0008002A': {'vr': 'DT'},\n",
-       "  '00080030': {'vr': 'TM', 'Value': ['120000']},\n",
-       "  '00080033': {'vr': 'TM'},\n",
-       "  '00080050': {'vr': 'SH'},\n",
-       "  '00080060': {'vr': 'CS', 'Value': ['OT']},\n",
-       "  '00080064': {'vr': 'CS', 'Value': ['SYN']},\n",
-       "  '00080090': {'vr': 'PN', 'Value': [{'Alphabetic': 'Doctor Doc'}]},\n",
-       "  '00100010': {'vr': 'PN', 'Value': [{'Alphabetic': 'Anony Mous'}]},\n",
-       "  '00100020': {'vr': 'LO', 'Value': ['ID1']},\n",
-       "  '00100030': {'vr': 'DA'},\n",
-       "  '00100040': {'vr': 'CS', 'Value': ['F']},\n",
-       "  '00101010': {'vr': 'AS', 'Value': ['024Y']},\n",
-       "  '00185100': {'vr': 'CS'},\n",
-       "  '0020000D': {'vr': 'UI',\n",
-       "   'Value': ['1.2.826.0.1.3680043.8.498.13230779778012324449356534479549187420']},\n",
-       "  '0020000E': {'vr': 'UI',\n",
-       "   'Value': ['1.2.826.0.1.3680043.8.498.45787841905473114233124723359129632652']},\n",
-       "  '00200010': {'vr': 'SH', 'Value': ['1']},\n",
-       "  '00200011': {'vr': 'IS', 'Value': [1]},\n",
-       "  '00200013': {'vr': 'IS', 'Value': [1]},\n",
-       "  '00200020': {'vr': 'CS'},\n",
-       "  '00200060': {'vr': 'CS'},\n",
-       "  '00204000': {'vr': 'LT', 'Value': ['Fake DICOM - Red Triangle']},\n",
-       "  '00280002': {'vr': 'US', 'Value': [3]},\n",
-       "  '00280004': {'vr': 'CS', 'Value': ['RGB']},\n",
-       "  '00280006': {'vr': 'US', 'Value': [0]},\n",
-       "  '00280010': {'vr': 'US', 'Value': [979]},\n",
-       "  '00280011': {'vr': 'US', 'Value': [985]},\n",
-       "  '00280030': {'vr': 'DS', 'Value': [1, 1]},\n",
-       "  '00280100': {'vr': 'US', 'Value': [8]},\n",
-       "  '00280101': {'vr': 'US', 'Value': [8]},\n",
-       "  '00280102': {'vr': 'US', 'Value': [7]},\n",
-       "  '00280103': {'vr': 'US', 'Value': [0]},\n",
-       "  '00280106': {'vr': 'US', 'Value': [0]},\n",
-       "  '00280107': {'vr': 'US', 'Value': [255]}}]"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "url = f'{base_url}/studies/{study_uid}/series/{series_uid}/metadata'\n",
     "headers = {'Accept':'application/dicom+json'}\n",
@@ -700,28 +455,19 @@
     "This request retrieves a single instance.\n",
     "\n",
     "_Details:_\n",
-    "\n",
-    "* GET /studies/{study}/series{series}/instances/{instance}\n",
+    "* Path: ../studies/{study}/series{series}/instances/{instance}\n",
+    "* Method: GET\n",
+    "* Headers:\n",
+    "   * `Accept: application/dicom; transfer-syntax=*`\n",
     "\n",
     "This should only return the instance red-triangle. Validate that the response has a status code of OK and that the instance is returned."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Response [200]>"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "url = f'{base_url}/studies/{study_uid}/series/{series_uid}/instances/{instance_uid}'\n",
     "headers = {'Accept':'application/dicom; transfer-syntax=*'}\n",
@@ -739,76 +485,19 @@
     "This request retrieves the metadata for a single instances within a single study and series.\n",
     "\n",
     "_Details:_\n",
-    "\n",
-    "* GET /studies/{study}/metadata\n",
+    "* Path: ../studies/{study}/series{series}/instances/{instance}\n",
+    "* Method: GET\n",
+    "* Headers:\n",
+    "   * `Accept: application/dicom; transfer-syntax=*`\n",
     "\n",
     "This should only return the metatdata for the instance red-triangle. Validate that the response has a status code of OK and that the metadata is returned.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<Response [200]>\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[{'00080005': {'vr': 'CS', 'Value': ['ISO_IR 192']},\n",
-       "  '00080008': {'vr': 'CS', 'Value': ['DERIVED', 'SECONDARY', 'OTHER']},\n",
-       "  '00080016': {'vr': 'UI', 'Value': ['1.2.840.10008.5.1.4.1.1.7']},\n",
-       "  '00080018': {'vr': 'UI',\n",
-       "   'Value': ['1.2.826.0.1.3680043.8.498.47359123102728459884412887463296905395']},\n",
-       "  '00080020': {'vr': 'DA', 'Value': ['20200922']},\n",
-       "  '00080023': {'vr': 'DA'},\n",
-       "  '0008002A': {'vr': 'DT'},\n",
-       "  '00080030': {'vr': 'TM', 'Value': ['120000']},\n",
-       "  '00080033': {'vr': 'TM'},\n",
-       "  '00080050': {'vr': 'SH'},\n",
-       "  '00080060': {'vr': 'CS', 'Value': ['OT']},\n",
-       "  '00080064': {'vr': 'CS', 'Value': ['SYN']},\n",
-       "  '00080090': {'vr': 'PN', 'Value': [{'Alphabetic': 'Doctor Doc'}]},\n",
-       "  '00100010': {'vr': 'PN', 'Value': [{'Alphabetic': 'Anony Mous'}]},\n",
-       "  '00100020': {'vr': 'LO', 'Value': ['ID1']},\n",
-       "  '00100030': {'vr': 'DA'},\n",
-       "  '00100040': {'vr': 'CS', 'Value': ['F']},\n",
-       "  '00101010': {'vr': 'AS', 'Value': ['024Y']},\n",
-       "  '00185100': {'vr': 'CS'},\n",
-       "  '0020000D': {'vr': 'UI',\n",
-       "   'Value': ['1.2.826.0.1.3680043.8.498.13230779778012324449356534479549187420']},\n",
-       "  '0020000E': {'vr': 'UI',\n",
-       "   'Value': ['1.2.826.0.1.3680043.8.498.45787841905473114233124723359129632652']},\n",
-       "  '00200010': {'vr': 'SH', 'Value': ['1']},\n",
-       "  '00200011': {'vr': 'IS', 'Value': [1]},\n",
-       "  '00200013': {'vr': 'IS', 'Value': [1]},\n",
-       "  '00200020': {'vr': 'CS'},\n",
-       "  '00200060': {'vr': 'CS'},\n",
-       "  '00204000': {'vr': 'LT', 'Value': ['Fake DICOM - Red Triangle']},\n",
-       "  '00280002': {'vr': 'US', 'Value': [3]},\n",
-       "  '00280004': {'vr': 'CS', 'Value': ['RGB']},\n",
-       "  '00280006': {'vr': 'US', 'Value': [0]},\n",
-       "  '00280010': {'vr': 'US', 'Value': [979]},\n",
-       "  '00280011': {'vr': 'US', 'Value': [985]},\n",
-       "  '00280030': {'vr': 'DS', 'Value': [1, 1]},\n",
-       "  '00280100': {'vr': 'US', 'Value': [8]},\n",
-       "  '00280101': {'vr': 'US', 'Value': [8]},\n",
-       "  '00280102': {'vr': 'US', 'Value': [7]},\n",
-       "  '00280103': {'vr': 'US', 'Value': [0]},\n",
-       "  '00280106': {'vr': 'US', 'Value': [0]},\n",
-       "  '00280107': {'vr': 'US', 'Value': [255]}}]"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "url = f'{base_url}/studies/{study_uid}/series/{series_uid}/instances/{instance_uid}/metadata'\n",
     "headers = {'Accept':'application/dicom+json'}\n",
@@ -827,28 +516,21 @@
     "This request retrieves one or more frames from a single instance.\n",
     "\n",
     "_Details:_\n",
-    "\n",
-    "* GET /studies/{study}/series/{series}/instances/{instance}/frames/{frames}\n",
+    "* Path: ../studies/{study}/series{series}/instances/{instance}/frames/1,2,3\n",
+    "* Method: GET\n",
+    "* Headers:\n",
+    "   * `Accept: multipart/related; type=\"application/octet-stream\"; transfer-syntax=1.2.840.10008.1.2.1` (Default) or\n",
+    "   * `Accept: multipart/related; type=\"application/octet-stream\"; transfer-syntax=*` or\n",
+    "   * `Accept: multipart/related; type=\"application/octet-stream\";`\n",
     "\n",
     "This should return the only frame from the red-triangle. Validate that the response has a status code of OK and that the frame is returned."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Response [200]>"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "url = f'{base_url}/studies/{study_uid}/series/{series_uid}/instances/{instance_uid}/frames/1'\n",
     "headers = {'Accept':'multipart/related; type=\"application/octet-stream\"; transfer-syntax=*'}\n",
@@ -877,28 +559,19 @@
     "This request searches for one or more studies by DICOM attributes.\n",
     "\n",
     "_Details:_\n",
-    "\n",
-    "* GET /studies?StudyInstanceUID={study}\n",
+    "* Path: ../studies?StudyInstanceUID={study}\n",
+    "* Method: GET\n",
+    "* Headers:\n",
+    "   * `Accept: application/dicom+json`\n",
     "\n",
     "Validate that response includes 1 study and that response code is OK."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Response [200]>"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "url = f'{base_url}/studies'\n",
     "headers = {'Accept':'application/dicom+json'}\n",
@@ -917,28 +590,19 @@
     "This request searches for one or more series by DICOM attributes.\n",
     "\n",
     "_Details:_\n",
-    "\n",
-    "* GET /series?SeriesInstanceUID={series}\n",
+    "* Path: ../series?SeriesInstanceUID={series}\n",
+    "* Method: GET\n",
+    "* Headers:\n",
+    "   * `Accept: application/dicom+json`\n",
     "\n",
     "Validate that response includes 1 series and that response code is OK."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Response [200]>"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "url = f'{base_url}/series'\n",
     "headers = {'Accept':'application/dicom+json'}\n",
@@ -957,28 +621,19 @@
     "This request searches for one or more series within a single study by DICOM attributes.\n",
     "\n",
     "_Details:_\n",
-    "\n",
-    "* GET /studies/{study}/series?SeriesInstanceUID={series}\n",
+    "* Path: ../studies/{study}/series?SeriesInstanceUID={series}\n",
+    "* Method: GET\n",
+    "* Headers:\n",
+    "   * `Accept: application/dicom+json`\n",
     "\n",
     "Validate that response includes 1 series and that response code is OK.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Response [200]>"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "url = f'{base_url}/studies/{study_uid}/series'\n",
     "headers = {'Accept':'application/dicom+json'}\n",
@@ -997,28 +652,19 @@
     "This request searches for one or more instances by DICOM attributes.\n",
     "\n",
     "_Details:_\n",
-    "\n",
-    "* GET /instances?SOPInstanceUID={instance}\n",
+    "* Path: ../instances?SOPInstanceUID={instance}\n",
+    "* Method: GET\n",
+    "* Headers:\n",
+    "   * `Accept: application/dicom+json`\n",
     "\n",
     "Validate that response includes 1 instance and that response code is OK."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Response [200]>"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "url = f'{base_url}/instances'\n",
     "headers = {'Accept':'application/dicom+json'}\n",
@@ -1037,28 +683,19 @@
     "This request searches for one or more instances within a single study by DICOM attributes.\n",
     "\n",
     "_Details:_\n",
-    "\n",
-    "* GET /studies/{study}/instances?SOPInstanceUID={instance}\n",
+    "* Path: ../studies/{study}/instances?SOPInstanceUID={instance}\n",
+    "* Method: GET\n",
+    "* Headers:\n",
+    "   * `Accept: application/dicom+json`\n",
     "\n",
     "Validate that response includes 1 instance and that response code is OK.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Response [200]>"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "url = f'{base_url}/studies/{study_uid}/instances'\n",
     "headers = {'Accept':'application/dicom+json'}\n",
@@ -1077,28 +714,19 @@
     "This request searches for one or more instances within a single study and single series by DICOM attributes.\n",
     "\n",
     "_Details:_\n",
-    "\n",
-    "* GET /studies/{study}/series/{series}instances?SOPInstanceUID={instance}\n",
+    "* Path: ../studies/{study}/series/{series}/instances?SOPInstanceUID={instance}\n",
+    "* Method: GET\n",
+    "* Headers:\n",
+    "   * `Accept: application/dicom+json`\n",
     "\n",
     "Validate that response includes 1 instance and that response code is OK.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Response [200]>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "url = f'{base_url}/studies/{study_uid}/series/{series_uid}/instances'\n",
     "headers = {'Accept':'application/dicom+json'}\n",
@@ -1128,28 +756,18 @@
     "This request deletes a single instance within a single study and single series.\n",
     "\n",
     "_Details:_\n",
-    "\n",
-    "* DELETE /studies/{study}/series/{series}/instances/{instance}\n",
+    "* Path: ../studies/{study}/series/{series}/instances/{instance}\n",
+    "* Method: DELETE\n",
+    "* Headers: No special headers needed\n",
     "\n",
     "This deletes the red-triangle instance from the server. If it is successful the response status code contains no content."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Response [204]>"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#headers = {'Accept':'anything/at+all'}\n",
     "url = f'{base_url}/studies/{study_uid}/series/{series_uid}/instances/{instance_uid}'\n",
@@ -1166,8 +784,9 @@
     "This request deletes a single series (and all child instances) within a single study.\n",
     "\n",
     "_Details:_\n",
-    "\n",
-    "* DELETE /studies/{study}/series/{series}\n",
+    "* Path: ../studies/{study}/series/{series}\n",
+    "* Method: DELETE\n",
+    "* Headers: No special headers needed\n",
     "\n",
     "\n",
     "This deletes the green-square instance (it is the only element left in the series) from the server. If it is successful the response status code contains no content."
@@ -1175,20 +794,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Response [204]>"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#headers = {'Accept':'anything/at+all'}\n",
     "url = f'{base_url}/studies/{study_uid}/series/{series_uid}'\n",
@@ -1205,26 +813,16 @@
     "This request deletes a single study (and all child series and instances).\n",
     "\n",
     "_Details:_\n",
-    "\n",
-    "* DELETE /studies/{study}\n"
+    "* Path: ../studies/{study}\n",
+    "* Method: DELETE\n",
+    "* Headers: No special headers needed\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Response [204]>"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#headers = {'Accept':'anything/at+all'}\n",
     "url = f'{base_url}/studies/{study_uid}'\n",

--- a/docs/tutorials/use-dicom-web-standard-apis-with-curl.md
+++ b/docs/tutorials/use-dicom-web-standard-apis-with-curl.md
@@ -82,10 +82,6 @@ _Details:_
 
 `curl --request POST "http://{service-name}.azurewebsites.net/studies/1.2.826.0.1.3680043.8.498.13230779778012324449356534479549187420" --header "Accept: application/dicom+json" --header "Content-Type: multipart/related; type=\"application/dicom\"" --form "file1=@{path-to-dicoms}/blue-circle.dcm;type=application/dicom"`
 
-Adding green-square.dcm upload to support running all the cURL commands in sequence.
-`curl --request POST "http://{service-name}.azurewebsites.net/studies/1.2.826.0.1.3680043.8.498.13230779778012324449356534479549187420" --header "Accept: application/dicom+json" --header "Content-Type: multipart/related; type=\"application/dicom\"" --form "file1=@{path-to-dicoms}/green-square.dcm;type=application/dicom"`
-
-
 ---
 
 ### Store-single-instance
@@ -101,9 +97,9 @@ _Details:_
    *  `Accept: application/dicom+json`
    *  `Content-Type: application/dicom`
 * Body:
-    * Contains a single DICOM file as bytes.
+    * Contains a single DICOM file as binary bytes.
 
-> NOTE: Not currently implemented! TODO: Implement
+`curl --location --request POST "http://{service-name}.azurewebsites.net/studies" --header "Accept: application/dicom+json" --header "Content-Type: application/dicom" --data-binary "@{path-to-dicoms}/green-square.dcm"`
 
 ---
 ## Retrieving DICOM (WADO)

--- a/docs/tutorials/use-dicom-web-standard-apis-with-python.md
+++ b/docs/tutorials/use-dicom-web-standard-apis-with-python.md
@@ -170,7 +170,7 @@ response = client.post(url, body, headers=headers, verify=False)
 
 ### Store single instance (non-standard)
 
-This demonstrates how to upload a single DICOM file. This non-standard API endpoint simplifies uploading a single file as a byte array stored in the body of a reque
+This demonstrates how to upload a single DICOM file. This non-standard API endpoint simplifies uploading a single file as binary bytes sent in the body of a request
 
 _Details:_
 * Path: ../studies
@@ -179,12 +179,21 @@ _Details:_
    *  `Accept: application/dicom+json`
    *  `Content-Type: application/dicom`
 * Body:
-    * Contains a single DICOM file as bytes.
-
-> NOTE: Not currently implemented! TODO: Implement
+    * Contains a single DICOM file as binary bytes.
 
 ```python
-# This is currently not implemented
+#upload blue-circle.dcm
+filepath = Path(path_to_dicoms_dir).joinpath('blue-circle.dcm')
+
+# Hack. Need to open up and read through file and load bytes into memory 
+with open(filepath,'rb') as reader:
+    body = reader.read()
+
+headers = {'Accept':'application/dicom+json', 'Content-Type':'application/dicom'}
+
+url = f'{base_url}/studies'
+response = client.post(url, body, headers=headers, verify=False)
+response  # response should be a 409 Conflict if the file was already uploaded abovin the above request
 ```
 
 --------------------

--- a/docs/tutorials/use-dicom-web-standard-apis-with-python.md
+++ b/docs/tutorials/use-dicom-web-standard-apis-with-python.md
@@ -193,7 +193,7 @@ headers = {'Accept':'application/dicom+json', 'Content-Type':'application/dicom'
 
 url = f'{base_url}/studies'
 response = client.post(url, body, headers=headers, verify=False)
-response  # response should be a 409 Conflict if the file was already uploaded abovin the above request
+response  # response should be a 409 Conflict if the file was already uploaded in the above request
 ```
 
 --------------------


### PR DESCRIPTION
## Description
Add necessary documentation to Python, cURL and Postman walkthroughs to highlight the newly added (non-DICOMweb standard) API to upload a single file without needing to use multipart/related

## Related issues
Addresses #349 

## Testing
On a new install of the Medical Imaging Server for DICOM, I ran through cURL, Postman and Python end-to-end
