### PR TITLE
Update Dicom-Cast ARM template

### DIFF
--- a/converter/dicom-cast/samples/templates/default-azuredeploy.json
+++ b/converter/dicom-cast/samples/templates/default-azuredeploy.json
@@ -146,7 +146,7 @@
                                 },
                                 {
                                     "name": "ApplicationInsights__InstrumentationKey",
-                                    "value": "[reference(concat('Microsoft.Insights/components/', variables('appInsightsName'))).InstrumentationKey]"
+                                    "value": "[if(variables('deployAppInsights'), reference(concat('Microsoft.Insights/components/', variables('appInsightsName'))).InstrumentationKey, '')]"
                                 }
                             ]
                         }


### PR DESCRIPTION
## Description 
Update Dicom-Cast ARM template for when not deploying AppInsights. Previously it would fail validation and looking into [documentation](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/conditional-resource-deployment#runtime-functions) it looks like even if the resource is not deployed it still tries to reference it. Added a conditional to ensure only references if it is deployed.

## Related issues
#433 
[AB#77695](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/77695)
## Testing
Ran template to create dicom-cast instances with and without AppInsights.
