### PR TITLE
Clean up azure resources when PR is closed

### DIFF
--- a/.github/workflows/cleanup-azure-resources.yml
+++ b/.github/workflows/cleanup-azure-resources.yml
@@ -1,0 +1,37 @@
+on:
+  pull_request:
+    types: [closed]
+
+name: CleanupAzureResources
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login via Az module
+        uses: azure/login@v1.1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          enable-AzPSSession: true
+      
+      - name: Clean Up Azure Resources
+        uses: azure/powershell@v1
+        with:
+          azPSVersion: '3.1.0'
+          inlineScript: | 
+            [string]$PRNumber = "${{github.event.pull_request.number}}"
+            $groups = Get-AzResourceGroup -Name "dcm-pr$PR-*-*"  
+            if ($groups -eq $null -or $groups.Count -eq 0)
+            {
+              Write-Host "No Resource groups related to PR $PRNumber are found."
+            }
+            else
+            {
+              Write-Host "$($groups.Count) Resource groups related to PR $PRNumber are found."
+              foreach($group in $groups)
+              {
+                [string]$name = $group.ResourceGroupName
+                Write-Host -Message "Deleting Resource Group $name"
+                Remove-AzResourceGroup -Name $name -Force
+              }  
+            }

--- a/.github/workflows/cleanup-azure-resources.yml
+++ b/.github/workflows/cleanup-azure-resources.yml
@@ -20,7 +20,7 @@ jobs:
           azPSVersion: '3.1.0'
           inlineScript: | 
             [string]$PRNumber = "${{github.event.pull_request.number}}"
-            $groups = Get-AzResourceGroup -Name "dcm-pr$PR-*-*"  
+            $groups = Get-AzResourceGroup -Name "dcm-pr$PRNumber-*-*"  
             if ($groups -eq $null -or $groups.Count -eq 0)
             {
               Write-Host "No Resource groups related to PR $PRNumber are found."
@@ -31,7 +31,7 @@ jobs:
               foreach($group in $groups)
               {
                 [string]$name = $group.ResourceGroupName
-                Write-Host -Message "Deleting Resource Group $name"
+                Write-Host "Deleting Resource Group $name"
                 Remove-AzResourceGroup -Name $name -Force
               }  
             }


### PR DESCRIPTION
## Description
add a workflow to clean up azure resources when PR is closed

## Related issues
https://microsofthealth.visualstudio.com/Health/_boards/board/t/Medical%20Imaging/Stories/?workitem=76751

## Testing
Verified on private [repository](https://github.com/pengchen0692/TestRepository/blob/penche/somechange/.github/workflows/cleanup_azure_resources.yml):
* When PR is merged to master, the action is triggered and able to query with PR number
* When PR is manually closed, the action is triggered and able to query with PR number
