### PR TITLE
Add numberOf fields in Imaging Study Resource from dicom-cast

### DIFF
--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/FhirTransactionContextBuilder.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/FhirTransactionContextBuilder.cs
@@ -22,9 +22,9 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
         public const string DefaultSeriesNumber = "1";
         public const string DefaultInstanceNumber = "1";
         public const string DefaultAccessionNumber = "1";
-        public const int DefaultNumberOfStudyRelatedSeries = 0;
-        public const int DefualtNumberOfStudyRelatedInstances = 0;
-        public const int DefaultnumberOfSeriesRelatedInstances = 0;
+        public const int DefaultNumberOfStudyRelatedSeries = 10;
+        public const int DefualtNumberOfStudyRelatedInstances = 9;
+        public const int DefaultnumberOfSeriesRelatedInstances = 8;
 
         public static DicomDataset CreateDicomDataset(string sopClassUid = null, string studyDescription = null, string seriesDescrition = null, string modalityInStudy = null, string modalityInSeries = null, string seriesNumber = null, string instanceNumber = null, string accessionNumber = null, int numberOfStudyRelatedSeries = DefaultNumberOfStudyRelatedSeries, int numberOfStudyRelatedInstances = DefualtNumberOfStudyRelatedInstances, int numberOfSeriesRelatedInstances = DefaultnumberOfSeriesRelatedInstances)
         {

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/FhirTransactionContextBuilder.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/FhirTransactionContextBuilder.cs
@@ -22,8 +22,11 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
         public const string DefaultSeriesNumber = "1";
         public const string DefaultInstanceNumber = "1";
         public const string DefaultAccessionNumber = "1";
+        public const int DefaultNumberOfStudyRelatedSeries = 0;
+        public const int DefualtNumberOfStudyRelatedInstances = 0;
+        public const int DefaultnumberOfSeriesRelatedInstances = 0;
 
-        public static DicomDataset CreateDicomDataset(string sopClassUid = null, string studyDescription = null, string seriesDescrition = null, string modalityInStudy = null, string modalityInSeries = null, string seriesNumber = null, string instanceNumber = null, string accessionNumber = null)
+        public static DicomDataset CreateDicomDataset(string sopClassUid = null, string studyDescription = null, string seriesDescrition = null, string modalityInStudy = null, string modalityInSeries = null, string seriesNumber = null, string instanceNumber = null, string accessionNumber = null, int numberOfStudyRelatedSeries = DefaultNumberOfStudyRelatedSeries, int numberOfStudyRelatedInstances = DefualtNumberOfStudyRelatedInstances, int numberOfSeriesRelatedInstances = DefaultnumberOfSeriesRelatedInstances)
         {
             var ds = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian)
                 {
@@ -39,6 +42,9 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
                     { DicomTag.SeriesNumber, seriesNumber ?? DefaultSeriesNumber },
                     { DicomTag.InstanceNumber, instanceNumber ?? DefaultInstanceNumber },
                     { DicomTag.AccessionNumber, accessionNumber ?? DefaultAccessionNumber },
+                    { DicomTag.NumberOfStudyRelatedSeries, numberOfStudyRelatedSeries },
+                    { DicomTag.NumberOfStudyRelatedInstances, numberOfStudyRelatedInstances },
+                    { DicomTag.NumberOfSeriesRelatedInstances, numberOfSeriesRelatedInstances },
                 };
 
             return ds;

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyPropertySynchronizerTests.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyPropertySynchronizerTests.cs
@@ -145,9 +145,15 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
         public void GivenATransactionContexAndImagingStudyWithNumberOfFields_WhenProcessedForStudy_ThenNumberofFieldsAdded()
         {
             ImagingStudy imagingStudy = FhirResourceBuilder.CreateNewImagingStudy(DefaultStudyInstanceUid, new List<string>() { DefaultSeriesInstanceUid }, new List<string>() { DefaultSopInstanceUid }, DefaultPatientResourceId);
-            FhirTransactionContext context = FhirTransactionContextBuilder.DefaultFhirTransactionContext(FhirTransactionContextBuilder.CreateDicomDataset(numberOfStudyRelatedSeries: NumberOfStudyRelatedSeries, numberOfStudyRelatedInstances: NumberOfStudyRelatedInstances));
-
+            FhirTransactionContext context = FhirTransactionContextBuilder.DefaultFhirTransactionContext(FhirTransactionContextBuilder.CreateDicomDataset());
             _imagingStudyPropertySynchronizer.Synchronize(context, imagingStudy);
+
+            Assert.Equal(FhirTransactionContextBuilder.DefaultNumberOfStudyRelatedSeries, imagingStudy.NumberOfSeries);
+            Assert.Equal(FhirTransactionContextBuilder.DefualtNumberOfStudyRelatedInstances, imagingStudy.NumberOfInstances);
+
+            FhirTransactionContext contextNew = FhirTransactionContextBuilder.DefaultFhirTransactionContext(FhirTransactionContextBuilder.CreateDicomDataset(numberOfStudyRelatedSeries: NumberOfStudyRelatedSeries, numberOfStudyRelatedInstances: NumberOfStudyRelatedInstances));
+
+            _imagingStudyPropertySynchronizer.Synchronize(contextNew, imagingStudy);
 
             Assert.Equal(NumberOfStudyRelatedSeries, imagingStudy.NumberOfSeries);
             Assert.Equal(NumberOfStudyRelatedInstances, imagingStudy.NumberOfInstances);

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyPropertySynchronizerTests.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyPropertySynchronizerTests.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
         private const string DefaultSopInstanceUid = "333";
         private const string DefaultPatientResourceId = "555";
         private const string NewAccessionNumber = "2";
+        private const int NumberOfStudyRelatedSeries = 3;
+        private const int NumberOfStudyRelatedInstances = 2;
         private readonly IImagingStudyPropertySynchronizer _imagingStudyPropertySynchronizer;
 
         public ImagingStudyPropertySynchronizerTests()
@@ -137,6 +139,18 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
                 imagingStudy.Identifier,
                 identifier => ValidationUtility.ValidateIdentifier("urn:dicom:uid", $"urn:oid:{DefaultStudyInstanceUid}", identifier),
                 identifier => ValidationUtility.ValidateAccessionNumber(null, FhirTransactionContextBuilder.DefaultAccessionNumber, identifier));
+        }
+
+        [Fact]
+        public void GivenATransactionContexAndImagingStudyWithNumberOfFields_WhenProcessedForStudy_ThenNumberofFieldsAdded()
+        {
+            ImagingStudy imagingStudy = FhirResourceBuilder.CreateNewImagingStudy(DefaultStudyInstanceUid, new List<string>() { DefaultSeriesInstanceUid }, new List<string>() { DefaultSopInstanceUid }, DefaultPatientResourceId);
+            FhirTransactionContext context = FhirTransactionContextBuilder.DefaultFhirTransactionContext(FhirTransactionContextBuilder.CreateDicomDataset(numberOfStudyRelatedSeries: NumberOfStudyRelatedSeries, numberOfStudyRelatedInstances: NumberOfStudyRelatedInstances));
+
+            _imagingStudyPropertySynchronizer.Synchronize(context, imagingStudy);
+
+            Assert.Equal(NumberOfStudyRelatedSeries, imagingStudy.NumberOfSeries);
+            Assert.Equal(NumberOfStudyRelatedInstances, imagingStudy.NumberOfInstances);
         }
 
         [Fact]

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudySeriesPropertySynchronizerTests.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudySeriesPropertySynchronizerTests.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
         private readonly string seriesInstanceUid = "222";
         private readonly string sopInstanceUid = "333";
         private readonly string patientResourceId = "555";
