### PR TITLE
Direct reference to Microsoft.AspNetCore.Http

### DIFF
--- a/src/Microsoft.Health.Dicom.Web/Microsoft.Health.Dicom.Web.csproj
+++ b/src/Microsoft.Health.Dicom.Web/Microsoft.Health.Dicom.Web.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="Ensure.That" Version="9.2.0" />
     <PackageReference Include="MediatR" Version="8.1.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.5.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />


### PR DESCRIPTION
## Description
Adds a direct reference to Microsoft.AspNetCore.Http to mitigate CVE-2020-1045.

## Related issues
Addresses [AB#77157](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/77157).

## Testing
Tests continue to run
