### PR TITLE
Fix Bug: Dicom Cast error when processing changefeed entry that has been deleted

### DIFF
--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/ChangeFeedProcessor.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/ChangeFeedProcessor.cs
@@ -69,7 +69,10 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker
                 // Process each change feed as a FHIR transaction.
                 foreach (ChangeFeedEntry changeFeedEntry in changeFeedEntries)
                 {
-                    await _fhirTransactionPipeline.ProcessAsync(changeFeedEntry, cancellationToken);
+                    if (!(changeFeedEntry.Action == ChangeFeedAction.Create && changeFeedEntry.State == ChangeFeedState.Deleted))
+                    {
+                        await _fhirTransactionPipeline.ProcessAsync(changeFeedEntry, cancellationToken);
+                    }
                 }
 
                 var newSyncState = new SyncState(maxSequence, Clock.UtcNow);

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/ChangeFeedProcessor.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/ChangeFeedProcessor.cs
@@ -73,6 +73,10 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker
                     {
                         await _fhirTransactionPipeline.ProcessAsync(changeFeedEntry, cancellationToken);
                     }
+                    else
+                    {
+                        _logger.LogInformation($"Skip change feed entry due to deletion before processing creation.");
+                    }
                 }
 
                 var newSyncState = new SyncState(maxSequence, Clock.UtcNow);

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/ChangeFeedProcessor.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/ChangeFeedProcessor.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker
                     }
                     else
                     {
-                        _logger.LogInformation($"Skip change feed entry due to deletion before processing creation.");
+                        _logger.LogInformation($"Skip DICOM event with SequenceId {state.SyncedSequence + 1} due to deletion before processing creation.");
                     }
                 }
 


### PR DESCRIPTION
## Description
Prevent processing of change feed entry if the action is Create but the state is Deleted.

## Related issues
https://microsofthealth.visualstudio.com/Health/_workitems/edit/76453
