### PR TITLE
add link for dcm files in electron readme

### DIFF
--- a/tools/dicom-web-electron/readme.md
+++ b/tools/dicom-web-electron/readme.md
@@ -25,6 +25,8 @@ Once the Electron Tool launches, navigate to Server Settings. Select 'Change' to
 
 To upload files stored locally on your device, click 'Select File(s)'. You can upload multiple DICOM files at once to your server.
 
+You can get sample DICOM files at [../../docs/dcms](../../docs/dcms)
+
 ![Electron tool upload](images/electron-tool-upload.png)
 
 ## Change Feed


### PR DESCRIPTION
## Description
I didn't know where to find sample DICOM files when going through walkthroughs for electron readme. Added a link to address that issue.

## Testing
Clicked comment link in branch and took me to dicom samples folder.
