### PR TITLE
Update python docs to show reading multipart/related responses

### DIFF
--- a/docs/resources/use-dicom-web-standard-apis-with-python.ipynb
+++ b/docs/resources/use-dicom-web-standard-apis-with-python.ipynb
@@ -345,12 +345,32 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Use the retrieved instances\n",
+    "The instances are retrieved as binary bytes. You can loop through the returned items and convert the bytes into a file-like structure which can be read by `pydicom`."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# TODO: show how to pull out instances"
+    "import requests_toolbelt as tb\n",
+    "from io import BytesIO\n",
+    "\n",
+    "mpd = tb.MultipartDecoder.from_response(response)\n",
+    "for part in mpd.parts:\n",
+    "    # Note that the headers are returned as binary!\n",
+    "    print(part.headers[b'content-type'])\n",
+    "    \n",
+    "    # You can convert the binary body (of each part) into a pydicom DataSet\n",
+    "    #   And get direct access to the various underlying fields\n",
+    "    dcm = pydicom.dcmread(BytesIO(part.content))\n",
+    "    print(dcm.PatientName)\n",
+    "    print(dcm.SOPInstanceUID)"
    ]
   },
   {

--- a/docs/tutorials/use-dicom-web-standard-apis-with-python.md
+++ b/docs/tutorials/use-dicom-web-standard-apis-with-python.md
@@ -200,7 +200,8 @@ response  # response should be a 409 Conflict if the file was already uploaded i
 ## Retrieve DICOM Instances (WADO)
 
 The following examples highlight retrieving DICOM instances.
----
+
+------
 
 ### Retrieve all instances within a study
 
@@ -220,6 +221,28 @@ headers = {'Accept':'multipart/related; type="application/dicom"; transfer-synta
 
 response = client.get(url, headers=headers) #, verify=False)
 ```
+
+### Use the retrieved instances
+
+The instances are retrieved as binary bytes. You can loop through the returned items and convert the bytes into a file-like structure which can be read by `pydicom`.
+
+
+```python
+import requests_toolbelt as tb
+from io import BytesIO
+
+mpd = tb.MultipartDecoder.from_response(response)
+for part in mpd.parts:
+    # Note that the headers are returned as binary!
+    print(part.headers[b'content-type'])
+    
+    # You can convert the binary body (of each part) into a pydicom DataSet
+    #   And get direct access to the various underlying fields
+    dcm = pydicom.dcmread(BytesIO(part.content))
+    print(dcm.PatientName)
+    print(dcm.SOPInstanceUID)
+```
+
 
 ### Retrieve metadata of all instances in study
 


### PR DESCRIPTION
## Description
Update python docs to show reading multipart/related responses. That's been difficult for some users. Putting an example in the docs is a good way to solve it.

## Related issues
Addresses [AB#76229](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/76229)

## Testing
Tested by running in Jupyter notebook against latest Medical Imaging Server for DICOM instance.