+        private const int NumberOfSeriesRelatedInstances = 1;
 
         public ImagingStudySeriesPropertySynchronizerTests()
         {
@@ -106,6 +107,18 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
 
             _imagingStudySeriesPropertySynchronizer.Synchronize(newContext, series);
             Assert.Equal(1, series.Number);
+        }
+
+        [Fact]
+        public void GivenATransactionContextWithNumberOfInstancesInSeries_WhenprocessedForSeries_ThenDicomPropertyValuesAreUpdatedAreCorrectly()
+        {
+            ImagingStudy imagingStudy = FhirResourceBuilder.CreateNewImagingStudy(studyInstanceUid, new List<string>() { seriesInstanceUid }, new List<string>() { sopInstanceUid }, patientResourceId);
+            FhirTransactionContext context = FhirTransactionContextBuilder.DefaultFhirTransactionContext(FhirTransactionContextBuilder.CreateDicomDataset(numberOfSeriesRelatedInstances: NumberOfSeriesRelatedInstances));
+            ImagingStudy.SeriesComponent series = imagingStudy.Series.First();
+
+            _imagingStudySeriesPropertySynchronizer.Synchronize(context, series);
+
+            Assert.Equal(NumberOfSeriesRelatedInstances, series.NumberOfInstances);
         }
     }
 }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudySeriesPropertySynchronizerTests.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudySeriesPropertySynchronizerTests.cs
