### PR TITLE
Log exception when retrive change feed fails

### DIFF
--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/DicomCastWorkerTests.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/DicomCastWorkerTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.DicomCast.Core.Configurations;
@@ -22,6 +23,7 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker
 
         private readonly DicomCastWorkerConfiguration _dicomCastWorkerConfiguration = new DicomCastWorkerConfiguration();
         private readonly IChangeFeedProcessor _changeFeedProcessor = Substitute.For<IChangeFeedProcessor>();
+        private readonly IHostApplicationLifetime _hostApplication = Substitute.For<IHostApplicationLifetime>();
         private readonly DicomCastWorker _dicomCastWorker;
 
         private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
@@ -36,7 +38,8 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker
             _dicomCastWorker = new DicomCastWorker(
                 Options.Create(_dicomCastWorkerConfiguration),
                 _changeFeedProcessor,
-                NullLogger<DicomCastWorker>.Instance);
+                NullLogger<DicomCastWorker>.Instance,
+                _hostApplication);
         }
 
         [Fact]

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/DicomCastWorker.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/DicomCastWorker.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker
                 default,
                 $"{typeof(DicomCastWorker)} is exiting.");
 
-        private static readonly Action<ILogger, Exception> LogUnexpectedExceptionDelegate =
+        private static readonly Action<ILogger, Exception> LogUnhandledExceptionDelegate =
            LoggerMessage.Define(
                LogLevel.Critical,
                default,
@@ -86,7 +86,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker
                 }
                 catch (Exception ex)
                 {
-                    LogUnexpectedExceptionDelegate(_logger, ex);
+                    LogUnhandledExceptionDelegate(_logger, ex);
 
                     // Any exception in ExecuteAsync will not shutdown application, call hostApplicationLifetime.StopApplication() to force shutdown.
                     // Please refer to .net core issue on github for more details: "Exceptions in BackgroundService ExecuteAsync are (sometimes) hidden" https://github.com/dotnet/extensions/issues/2363

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/DicomCastWorker.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/DicomCastWorker.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Threading;
 using EnsureThat;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.DicomCast.Core.Configurations;
@@ -36,22 +37,32 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker
                 default,
                 $"{typeof(DicomCastWorker)} is exiting.");
 
+        private static readonly Action<ILogger, Exception> LogUnexpectedExceptionDelegate =
+           LoggerMessage.Define(
+               LogLevel.Critical,
+               default,
+               "Unhandled exception.");
+
         private readonly DicomCastWorkerConfiguration _dicomCastWorkerConfiguration;
         private readonly IChangeFeedProcessor _changeFeedProcessor;
         private readonly ILogger _logger;
+        private readonly IHostApplicationLifetime _hostApplicationLifetime;
 
         public DicomCastWorker(
             IOptions<DicomCastWorkerConfiguration> dicomCastWorkerConfiguration,
             IChangeFeedProcessor changeFeedProcessor,
-            ILogger<DicomCastWorker> logger)
+            ILogger<DicomCastWorker> logger,
+            IHostApplicationLifetime hostApplicationLifetime)
         {
             EnsureArg.IsNotNull(dicomCastWorkerConfiguration?.Value, nameof(dicomCastWorkerConfiguration));
             EnsureArg.IsNotNull(changeFeedProcessor, nameof(changeFeedProcessor));
             EnsureArg.IsNotNull(logger, nameof(logger));
+            EnsureArg.IsNotNull(hostApplicationLifetime, nameof(hostApplicationLifetime));
 
             _dicomCastWorkerConfiguration = dicomCastWorkerConfiguration.Value;
             _changeFeedProcessor = changeFeedProcessor;
             _logger = logger;
+            _hostApplicationLifetime = hostApplicationLifetime;
         }
 
         /// <inheritdoc/>
@@ -72,6 +83,14 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker
                     // Cancel requested.
                     LogWorkerCancelRequestedDelegate(_logger, null);
                     break;
+                }
+                catch (Exception ex)
+                {
+                    LogUnexpectedExceptionDelegate(_logger, ex);
+
+                    // Any exception in ExecuteAsync will not shutdown application, call hostApplicationLifetime.StopApplication() to force shutdown.
+                    // Please refer to .net core issue on github for more details: "Exceptions in BackgroundService ExecuteAsync are (sometimes) hidden" https://github.com/dotnet/extensions/issues/2363
+                    _hostApplicationLifetime.StopApplication();
                 }
             }
 


### PR DESCRIPTION
Log unhandled exception in DicomCastWorker.ExecuteAsync, and exit application

## Context
When retrieve change feed fails for authentication, we don't log anything. This change logs that exception, and quit application

## Related issues
Addresses https://microsofthealth.visualstudio.com/Health/_workitems/edit/76891

## Note
Any exception in ExecuteAsync should be caught, since it won't be able to raise up to upper level (like Main method).
For more details, please refer to:
* [Exceptions in BackgroundService ExecuteAsync are (sometimes) hidden](https://github.com/dotnet/extensions/issues/2363)
* [Exception thrown from task is swallowed if thrown after 'await']( https://stackoverflow.com/questions/56871146/exception-thrown-from-task-is-swallowed-if-thrown-after-await )


## Testing
Verified locally when not able to retrieve change feed, see the exception in log and application quit.
