### PR TITLE
Bug Fix: Invalid Multipart Request Causes Internal Server Error

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Web/AspNetCoreMultipartReader.cs
+++ b/src/Microsoft.Health.Dicom.Api/Web/AspNetCoreMultipartReader.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Dicom.Core.Configs;
+using Microsoft.Health.Dicom.Core.Exceptions;
 using Microsoft.Health.Dicom.Core.Web;
 using Microsoft.Net.Http.Headers;
 using NotSupportedException = Microsoft.Health.Dicom.Core.Exceptions.NotSupportedException;
@@ -90,7 +91,15 @@ namespace Microsoft.Health.Dicom.Api.Web
         /// <inheritdoc />
         public async Task<MultipartBodyPart> ReadNextBodyPartAsync(CancellationToken cancellationToken)
         {
-            MultipartSection section = await _multipartReader.ReadNextSectionAsync(cancellationToken);
+            MultipartSection section;
+            try
+            {
+                section = await _multipartReader.ReadNextSectionAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidMultipartRequestException(ex.Message);
+            }
 
             if (section == null)
             {

--- a/src/Microsoft.Health.Dicom.Api/Web/AspNetCoreMultipartReader.cs
+++ b/src/Microsoft.Health.Dicom.Api/Web/AspNetCoreMultipartReader.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Health.Dicom.Api.Web
             {
                 section = await _multipartReader.ReadNextSectionAsync(cancellationToken);
             }
-            catch (Exception ex)
+            catch (InvalidDataException ex)
             {
                 throw new InvalidMultipartRequestException(ex.Message);
             }

--- a/src/Microsoft.Health.Dicom.Core/Exceptions/InvalidMultipartRequestException.cs
+++ b/src/Microsoft.Health.Dicom.Core/Exceptions/InvalidMultipartRequestException.cs
@@ -1,0 +1,15 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Dicom.Core.Exceptions
+{
+    public class InvalidMultipartRequestException : BadRequestException
+    {
+        public InvalidMultipartRequestException(string message)
+            : base(message)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Description
Invalid multipart request was throwing an internal server error when missing new line. Updated to throw 400 Bad Request error.

## Related issues
https://microsofthealth.visualstudio.com/Health/_workitems/edit/73702

## Testing
Reproduced original bug and validated 400 Bad request thrown instead of 500 internal server error.
