### PR TITLE
Support store/retrieve up to 4GB file 

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ using Microsoft.Health.Dicom.Api.Configs;
 using Microsoft.Health.Dicom.Api.Features.Context;
 using Microsoft.Health.Dicom.Api.Features.Formatters;
 using Microsoft.Health.Dicom.Api.Features.Routing;
+using Microsoft.Health.Dicom.Core.Common;
 using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Core.Features.Routing;
 using Microsoft.Health.Dicom.Core.Registration;
@@ -84,6 +85,7 @@ namespace Microsoft.AspNetCore.Builder
             services.AddSingleton(jsonSerializer);
 
             services.TryAddSingleton<RecyclableMemoryStreamManager>();
+            services.TryAddSingleton<FileStreamManager>();
 
             // Disable fo-dicom data item validation. Disabling at global level
             // Opt-in validation instead of opt-out

--- a/src/Microsoft.Health.Dicom.Client/DicomWebClient.cs
+++ b/src/Microsoft.Health.Dicom.Client/DicomWebClient.cs
@@ -17,6 +17,7 @@ using Dicom.Serialization;
 using EnsureThat;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Health.Dicom.Client.Models;
+using Microsoft.Health.Dicom.Core.Common;
 using Microsoft.Net.Http.Headers;
 using Newtonsoft.Json;
 using MediaTypeHeaderValue = Microsoft.Net.Http.Headers.MediaTypeHeaderValue;
@@ -112,10 +113,10 @@ namespace Microsoft.Health.Dicom.Client
 
                     if (singleInstance)
                     {
-                        var memoryStream = GetMemoryStream();
-                        await response.Content.CopyToAsync(memoryStream);
-                        memoryStream.Seek(0, SeekOrigin.Begin);
-                        var dicomFile = await DicomFile.OpenAsync(memoryStream);
+                        var stream = new FileStreamManager().GetStream();
+                        await response.Content.CopyToAsync(stream);
+                        stream.Seek(0, SeekOrigin.Begin);
+                        var dicomFile = await DicomFile.OpenAsync(stream);
                         return new DicomWebResponse<IReadOnlyList<DicomFile>>(response, new DicomFile[] { dicomFile });
                     }
                     else
@@ -418,7 +419,7 @@ namespace Microsoft.Health.Dicom.Client
 
                 while ((part = await multipartReader.ReadNextSectionAsync(cancellationToken)) != null)
                 {
-                    var memoryStream = GetMemoryStream();
+                    var memoryStream = new FileStreamManager().GetStream();
                     await part.Body.CopyToAsync(memoryStream, cancellationToken);
                     memoryStream.Seek(0, SeekOrigin.Begin);
                     result.Add(memoryStream);

--- a/src/Microsoft.Health.Dicom.Client/Microsoft.Health.Dicom.Client.csproj
+++ b/src/Microsoft.Health.Dicom.Client/Microsoft.Health.Dicom.Client.csproj
@@ -3,6 +3,9 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\Microsoft.Health.Dicom.Core\Common\FileStreamManager.cs" Link="FileStreamManager.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Health.Dicom.Core/Common/FileStreamManager.cs
+++ b/src/Microsoft.Health.Dicom.Core/Common/FileStreamManager.cs
@@ -1,0 +1,19 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.IO;
+
+namespace Microsoft.Health.Dicom.Core.Common
+{
+    public class FileStreamManager
+    {
+#pragma warning disable CA1822 // Mark members as static
+        public Stream GetStream()
+#pragma warning restore CA1822 // Mark members as static
+        {
+            return new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.Delete, 1024 * 1024 * 5, FileOptions.DeleteOnClose);
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Web/Program.cs
+++ b/src/Microsoft.Health.Dicom.Web/Program.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
+using System.Collections;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Azure.KeyVault;
@@ -32,7 +34,7 @@ namespace Microsoft.Health.Dicom.Web
 
                     builder.AddDevelopmentAuthEnvironmentIfConfigured(builtConfig, "DicomServer");
                 })
-                .ConfigureKestrel(option => option.Limits.MaxRequestBodySize = int.MaxValue) // When hosted on Kestrel, it's allowed to upload >2GB file, set to 2GB by default
+                .ConfigureKestrel(option => option.Limits.MaxRequestBodySize = uint.MaxValue) // When hosted on Kestrel, it's allowed to upload >2GB file, set to 2GB by default
                 .UseStartup<Startup>()
                 .Build();
 

--- a/src/Microsoft.Health.Dicom.Web/Startup.cs
+++ b/src/Microsoft.Health.Dicom.Web/Startup.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Health.Dicom.Web
             services.Configure<IISServerOptions>(options =>
             {
                 // When hosted on IIS, the max request body size can not over 2GB, according to Asp.net Core bug https://github.com/dotnet/aspnetcore/issues/2711
-                options.MaxRequestBodySize = int.MaxValue;
+                options.MaxRequestBodySize = uint.MaxValue;
             });
             services.AddDevelopmentIdentityProvider(Configuration);
 

--- a/src/Microsoft.Health.Dicom.Web/appsettings.json
+++ b/src/Microsoft.Health.Dicom.Web/appsettings.json
@@ -21,7 +21,7 @@
                 "BatchSize": 10
             },
             "StoreServiceSettings": {
-                "MaxAllowedDicomFileSize": 2147483647
+                "MaxAllowedDicomFileSize": 4294967295
             }
         },
         "Audit": {

--- a/src/Microsoft.Health.Dicom.Web/web.config
+++ b/src/Microsoft.Health.Dicom.Web/web.config
@@ -9,7 +9,7 @@
       <requestFiltering>
         <!-- When the process is hosted in IIS, change the following limit to increase maximum content length allowed. -->
         <!-- Set to 2GB by default. -->
-        <requestLimits maxAllowedContentLength="2147483648" />
+        <requestLimits maxAllowedContentLength="4294967295" />
       </requestFiltering>
     </security>
   </system.webServer>

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/DataStoreTestsFixture.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/DataStoreTestsFixture.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             var jsonSerializer = new JsonSerializer();
             jsonSerializer.Converters.Add(new JsonDicomConverter());
 
-            FileStore = new BlobFileStore(_blobClient, optionsMonitor, RecyclableMemoryStreamManager, Substitute.For<BlobDataStoreConfiguration>());
+            FileStore = new BlobFileStore(_blobClient, optionsMonitor, new Core.Common.FileStreamManager(), Substitute.For<BlobDataStoreConfiguration>(), NullLogger<BlobFileStore>.Instance);
             MetadataStore = new BlobMetadataStore(_blobClient, jsonSerializer, optionsMonitor, RecyclableMemoryStreamManager);
         }
 


### PR DESCRIPTION
## Description
This is private fix for store/retrieve up to 4GB file. (**NOT** intended for production use)

## Summary
* MemoryStream won't be able to support >2GB file, replace with FileStream
* Update client to use FileStream also to support >2GB file

## Note
* This change is not intended for production use

## Related issues
Addresses https://microsofthealth.visualstudio.com/Health/_boards/board/t/Medical%20Imaging/Stories/?workitem=76230

## Testing
* Test locally
* Tested in K8s cluster
