### PR TITLE
increase min name length

### DIFF
--- a/samples/templates/dicomcast-quick-deploy.json
+++ b/samples/templates/dicomcast-quick-deploy.json
@@ -4,7 +4,7 @@
     "parameters": {
         "serviceName": {
             "type": "string",
-            "minLength": 3,
+            "minLength": 6,
             "maxLength": 18,
             "metadata": {
                 "description": "Base name of service for DICOM, FHIR and DICOM Cast."


### PR DESCRIPTION
increase min serviceName length=6 so that default-azuredeploy.json does not error out due to too short name (min size = 11) for name+id.

## Description
When the serviceName length <= 5 results in an InvalidTemplate error in default-azuredeploy.json.  Increasing size >= 6 resolves this issue.

## Testing
Manually tested with length 5 and then length 6-8 to verify.
