### PR TITLE
Dicom-Cast Delete

### DIFF
--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Fhir/FhirTransactionExecutorTests.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Fhir/FhirTransactionExecutorTests.cs
@@ -8,8 +8,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Utility;
-using Microsoft.Extensions.Options;
-using Microsoft.Health.DicomCast.Core.Configurations;
 using Microsoft.Health.DicomCast.Core.Exceptions;
 using Microsoft.Health.DicomCast.Core.Features.Fhir;
 using Microsoft.Health.Fhir.Client;

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/FhirResourceBuilder.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/FhirResourceBuilder.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
 {
     public class FhirResourceBuilder
     {
-        public static ImagingStudy CreateNewImagingStudy(string studyInstanceUid, List<string> seriesInstanceUidList, List<string> sopInstanceUidList, string patientResourceId)
+        public static ImagingStudy CreateNewImagingStudy(string studyInstanceUid, List<string> seriesInstanceUidList, List<string> sopInstanceUidList, string patientResourceId, string source = "defaultSouce")
         {
             // Create a new ImagingStudy
             ImagingStudy study = new ImagingStudy
@@ -20,7 +20,11 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
                 Id = "123",
                 Status = ImagingStudy.ImagingStudyStatus.Available,
                 Subject = new ResourceReference(patientResourceId),
-                Meta = new Meta() { VersionId = "1" },
+                Meta = new Meta()
+                {
+                    VersionId = "1",
+                    Source = source,
+                },
             };
 
             foreach (string seriesInstanceUid in seriesInstanceUidList)

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyUpsertHandlerTests.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyUpsertHandlerTests.cs
@@ -10,7 +10,9 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Hl7.Fhir.Model;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.Dicom.Client.Models;
+using Microsoft.Health.DicomCast.Core.Configurations;
 using Microsoft.Health.DicomCast.Core.Features.Fhir;
 using Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction;
 using NSubstitute;
@@ -21,17 +23,23 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
 {
     public class ImagingStudyUpsertHandlerTests
     {
+        private const string DefaultDicomWebEndpoint = "https://dicom/";
+
         private readonly IFhirService _fhirService;
         private readonly IImagingStudySynchronizer _imagingStudySynchronizer;
         private readonly ImagingStudyUpsertHandler _imagingStudyUpsertHandler;
+        private readonly DicomWebConfiguration _configuration;
 
         private FhirTransactionContext _fhirTransactionContext;
 
         public ImagingStudyUpsertHandlerTests()
         {
+            _configuration = new DicomWebConfiguration() { Endpoint = new System.Uri(DefaultDicomWebEndpoint), };
+            IOptions<DicomWebConfiguration> optionsConfiguration = Options.Create(_configuration);
+
             _fhirService = Substitute.For<IFhirService>();
             _imagingStudySynchronizer = new ImagingStudySynchronizer(new ImagingStudyPropertySynchronizer(), new ImagingStudySeriesPropertySynchronizer(), new ImagingStudyInstancePropertySynchronizer());
-            _imagingStudyUpsertHandler = new ImagingStudyUpsertHandler(_fhirService, _imagingStudySynchronizer);
+            _imagingStudyUpsertHandler = new ImagingStudyUpsertHandler(_fhirService, _imagingStudySynchronizer, optionsConfiguration);
         }
 
         [Fact]

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/FhirTransactionRequestMode.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/FhirTransactionRequestMode.cs
@@ -24,5 +24,10 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
         /// The resource needs to be updated.
         /// </summary>
         Update,
+
+        /// <summary>
+        /// The resource needs to be deleted.
+        /// </summary>
+        Delete,
     }
 }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyDeleteHandler.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyDeleteHandler.cs
@@ -44,13 +44,14 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
 
             Identifier imagingStudyIdentifier = ImagingStudyIdentifierUtility.CreateIdentifier(changeFeedEntry.StudyInstanceUid);
             ImagingStudy imagingStudy = await _fhirService.RetrieveImagingStudyAsync(imagingStudyIdentifier, cancellationToken);
-            string imagingStudySource = imagingStudy.Meta.Source;
 
             // Returns null if imagingStudy does not exists for given studyInstanceUid
             if (imagingStudy == null)
             {
                 return null;
             }
+
+            string imagingStudySource = imagingStudy.Meta.Source;
 
             ImagingStudy.SeriesComponent series = ImagingStudyPipelineHelper.GetSeriesWithinAStudy(changeFeedEntry.SeriesInstanceUid, imagingStudy.Series);
             ImagingStudy.InstanceComponent instance = ImagingStudyPipelineHelper.GetInstanceWithinASeries(changeFeedEntry.SopInstanceUid, series);
@@ -70,7 +71,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
                 imagingStudy.Series.Remove(series);
             }
 
-            if (imagingStudy.Series.Count == 0 && imagingStudy.Meta.Source.Equals(_dicomWebEndpoint, System.StringComparison.Ordinal))
+            if (imagingStudy.Series.Count == 0 && _dicomWebEndpoint.Equals(imagingStudySource, System.StringComparison.Ordinal))
             {
                 return new FhirTransactionRequestEntry(
                     FhirTransactionRequestMode.Delete,

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyPipelineHelper.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyPipelineHelper.cs
@@ -65,6 +65,15 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
             };
         }
 
+        public static Bundle.RequestComponent GenerateDeleteRequest(ImagingStudy imagingStudy)
+        {
+            return new Bundle.RequestComponent()
+            {
+                Method = Bundle.HTTPVerb.DELETE,
+                Url = $"{ResourceType.ImagingStudy.GetLiteral()}/{imagingStudy.Id}",
+            };
+        }
+
         public static string GetModalityInString(DicomDataset dataset)
         {
             return dataset.GetSingleValueOrDefault<string>(DicomTag.Modality, default);


### PR DESCRIPTION
## Description
Delete empty resource from FHIR when ImagingStudy that was created by Dicom-Cast no longer has any instances in it.

## Related issues
https://microsofthealth.visualstudio.com/Health/_workitems/edit/76454

## Testing
Unit tests added and tested locally running local instances of dicom-cast, dicom-server, and fhir.
