### PR TITLE
Add accession number when sync to FHIR

### DIFF
--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/FhirTransactionContextBuilder.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/FhirTransactionContextBuilder.cs
@@ -12,24 +12,33 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
 {
     public class FhirTransactionContextBuilder
     {
-        private static DateTime studyDateTime = new DateTime(1974, 7, 10, 7, 10, 24);
-        private static DateTime seriesDateTime = new DateTime(1974, 8, 10, 8, 10, 24);
+        public static readonly DateTime DefaultStudyDateTime = new DateTime(1974, 7, 10, 7, 10, 24);
+        public static readonly DateTime DefaultSeriesDateTime = new DateTime(1974, 8, 10, 8, 10, 24);
+        public const string DefaultSOPClassUID = "4444";
+        public const string DefaultStudyDescription = "Study Description";
+        public const string DefaultSeriesDescription = "Series Description";
+        public const string DefaultModalitiesInStudy = "MODALITY";
+        public const string DefaultModality = "MODALITY";
+        public const string DefaultSeriesNumber = "1";
+        public const string DefaultInstanceNumber = "1";
+        public const string DefaultAccessionNumber = "1";
 
-        public static DicomDataset CreateDicomDataset(string sopClassUid = null, string studyDescription = null, string seriesDescrition = null, string modalityInStudy = null, string modalityInSeries = null, string seriesNumber = null, string instanceNumber = null)
+        public static DicomDataset CreateDicomDataset(string sopClassUid = null, string studyDescription = null, string seriesDescrition = null, string modalityInStudy = null, string modalityInSeries = null, string seriesNumber = null, string instanceNumber = null, string accessionNumber = null)
         {
             var ds = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian)
                 {
-                    { DicomTag.SOPClassUID, sopClassUid ?? "4444" },
-                    { DicomTag.StudyDate, studyDateTime },
-                    { DicomTag.StudyTime, studyDateTime },
-                    { DicomTag.SeriesDate, seriesDateTime },
-                    { DicomTag.SeriesTime, seriesDateTime },
-                    { DicomTag.StudyDescription, studyDescription ?? "Study Description" },
-                    { DicomTag.SeriesDescription, seriesDescrition ?? "Series Description" },
-                    { DicomTag.ModalitiesInStudy, modalityInStudy ?? "MODALITY" },
-                    { DicomTag.Modality, modalityInSeries ?? "MODALITY" },
-                    { DicomTag.SeriesNumber, seriesNumber ?? "1" },
-                    { DicomTag.InstanceNumber, instanceNumber ?? "1" },
+                    { DicomTag.SOPClassUID, sopClassUid ?? DefaultSOPClassUID },
+                    { DicomTag.StudyDate, DefaultStudyDateTime },
+                    { DicomTag.StudyTime, DefaultStudyDateTime },
+                    { DicomTag.SeriesDate, DefaultSeriesDateTime },
+                    { DicomTag.SeriesTime, DefaultSeriesDateTime },
+                    { DicomTag.StudyDescription, studyDescription ?? DefaultStudyDescription },
+                    { DicomTag.SeriesDescription, seriesDescrition ?? DefaultSeriesDescription },
+                    { DicomTag.ModalitiesInStudy, modalityInStudy ?? DefaultModalitiesInStudy },
+                    { DicomTag.Modality, modalityInSeries ?? DefaultModality },
+                    { DicomTag.SeriesNumber, seriesNumber ?? DefaultSeriesNumber },
+                    { DicomTag.InstanceNumber, instanceNumber ?? DefaultInstanceNumber },
+                    { DicomTag.AccessionNumber, accessionNumber ?? DefaultAccessionNumber },
                 };
 
             return ds;

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyDeleteHandlerTests.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyDeleteHandlerTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
             // delete an existing instance within a study
             FhirTransactionRequestEntry entry = await BuildImagingStudyEntryComponent(studyInstanceUid, seriesInstanceUid, sopInstanceUid, patientResourceId);
 
-            ImagingStudy updatedImagingStudy = ValidationUtility.ValidateImagingStudyUpdate(studyInstanceUid, patientResourceId, entry);
+            ImagingStudy updatedImagingStudy = ValidationUtility.ValidateImagingStudyUpdate(studyInstanceUid, patientResourceId, entry, hasAccessionNumber: false);
 
             Assert.Equal(ImagingStudy.ImagingStudyStatus.Available, updatedImagingStudy.Status);
 
@@ -121,7 +121,7 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
             // delete an existing instance within a study
             FhirTransactionRequestEntry entry = await BuildImagingStudyEntryComponent(studyInstanceUid, seriesInstanceUid, sopInstanceUid, patientResourceId);
 
-            ImagingStudy updatedImagingStudy = ValidationUtility.ValidateImagingStudyUpdate(studyInstanceUid, patientResourceId, entry);
+            ImagingStudy updatedImagingStudy = ValidationUtility.ValidateImagingStudyUpdate(studyInstanceUid, patientResourceId, entry, hasAccessionNumber: false);
 
             Assert.Equal(ImagingStudy.ImagingStudyStatus.Available, updatedImagingStudy.Status);
 

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyPipelineHelperTests.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyPipelineHelperTests.cs
@@ -35,5 +35,13 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
 
             Assert.Equal(utcTimeZoneOffset.Offset, fhirTransactionContext.UtcDateTimeOffset);
         }
+
+        [Fact]
+        public void GivenAccessionNumber_WhenGetAccessionNumber_ThenReturnsCorrectIdentifier()
+        {
+            string accessionNumber = "01234";
+            var result = ImagingStudyPipelineHelper.GetAccessionNumber(accessionNumber);
+            ValidationUtility.ValidateAccessionNumber(null, accessionNumber, result);
+        }
     }
 }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyUpsertHandlerTests.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyUpsertHandlerTests.cs
