### PR TITLE
Dont fwd azure emulator & sql to host in compose

### DIFF
--- a/build/docker/sql/Dockerfile
+++ b/build/docker/sql/Dockerfile
@@ -21,5 +21,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists
 
+EXPOSE 1433
+
 # Run SQL Server process
 CMD /opt/mssql/bin/sqlservr

--- a/samples/docker/docker-compose.yaml
+++ b/samples/docker/docker-compose.yaml
@@ -21,9 +21,9 @@ services:
     container_name: azurite
     image: mcr.microsoft.com/azure-storage/azurite
     restart: always
-    ports:
-      - "10001:10001"
-      - "10000:10000"
+    # ports:
+    #   - "10001:10001"
+    #   - "10000:10000"
   sql:
     build: 
       context: ./../../
@@ -31,8 +31,8 @@ services:
     environment:
       SA_PASSWORD: ${SAPASSWORD}
       ACCEPT_EULA: "Y"
-    ports:
-      - "1433:1433"
+    # ports:
+    #   - "1433:1433"
     healthcheck:
         test: ["CMD", "/opt/mssql-tools/bin/sqlcmd","-U sa -P ${SAPASSWORD} -Q 'SELECT * FROM INFORMATION_SCHEMA.TABLES'"]
         interval: 10s

--- a/samples/docker/docker-compose.yaml
+++ b/samples/docker/docker-compose.yaml
@@ -21,6 +21,7 @@ services:
     container_name: azurite
     image: mcr.microsoft.com/azure-storage/azurite
     restart: always
+    # # uncomment if you want to azure storage explorer against localhost
     # ports:
     #   - "10001:10001"
     #   - "10000:10000"
@@ -31,6 +32,7 @@ services:
     environment:
       SA_PASSWORD: ${SAPASSWORD}
       ACCEPT_EULA: "Y"
+    # # uncomment if you want to sql management studio against localhost
     # ports:
     #   - "1433:1433"
     healthcheck:


### PR DESCRIPTION
## Description
Do not expose azure emulator and sql ports to host. This will prevent them from colliding if sql server or azure storage emulator is installed in the host already

## Testing
Did the following simultaneously 
* Started azure storage emulator and sql server on machine 
* ran dicom tests
* started docker-compose environment
* uploaded dicom files to docker-compose environment