@@ -113,10 +113,14 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
         public void GivenATransactionContextWithNumberOfInstancesInSeries_WhenprocessedForSeries_ThenDicomPropertyValuesAreUpdatedAreCorrectly()
         {
             ImagingStudy imagingStudy = FhirResourceBuilder.CreateNewImagingStudy(studyInstanceUid, new List<string>() { seriesInstanceUid }, new List<string>() { sopInstanceUid }, patientResourceId);
-            FhirTransactionContext context = FhirTransactionContextBuilder.DefaultFhirTransactionContext(FhirTransactionContextBuilder.CreateDicomDataset(numberOfSeriesRelatedInstances: NumberOfSeriesRelatedInstances));
+            FhirTransactionContext context = FhirTransactionContextBuilder.DefaultFhirTransactionContext(FhirTransactionContextBuilder.CreateDicomDataset());
             ImagingStudy.SeriesComponent series = imagingStudy.Series.First();
 
             _imagingStudySeriesPropertySynchronizer.Synchronize(context, series);
+            Assert.Equal(FhirTransactionContextBuilder.DefaultnumberOfSeriesRelatedInstances, series.NumberOfInstances);
+
+            FhirTransactionContext newContext = FhirTransactionContextBuilder.DefaultFhirTransactionContext(FhirTransactionContextBuilder.CreateDicomDataset(numberOfSeriesRelatedInstances: NumberOfSeriesRelatedInstances));
+            _imagingStudySeriesPropertySynchronizer.Synchronize(newContext, series);
 
             Assert.Equal(NumberOfSeriesRelatedInstances, series.NumberOfInstances);
         }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyPropertySynchronizer.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyPropertySynchronizer.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
             AddModality(imagingStudy, dataset);
             AddNote(imagingStudy, dataset);
             AddAccessionNumber(imagingStudy, dataset);
+            AddNumberOfSeries(imagingStudy, dataset);
+            AddNumberOfStudyInstances(imagingStudy, dataset);
         }
 
         private static void AddNote(ImagingStudy imagingStudy, DicomDataset dataset)
@@ -97,6 +99,28 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
                 if (!imagingStudy.Identifier.Any(item => accessionNumberId.IsExactly(item)))
                 {
                     imagingStudy.Identifier.Add(accessionNumberId);
+                }
+            }
+        }
+
+        private void AddNumberOfSeries(ImagingStudy imagingStudy, DicomDataset dataset)
+        {
+            if (dataset.TryGetSingleValue(DicomTag.NumberOfStudyRelatedSeries, out int numberOfSeries))
+            {
+                if (imagingStudy.NumberOfSeries == null)
+                {
+                    imagingStudy.NumberOfSeries = numberOfSeries;
+                }
+            }
+        }
+
+        private void AddNumberOfStudyInstances(ImagingStudy imagingStudy, DicomDataset dataset)
+        {
+            if (dataset.TryGetSingleValue(DicomTag.NumberOfStudyRelatedInstances, out int numberOfInstances))
+            {
+                if (imagingStudy.NumberOfInstances == null)
+                {
+                    imagingStudy.NumberOfInstances = numberOfInstances;
                 }
             }
         }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyPropertySynchronizer.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyPropertySynchronizer.cs
