### PR TITLE
Add secondary audience with opposite trailing slash existence.

### DIFF
--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Security/SecurityModuleTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Security/SecurityModuleTests.cs
@@ -1,0 +1,38 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Dicom.Api.Configs;
+using Microsoft.Health.Dicom.Api.Modules;
+using Microsoft.Health.Dicom.Core.Configs;
+using Xunit;
+
+namespace Microsoft.Health.Dicom.Api.UnitTests.Features.Security
+{
+    public class SecurityModuleTests
+    {
+        [Theory]
+        [InlineData("https://example.com", "https://example.com/")]
+        [InlineData("https://example.com/", "https://example.com")]
+        [InlineData("", "/")]
+        [InlineData("/", "")]
+        public void GivenASecurityConfiguration_WhenGettingTheSecondaryAudience_ThenCorrectAudienceShouldBeReturned(string initialAudience, string expectedAudience)
+        {
+            var dicomServerConfiguration = new DicomServerConfiguration
+            {
+                Security =
+                {
+                    Authentication = new AuthenticationConfiguration
+                    {
+                        Audience = initialAudience,
+                    },
+                },
+            };
+
+            var securityModule = new SecurityModule(dicomServerConfiguration);
+
+            Assert.Equal(expectedAudience, securityModule.GenerateSecondaryAudience());
+        }
+    }
+}


### PR DESCRIPTION
## Description
This PR updates the security module to use a list of audiences instead of just the single value from the configuration. It adds a secondary value that has the opposite existence of the trailing slash.

| Given Audience | Secondary Audience |
| --- | --- |
| https://example.com | https://example.com/ |
| https://example.com/ | https://example.com |

## Related issues
Addresses [AB#78859](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/78859)

## Testing
Manually tested hitting the endpoint with both audiences. Added unit test for generating the secondary audience.
