### PR TITLE
Update to support multiple audiences

### DIFF
--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Security/SecurityModuleTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Security/SecurityModuleTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Health.Dicom.Api.UnitTests.Features.Security
     public class SecurityModuleTests
     {
         [Fact]
-        public void GivenASecurityConfigurationWithAudience_WhenGettingAudiences_ThenCorrectAudienceShouldBeReturned()
+        public void GivenASecurityConfigurationWithAudience_WhenGettingValidAudiences_ThenCorrectAudienceShouldBeReturned()
         {
             var dicomServerConfiguration = new DicomServerConfiguration
             {
@@ -28,11 +28,11 @@ namespace Microsoft.Health.Dicom.Api.UnitTests.Features.Security
 
             var securityModule = new SecurityModule(dicomServerConfiguration);
 
-            Assert.Equal(new[] { "initialAudience" }, securityModule.GetAuthenticationAudiences());
+            Assert.Equal(new[] { "initialAudience" }, securityModule.GetValidAudiences());
         }
 
         [Fact]
-        public void GivenASecurityConfigurationWithAudienceAndAudiences_WhenGettingAudiences_ThenCorrectAudienceShouldBeReturned()
+        public void GivenASecurityConfigurationWithAudienceAndAudiences_WhenGettingValidAudiences_ThenCorrectAudienceShouldBeReturned()
         {
             var dicomServerConfiguration = new DicomServerConfiguration
             {
@@ -48,11 +48,11 @@ namespace Microsoft.Health.Dicom.Api.UnitTests.Features.Security
 
             var securityModule = new SecurityModule(dicomServerConfiguration);
 
-            Assert.Equal(new[] { "audience1", "audience2" }, securityModule.GetAuthenticationAudiences());
+            Assert.Equal(new[] { "audience1", "audience2" }, securityModule.GetValidAudiences());
         }
 
         [Fact]
-        public void GivenASecurityConfigurationWithAudiences_WhenGettingAudiences_ThenCorrectAudienceShouldBeReturned()
+        public void GivenASecurityConfigurationWithAudiences_WhenGettingValidAudiences_ThenCorrectAudienceShouldBeReturned()
         {
             var dicomServerConfiguration = new DicomServerConfiguration
             {
@@ -67,7 +67,23 @@ namespace Microsoft.Health.Dicom.Api.UnitTests.Features.Security
 
             var securityModule = new SecurityModule(dicomServerConfiguration);
 
-            Assert.Equal(new[] { "audience1", "audience2" }, securityModule.GetAuthenticationAudiences());
+            Assert.Equal(new[] { "audience1", "audience2" }, securityModule.GetValidAudiences());
+        }
+
+        [Fact]
+        public void GivenASecurityConfigurationWithNoAudienceSpecified_WhenGettingValidAudiences_ThenNullShouldBeReturned()
+        {
+            var dicomServerConfiguration = new DicomServerConfiguration
+            {
+                Security =
+                {
+                    Authentication = new AuthenticationConfiguration(),
+                },
+            };
+
+            var securityModule = new SecurityModule(dicomServerConfiguration);
+
+            Assert.Null(securityModule.GetValidAudiences());
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Security/SecurityModuleTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Security/SecurityModuleTests.cs
@@ -1,0 +1,38 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Dicom.Api.Configs;
+using Microsoft.Health.Dicom.Api.Modules;
+using Microsoft.Health.Dicom.Core.Configs;
+using Xunit;
+
+namespace Microsoft.Health.Dicom.Api.UnitTests.Features.Security
+{
+    public class SecurityModuleTests
+    {
+        [Theory]
+        [InlineData("https://example.com", "https://example.com/")]
+        [InlineData("https://example.com/", "https://example.com")]
+        [InlineData("", "/")]
+        [InlineData("/", "")]
+        public void GivenASecurityConfiguration_WhenGettingTheSecondaryAudience_ThenCorrectAudienceShouldBeReturned(string initialAudience, string expectedAudience)
+        {
+            var dicomServerConfiguration = new DicomServerConfiguration
+            {
+                Security =
+                {
+                    Authentication = new AuthenticationConfiguration
+                    {
+                        Audience = initialAudience,
+                    },
+                },
+            };
+
+            var securityModule = new SecurityModule(dicomServerConfiguration);
+
+            Assert.Equal(expectedAudience, securityModule.GenerateSecondaryAudience());
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Security/SecurityModuleTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Security/SecurityModuleTests.cs
@@ -12,12 +12,8 @@ namespace Microsoft.Health.Dicom.Api.UnitTests.Features.Security
 {
     public class SecurityModuleTests
     {
-        [Theory]
-        [InlineData("https://example.com", "https://example.com/")]
-        [InlineData("https://example.com/", "https://example.com")]
-        [InlineData("", "/")]
-        [InlineData("/", "")]
-        public void GivenASecurityConfiguration_WhenGettingTheSecondaryAudience_ThenCorrectAudienceShouldBeReturned(string initialAudience, string expectedAudience)
+        [Fact]
+        public void GivenASecurityConfigurationWithAudience_WhenGettingAudiences_ThenCorrectAudienceShouldBeReturned()
         {
             var dicomServerConfiguration = new DicomServerConfiguration
             {
@@ -25,14 +21,53 @@ namespace Microsoft.Health.Dicom.Api.UnitTests.Features.Security
                 {
                     Authentication = new AuthenticationConfiguration
                     {
-                        Audience = initialAudience,
+                        Audience = "initialAudience",
                     },
                 },
             };
 
             var securityModule = new SecurityModule(dicomServerConfiguration);
 
-            Assert.Equal(expectedAudience, securityModule.GenerateSecondaryAudience());
+            Assert.Equal(new[] { "initialAudience" }, securityModule.GetAuthenticationAudiences());
+        }
+
+        [Fact]
+        public void GivenASecurityConfigurationWithAudienceAndAudiences_WhenGettingAudiences_ThenCorrectAudienceShouldBeReturned()
+        {
+            var dicomServerConfiguration = new DicomServerConfiguration
+            {
+                Security =
+                {
+                    Authentication = new AuthenticationConfiguration
+                    {
+                        Audience = "initialAudience",
+                        Audiences = new[] { "audience1", "audience2" },
+                    },
+                },
+            };
+
+            var securityModule = new SecurityModule(dicomServerConfiguration);
+
+            Assert.Equal(new[] { "audience1", "audience2" }, securityModule.GetAuthenticationAudiences());
+        }
+
+        [Fact]
+        public void GivenASecurityConfigurationWithAudiences_WhenGettingAudiences_ThenCorrectAudienceShouldBeReturned()
+        {
+            var dicomServerConfiguration = new DicomServerConfiguration
+            {
+                Security =
+                {
+                    Authentication = new AuthenticationConfiguration
+                    {
+                        Audiences = new[] { "audience1", "audience2" },
+                    },
+                },
+            };
+
+            var securityModule = new SecurityModule(dicomServerConfiguration);
+
+            Assert.Equal(new[] { "audience1", "audience2" }, securityModule.GetAuthenticationAudiences());
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Api/Modules/SecurityModule.cs
+++ b/src/Microsoft.Health.Dicom.Api/Modules/SecurityModule.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using EnsureThat;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
@@ -48,11 +49,7 @@ namespace Microsoft.Health.Dicom.Api.Modules
                     options.Challenge = $"Bearer authorization_uri=\"{_securityConfiguration.Authentication.Authority}\", resource_id=\"{_securityConfiguration.Authentication.Audience}\", realm=\"{_securityConfiguration.Authentication.Audience}\"";
                     options.TokenValidationParameters = new TokenValidationParameters
                     {
-                        ValidAudiences = new[]
-                        {
-                            _securityConfiguration.Authentication.Audience,
-                            GenerateSecondaryAudience(),
-                        },
+                        ValidAudiences = GetAuthenticationAudiences(),
                     };
                 });
 
@@ -74,14 +71,12 @@ namespace Microsoft.Health.Dicom.Api.Modules
             services.AddSingleton<IClaimsExtractor, PrincipalClaimsExtractor>();
         }
 
-        internal string GenerateSecondaryAudience()
+        internal IEnumerable<string> GetAuthenticationAudiences()
         {
-            if (_securityConfiguration.Authentication.Audience.EndsWith('/'))
+            return _securityConfiguration.Authentication.Audiences ?? new[]
             {
-                return _securityConfiguration.Authentication.Audience.TrimEnd('/');
-            }
-
-            return _securityConfiguration.Authentication.Audience + '/';
+                _securityConfiguration.Authentication.Audience,
+            };
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Configs/AuthenticationConfiguration.cs
+++ b/src/Microsoft.Health.Dicom.Core/Configs/AuthenticationConfiguration.cs
@@ -3,11 +3,15 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+
 namespace Microsoft.Health.Dicom.Core.Configs
 {
     public class AuthenticationConfiguration
     {
         public string Audience { get; set; }
+
+        public IEnumerable<string> Audiences { get; set; }
 
         public string Authority { get; set; }
     }


### PR DESCRIPTION
## Description
This PR updates the code to support having multiple audiences for authentication. It adds a secondary property called `Audiences` that takes precedence over the `Audience` property.

## Related issues
Addresses #505, [AB#78859](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/78859)

## Testing
Added unit tests and manually tested options.