@@ -107,10 +107,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
         {
             if (dataset.TryGetSingleValue(DicomTag.NumberOfStudyRelatedSeries, out int numberOfSeries))
             {
-                if (imagingStudy.NumberOfSeries == null)
-                {
-                    imagingStudy.NumberOfSeries = numberOfSeries;
-                }
+                imagingStudy.NumberOfSeries = numberOfSeries;
             }
         }
 
@@ -118,10 +115,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
         {
             if (dataset.TryGetSingleValue(DicomTag.NumberOfStudyRelatedInstances, out int numberOfInstances))
             {
-                if (imagingStudy.NumberOfInstances == null)
-                {
-                    imagingStudy.NumberOfInstances = numberOfInstances;
-                }
+                imagingStudy.NumberOfInstances = numberOfInstances;
             }
         }
     }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudySeriesPropertySynchronizer.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudySeriesPropertySynchronizer.cs
@@ -38,6 +38,9 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
 
             // Add startedElement to series
             AddStartedElement(series, dataset, context.UtcDateTimeOffset);
+
+            // Add numberOfInstances to series
+            AddNumberOfInstances(series, dataset);
         }
 
         private void AddSeriesNumber(ImagingStudy.SeriesComponent series, DicomDataset dataset)
@@ -70,6 +73,15 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
             if (modalityInString != null && !string.Equals(series.Modality?.Code, modalityInString, StringComparison.Ordinal))
             {
                 series.Modality = ImagingStudyPipelineHelper.GetModality(modalityInString);
+            }
+        }
+
+        // Add numberOfInstances to series
+        private void AddNumberOfInstances(ImagingStudy.SeriesComponent series, DicomDataset dataset)
+        {
+            if (dataset.TryGetSingleValue(DicomTag.NumberOfSeriesRelatedInstances, out int numberofInstances))
+            {
+                series.NumberOfInstances = numberofInstances;
             }
         }
     }

--- a/docs/concepts/dicom-cast.md
+++ b/docs/concepts/dicom-cast.md
@@ -47,11 +47,14 @@ The current implementation of DICOM Cast has the following mappings:
 | ImagingStudy.subject | | | It will be linked to the Patient [above](##Mappings). |
 | ImagingStudy.started | (0008,0020), (0008,0030), (0008,0201) | StudyDate, StudyTime, TimezoneOffsetFromUTC | More detail about how timestamp is constructed [below](###Timestamp). |
 | ImagingStudy.endpoint | | | It will be linked to the Endpoint above. |
+| ImagingStudy.numberOfSeries | (0020,1206) | NumberOfStudyRelatedSeries | Value will be used from the most recently uploaded DICOM instance with the field populated in the study. |
+| ImagingStudy.numberOfInstances | (0020,1208) | NumberOfStudyRelatedInstances | Value will be used from most recently uploaded DICOM instance with the field pouplated in the study.|
 | ImagingStudy.note | (0008,1030) | StudyDescription | |
 | ImagingStudy.series.uid | (0020,000E) | SeriesInstanceUID | |
 | ImagingStudy.series.number | (0020,0011) | SeriesNumber | |
 | ImagingStudy.series.modality | (0008,0060) | Modality | |
 | ImagingStudy.series.description | (0008,103E) | SeriesDescription | |
+| ImagingStudy.series.numberOfInstances | (0020,1209) | NumberOfSeriesRelatedInstances | Value will be used from most recently uploaded DICOM instance with the field populated in the series. |
 | ImagingStudy.series.started | (0008,0021), (0008,0031), (0008,0201) | SeriesDate, SeriesTime, TimezoneOffsetFromUTC | More detail about how timestamp is constructed [below](###Timestamp). |
 | ImagingStudy.series.instance.uid | (0008,0018) | SOPInstanceUID | |
 | ImagingStudy.series.instance.sopClass | (0008,0016) | SOPClassUID | |


### PR DESCRIPTION
## Description
Add the numberOfSeries, numberOfInstances, and series.numberOfInstances fields to imaging study resource created by dicom-cast. Based mapping off of DICOM Tag Mapping in the [fhir standards](http://hl7.org/implement/standards/fhir/imagingstudy-mappings.html).

## Related issues
[AB#76993](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/76993)

## Testing
Test cases were added, also validated manually by updating test files to dicom-server and querying imaging study resources from fhir.