@@ -73,7 +73,8 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
 
             Assert.Collection(
                 imagingStudy.Identifier,
-                identifier => ValidationUtility.ValidateIdentifier("urn:dicom:uid", $"urn:oid:{studyInstanceUid}", identifier));
+                identifier => ValidationUtility.ValidateIdentifier("urn:dicom:uid", $"urn:oid:{studyInstanceUid}", identifier),
+                identifier => ValidationUtility.ValidateAccessionNumber(null, FhirTransactionContextBuilder.DefaultAccessionNumber, identifier));
 
             Assert.Collection(
                 imagingStudy.Series,

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/FhirTransactionConstants.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/FhirTransactionConstants.cs
@@ -15,6 +15,9 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
 
         public const string ModalityInSystem = "DCM";
 
+        public const string AccessionNumberTypeSystem = "http://terminology.hl7.org/CodeSystem/v2-0203";
+        public const string AccessionNumberTypeCode = "ACSN";
+
         // Refer http://dicom.nema.org/medical/dicom/current/output/html/part05.html#PS3.5 for format
         public const string UtcTimezoneOffsetFormat = "&zzxx";
     }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyPipelineHelper.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyPipelineHelper.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.Linq;
 using System.Net.Http.Headers;
 using Dicom;
+using EnsureThat;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Utility;
 using Microsoft.Health.DicomCast.Core.Extensions;
@@ -81,11 +82,13 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
 
         public static string GetAccessionNumberInString(DicomDataset dataset)
         {
+            EnsureArg.IsNotNull(dataset, nameof(dataset));
             return dataset.GetSingleValueOrDefault<string>(DicomTag.AccessionNumber, default);
         }
 
         public static Identifier GetAccessionNumber(string accessionNumber)
         {
+            EnsureArg.IsNotNull(accessionNumber, nameof(accessionNumber));
             Coding coding = new Coding(system: FhirTransactionConstants.AccessionNumberTypeSystem, code: FhirTransactionConstants.AccessionNumberTypeCode);
             CodeableConcept codeableConcept = new CodeableConcept();
             codeableConcept.Coding.Add(coding);

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyPipelineHelper.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyPipelineHelper.cs
@@ -79,6 +79,21 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
             return dataset.GetSingleValueOrDefault<string>(DicomTag.Modality, default);
         }
 
+        public static string GetAccessionNumberInString(DicomDataset dataset)
+        {
+            return dataset.GetSingleValueOrDefault<string>(DicomTag.AccessionNumber, default);
+        }
+
+        public static Identifier GetAccessionNumber(string accessionNumber)
+        {
+            Coding coding = new Coding(system: FhirTransactionConstants.AccessionNumberTypeSystem, code: FhirTransactionConstants.AccessionNumberTypeCode);
+            CodeableConcept codeableConcept = new CodeableConcept();
+            codeableConcept.Coding.Add(coding);
+            Identifier identifier = new Identifier(system: null, value: accessionNumber);
+            identifier.Type = codeableConcept;
+            return identifier;
+        }
+
         public static Coding GetModality(string modalityInString)
         {
             if (modalityInString != null)

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyPropertySynchronizer.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyPropertySynchronizer.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
             AddImagingStudyEndpoint(imagingStudy, context);
             AddModality(imagingStudy, dataset);
             AddNote(imagingStudy, dataset);
+            AddAccessionNumber(imagingStudy, dataset);
         }
 
         private static void AddNote(ImagingStudy imagingStudy, DicomDataset dataset)
@@ -83,6 +84,19 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
                     !existingModalities.Any(existingModality => string.Equals(existingModality.Code, modalityInString, StringComparison.OrdinalIgnoreCase)))
                 {
                     imagingStudy.Modality.Add(modality);
+                }
+            }
+        }
+
+        private void AddAccessionNumber(ImagingStudy imagingStudy, DicomDataset dataset)
+        {
+            string accessionNumber = ImagingStudyPipelineHelper.GetAccessionNumberInString(dataset);
+            if (accessionNumber != null)
+            {
+                Identifier accessionNumberId = ImagingStudyPipelineHelper.GetAccessionNumber(accessionNumber);
+                if (!imagingStudy.Identifier.Any(item => accessionNumberId.IsExactly(item)))
+                {
+                    imagingStudy.Identifier.Add(accessionNumberId);
                 }
             }
         }


### PR DESCRIPTION

## Description
Add Accession Number to Fhir ImagingStudy

## Related issues
Addresses https://microsofthealth.visualstudio.com/Health/_boards/board/t/Medical%20Imaging/Stories/?workitem=76989

## Testing
* Added unit tests, and all unit tests pass
* When study has accession number, it is synced to FHIR
```  
"identifier": 
[
    {
        "system": "urn:dicom:uid",
        "value": "urn:oid:2.25.306734014169222155358388162298278737129"
    },
    {
        "type": 
        {
            "coding": 
            [
                {
                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
                    "code": "ACSN"
                }
            ]
        },
        "value": "0123456"
        }
],
```
    

* When study doesn't has accession number
  
```
"identifier": 
[
    {
        "system": "urn:dicom:uid",
        "value": "urn:oid:1.2.276.0.75.2.1.11.1.1.200709113729721.966169828020.1000004"
    }
],
```