### PR TITLE
Log AcceptHeaders for retrieving resources

### DIFF
--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveResourceServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveResourceServiceTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Retrieve
             _fileStore = Substitute.For<IFileStore>();
             _retrieveTranscoder = Substitute.For<ITranscoder>();
             _dicomFrameHandler = Substitute.For<IFrameHandler>();
-            _retrieveTransferSyntaxHandler = new RetrieveTransferSyntaxHandler();
+            _retrieveTransferSyntaxHandler = new RetrieveTransferSyntaxHandler(NullLogger<RetrieveTransferSyntaxHandler>.Instance);
             _logger = NullLogger<RetrieveResourceService>.Instance;
             _recyclableMemoryStreamManager = new RecyclableMemoryStreamManager();
             _retrieveResourceService = new RetrieveResourceService(

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveTransferSyntaxHandlerTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveTransferSyntaxHandlerTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using Dicom;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Dicom.Core.Exceptions;
 using Microsoft.Health.Dicom.Core.Features.Retrieve;
 using Microsoft.Health.Dicom.Core.Messages;
@@ -20,7 +21,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Retrieve
 
         public RetrieveTransferSyntaxHandlerTests()
         {
-            _handler = new RetrieveTransferSyntaxHandler();
+            _handler = new RetrieveTransferSyntaxHandler(NullLogger<RetrieveTransferSyntaxHandler>.Instance);
         }
 
         [Fact(Skip = "Will be enabled later as https://microsofthealth.visualstudio.com/Health/_workitems/edit/75782")]

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Messages/Retrieve/AcceptHeaderTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Messages/Retrieve/AcceptHeaderTests.cs
@@ -28,5 +28,17 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Messages.Retrieve
             Assert.Equal(transferSytnax, header.TransferSyntax);
             Assert.Equal(quality, header.Quality);
         }
+
+        [Fact]
+        public void GivenValidInput_WhenToString_ThenShouldReturnExpectedContent()
+        {
+            StringSegment mediaType = KnownContentTypes.ApplicationDicom;
+            PayloadTypes payloadType = PayloadTypes.MultipartRelated;
+            StringSegment transferSytnax = DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID;
+            double quality = 0.5;
+            AcceptHeader header = new AcceptHeader(mediaType, payloadType, transferSytnax, quality);
+
+            Assert.Equal($"MediaType:'{mediaType}', PayloadType:'{payloadType}', TransferSyntax:'{transferSytnax}', Quality:'{quality}'", header.ToString());
+        }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveTransferSyntaxHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveTransferSyntaxHandler.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Dicom;
 using EnsureThat;
+using Microsoft.Extensions.Logging;
 using Microsoft.Health.Dicom.Core.Exceptions;
 using Microsoft.Health.Dicom.Core.Messages;
 using Microsoft.Health.Dicom.Core.Messages.Retrieve;
@@ -28,16 +29,27 @@ namespace Microsoft.Health.Dicom.Core.Features.Retrieve
 
         private readonly IReadOnlyDictionary<ResourceType, AcceptHeaderDescriptors> _acceptableDescriptors;
 
-        public RetrieveTransferSyntaxHandler()
-            : this(AcceptableDescriptors)
+        private readonly ILogger<RetrieveTransferSyntaxHandler> _logger;
+
+        public RetrieveTransferSyntaxHandler(ILogger<RetrieveTransferSyntaxHandler> logger)
+            : this(AcceptableDescriptors, logger)
         {
         }
 
-        public RetrieveTransferSyntaxHandler(IReadOnlyDictionary<ResourceType, AcceptHeaderDescriptors> acceptableDescriptors) => _acceptableDescriptors = acceptableDescriptors;
+        public RetrieveTransferSyntaxHandler(IReadOnlyDictionary<ResourceType, AcceptHeaderDescriptors> acceptableDescriptors, ILogger<RetrieveTransferSyntaxHandler> logger)
+        {
+            EnsureArg.IsNotNull(logger, nameof(logger));
+            EnsureArg.IsNotNull(acceptableDescriptors, nameof(acceptableDescriptors));
+
+            _acceptableDescriptors = acceptableDescriptors;
+            _logger = logger;
+        }
 
         public string GetTransferSyntax(ResourceType resourceType, IEnumerable<AcceptHeader> acceptHeaders, out AcceptHeaderDescriptor acceptableHeaderDescriptor)
         {
             EnsureArg.IsNotNull(acceptHeaders, nameof(acceptHeaders));
+
+            _logger.LogInformation($"Getting transfer syntax for retrieving '{resourceType}' with accept headers '{string.Join(";", acceptHeaders)}'.");
 
             // TODO: disable multiple accept headers, will fully implement it later (https://microsofthealth.visualstudio.com/Health/_workitems/edit/75782)
             if (acceptHeaders.Count() > 1)

--- a/src/Microsoft.Health.Dicom.Core/Messages/Retrieve/AcceptHeader.cs
+++ b/src/Microsoft.Health.Dicom.Core/Messages/Retrieve/AcceptHeader.cs
@@ -25,5 +25,10 @@ namespace Microsoft.Health.Dicom.Core.Messages.Retrieve
         public StringSegment TransferSyntax { get; }
 
         public double? Quality { get; }
+
+        public override string ToString()
+        {
+            return $"MediaType:'{MediaType}', PayloadType:'{PayloadType}', TransferSyntax:'{TransferSyntax}', Quality:'{Quality}'";
+        }
     }
 }

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Features/RetrieveResourceServiceTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Features/RetrieveResourceServiceTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Features
             _fileStore = blobStorageFixture.FileStore;
             _retrieveTranscoder = Substitute.For<ITranscoder>();
             _frameHandler = Substitute.For<IFrameHandler>();
-            _retrieveTransferSyntaxHandler = new RetrieveTransferSyntaxHandler();
+            _retrieveTransferSyntaxHandler = new RetrieveTransferSyntaxHandler(NullLogger<RetrieveTransferSyntaxHandler>.Instance);
             _recyclableMemoryStreamManager = blobStorageFixture.RecyclableMemoryStreamManager;
             _retrieveResourceService = new RetrieveResourceService(
                 _instanceStore, _fileStore, _retrieveTranscoder, _frameHandler, _retrieveTransferSyntaxHandler, blobStorageFixture.RecyclableMemoryStreamManager, NullLogger<RetrieveResourceService>.Instance);


### PR DESCRIPTION
## Description
There are a lot of reason retrieving resources could return NotAcceptable, log accept headers for diagnosis convenience.

## Example Log:
Getting transfer syntax for retrieving 'Frames' with accept headers 'MediaType:'application/octet-stream', PayloadType:'MultipartRelated', TransferSyntax:'', Quality:'''.

## Related issues
Addresses https://microsofthealth.visualstudio.com/Health/_workitems/edit/75185
