### PR TITLE
ignore .env file for docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -287,3 +287,6 @@ __pycache__/
 
 # IdentityServer workspace
 tempkey.rsa
+
+# docker .env file
+**/.env


### PR DESCRIPTION
## Description
Was using .env files for docker-compose setup, want to ignore them from environment.

## Testing
N/A
