### PR TITLE
Fix integration tests timing out on schema initialization

### DIFF
--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlDataStoreTestsFixture.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlDataStoreTestsFixture.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
                     }
                 });
 
-            _schemaInitializer.Start();
+            await _schemaInitializer.InitializeAsync();
         }
 
         public async Task DisposeAsync()


### PR DESCRIPTION
## Description
Async and sync versions are missing resulting in threads deadlocking.
This fix replaces sync Start() with async InitializeAsync()

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.
