### PR TITLE
[Dicom-Cast] Update retry policy wait time

### DIFF
--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/ChangeFeedProcessorTests.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/ChangeFeedProcessorTests.cs
@@ -19,6 +19,7 @@ using Microsoft.Health.DicomCast.Core.Features.Worker;
 using Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction;
 using Microsoft.Health.Test.Utilities;
 using NSubstitute;
+using Polly.Timeout;
 using Xunit;
 
 namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker
@@ -106,7 +107,7 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker
         }
 
         [Fact]
-        public async Task WhenThrowRetryableException_ExceptionNotThrown()
+        public async Task WhenThrowTimeoutRejectedException_ExceptionNotThrown()
         {
             ChangeFeedEntry[] changeFeeds1 = new[]
             {
@@ -116,7 +117,7 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker
             _changeFeedRetrieveService.RetrieveChangeFeedAsync(0, DefaultCancellationToken).Returns(changeFeeds1);
             _changeFeedRetrieveService.RetrieveChangeFeedAsync(1, DefaultCancellationToken).Returns(Array.Empty<ChangeFeedEntry>());
 
-            _fhirTransactionPipeline.When(pipeline => pipeline.ProcessAsync(Arg.Any<ChangeFeedEntry>(), Arg.Any<CancellationToken>())).Do(pipeline => { throw new RetryableException(); });
+            _fhirTransactionPipeline.When(pipeline => pipeline.ProcessAsync(Arg.Any<ChangeFeedEntry>(), Arg.Any<CancellationToken>())).Do(pipeline => { throw new TimeoutRejectedException(); });
 
             await ExecuteProcessAsync();
         }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/RetryableFhirTransactionPipelineTests.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/RetryableFhirTransactionPipelineTests.cs
@@ -7,7 +7,9 @@ using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.Dicom.Client.Models;
+using Microsoft.Health.DicomCast.Core.Configurations;
 using Microsoft.Health.DicomCast.Core.Exceptions;
 using Microsoft.Health.DicomCast.Core.Features.ExceptionStorage;
 using Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction;
@@ -21,7 +23,7 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker
 {
     public class RetryableFhirTransactionPipelineTests
     {
-        private const double DefaultRetryTime = .5;
+        private TimeSpan _defaultRetryTime = new TimeSpan(0, 0, 30);
         private const int DefaultRetryCount = 3; // This value calculated based on defaultRetryTime
 
         private static readonly CancellationToken DefaultCancellationToken = new CancellationTokenSource().Token;
@@ -32,10 +34,12 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker
 
         public RetryableFhirTransactionPipelineTests()
         {
+            RetryConfiguration config = new RetryConfiguration();
+            config.TotalRetryDuration = new TimeSpan(0, 0, 30);
             _retryableFhirTransactionPipeline = new RetryableFhirTransactionPipeline(
                 _fhirTransactionPipeline,
                 _exceptionStore,
-                DefaultRetryTime);
+                Options.Create(config));
         }
 
         [Fact]

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/RetryableFhirTransactionPipelineTests.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/RetryableFhirTransactionPipelineTests.cs
@@ -32,7 +32,8 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker
         {
             _retryableFhirTransactionPipeline = new RetryableFhirTransactionPipeline(
                 _fhirTransactionPipeline,
-                _exceptionStore);
+                _exceptionStore,
+                DefaultRetryCount);
         }
 
         [Fact]

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Configurations/RetryConfiguration.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Configurations/RetryConfiguration.cs
@@ -1,0 +1,20 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Health.DicomCast.Core.Configurations
+{
+    /// <summary>
+    /// The configuration for retryable exceptions.
+    /// </summary>
+    public class RetryConfiguration
+    {
+        /// <summary>
+        /// The total amount of time to spend retrying a single change feed entry across all retries.
+        /// </summary>
+        public TimeSpan TotalRetryDuration { get; set; } = TimeSpan.FromMinutes(10);
+    }
+}

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/ExceptionStorage/IExceptionStore.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/ExceptionStorage/IExceptionStore.cs
@@ -29,9 +29,9 @@ namespace Microsoft.Health.DicomCast.Core.Features.ExceptionStorage
         /// </summary>
         /// <param name="changeFeedEntry">ChangeFeedEntry that threw exception</param>
         /// <param name="retryNum">Number of times the entry has been tried</param>
-        /// <param name="nextDelayTimeSeconds">Amount of time to wait before retrying</param>
+        /// <param name="nextDelayTimeSpan">TimeSpan to wait before next retry</param>
         /// <param name="exceptionToStore">The exception that was thrown and needs to be stored</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        Task WriteRetryableExceptionAsync(ChangeFeedEntry changeFeedEntry, int retryNum, double nextDelayTimeSeconds, Exception exceptionToStore, CancellationToken cancellationToken = default);
+        Task WriteRetryableExceptionAsync(ChangeFeedEntry changeFeedEntry, int retryNum, TimeSpan nextDelayTimeSpan, Exception exceptionToStore, CancellationToken cancellationToken = default);
     }
 }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/ExceptionStorage/IExceptionStore.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/ExceptionStorage/IExceptionStore.cs
@@ -29,8 +29,9 @@ namespace Microsoft.Health.DicomCast.Core.Features.ExceptionStorage
         /// </summary>
         /// <param name="changeFeedEntry">ChangeFeedEntry that threw exception</param>
         /// <param name="retryNum">Number of times the entry has been tried</param>
+        /// <param name="waitTime">Amount of time to wait before retrying</param>
         /// <param name="exceptionToStore">The exception that was thrown and needs to be stored</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        Task WriteRetryableExceptionAsync(ChangeFeedEntry changeFeedEntry, int retryNum, Exception exceptionToStore, CancellationToken cancellationToken = default);
+        Task WriteRetryableExceptionAsync(ChangeFeedEntry changeFeedEntry, int retryNum, double waitTime, Exception exceptionToStore, CancellationToken cancellationToken = default);
     }
 }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/ExceptionStorage/IExceptionStore.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/ExceptionStorage/IExceptionStore.cs
@@ -29,9 +29,9 @@ namespace Microsoft.Health.DicomCast.Core.Features.ExceptionStorage
         /// </summary>
         /// <param name="changeFeedEntry">ChangeFeedEntry that threw exception</param>
         /// <param name="retryNum">Number of times the entry has been tried</param>
-        /// <param name="waitTime">Amount of time to wait before retrying</param>
+        /// <param name="nextDelayTimeSeconds">Amount of time to wait before retrying</param>
         /// <param name="exceptionToStore">The exception that was thrown and needs to be stored</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        Task WriteRetryableExceptionAsync(ChangeFeedEntry changeFeedEntry, int retryNum, double waitTime, Exception exceptionToStore, CancellationToken cancellationToken = default);
+        Task WriteRetryableExceptionAsync(ChangeFeedEntry changeFeedEntry, int retryNum, double nextDelayTimeSeconds, Exception exceptionToStore, CancellationToken cancellationToken = default);
     }
 }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/ChangeFeedProcessor.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/ChangeFeedProcessor.cs
@@ -17,6 +17,7 @@ using Microsoft.Health.DicomCast.Core.Features.ExceptionStorage;
 using Microsoft.Health.DicomCast.Core.Features.Fhir;
 using Microsoft.Health.DicomCast.Core.Features.State;
 using Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction;
+using Polly.Timeout;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.DicomCast.Core.Features.Worker
@@ -89,7 +90,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker
                     }
                     catch (Exception ex)
                     {
-                        if (ex is FhirNonRetryableException || ex is DicomTagException || ex is RetryableException)
+                        if (ex is FhirNonRetryableException || ex is DicomTagException || ex is TimeoutRejectedException)
                         {
                             string studyUid = changeFeedEntry.StudyInstanceUid;
                             string seriesUid = changeFeedEntry.SeriesInstanceUid;
@@ -102,7 +103,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker
                             {
                                 errorType = ErrorType.DicomError;
                             }
-                            else if (ex is RetryableException)
+                            else if (ex is TimeoutRejectedException)
                             {
                                 errorType = ErrorType.TransientFailure;
                             }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/ChangeFeedProcessor.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/ChangeFeedProcessor.cs
@@ -6,9 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Threading;
-using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Core;

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/RetryableFhirTransactionPipeline.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/RetryableFhirTransactionPipeline.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
                         return _exceptionStore.WriteRetryableExceptionAsync(
                             changeFeedEntry,
                             retryCount,
-                            timeSpan.TotalSeconds,
+                            timeSpan,
                             exception);
                     });
         }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Modules/WorkerModule.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Modules/WorkerModule.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Health.DicomCast.Core.Modules
     {
         private const string DicomCastWorkerConfigurationSectionName = "DicomCastWorker";
         private const string DicomValidationConfigurationSectionName = "DicomCast";
+        private const string RetryConfigurationSectionName = "RetryConfiguration";
 
         private readonly IConfiguration _configuration;
 
@@ -41,6 +42,10 @@ namespace Microsoft.Health.DicomCast.Core.Modules
             DicomCastConfiguration dicomValidationConfiguration = services.Configure<DicomCastConfiguration>(
                 _configuration,
                 DicomValidationConfigurationSectionName);
+
+            RetryConfiguration retryConfiguration = services.Configure<RetryConfiguration>(
+                _configuration,
+                RetryConfigurationSectionName);
 
             services.Add<DicomCastWorker>()
                 .Singleton()

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Hosting/appsettings.json
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Hosting/appsettings.json
@@ -1,9 +1,4 @@
 {
-    "DicomCastStores": {
-        "SyncStateStore": {
-            "ContainerName": "dicomcastcontainer"
-        }
-    },
     "Logging": {
         "LogLevel": {
             "Default": "Information",
@@ -41,6 +36,9 @@
         "Features": {
             "EnforceValidationOfTagValues": false
         }
+    },
+    "RetryConfiguration": {
+        "TotalRetryDuration" :  "00:10:00"
     },
     "ApplicationInsights": {
         "InstrumentationKey": ""

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.TableStorage/Features/Storage/TableExceptionStore.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.TableStorage/Features/Storage/TableExceptionStore.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Health.DicomCast.TableStorage.Features.Storage
         }
 
         /// <inheritdoc/>
-        public async Task WriteRetryableExceptionAsync(ChangeFeedEntry changeFeedEntry, int retryNum, double nextDelayTimeSeconds, Exception exceptionToStore, CancellationToken cancellationToken)
+        public async Task WriteRetryableExceptionAsync(ChangeFeedEntry changeFeedEntry, int retryNum, TimeSpan nextDelayTimeSpan, Exception exceptionToStore, CancellationToken cancellationToken)
         {
             string tableName = Constants.TransientRetryTableName;
 
@@ -101,7 +101,7 @@ namespace Microsoft.Health.DicomCast.TableStorage.Features.Storage
             try
             {
                 await table.ExecuteAsync(operation, cancellationToken);
-                _logger.LogInformation("Retryable error when processsing changefeed entry: {ChangeFeedSequence} for DICOM instance with StudyUID: {StudyUID}, SeriesUID: {SeriesUID}, InstanceUID: {InstanceUID}. Tried {retryNum} time(s). Waiting {seconds} seconds. Stored into table: {Table} in table storage.", changeFeedSequence, studyUid, seriesUid, instanceUid, retryNum, nextDelayTimeSeconds, tableName);
+                _logger.LogInformation("Retryable error when processsing changefeed entry: {ChangeFeedSequence} for DICOM instance with StudyUID: {StudyUID}, SeriesUID: {SeriesUID}, InstanceUID: {InstanceUID}. Tried {retryNum} time(s). Waiting {milliseconds} milliseconds . Stored into table: {Table} in table storage.", changeFeedSequence, studyUid, seriesUid, instanceUid, retryNum, nextDelayTimeSpan.TotalMilliseconds, tableName);
             }
             catch
             {

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.TableStorage/Features/Storage/TableExceptionStore.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.TableStorage/Features/Storage/TableExceptionStore.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Health.DicomCast.TableStorage.Features.Storage
         }
 
         /// <inheritdoc/>
-        public async Task WriteRetryableExceptionAsync(ChangeFeedEntry changeFeedEntry, int retryNum, double waitTime, Exception exceptionToStore, CancellationToken cancellationToken)
+        public async Task WriteRetryableExceptionAsync(ChangeFeedEntry changeFeedEntry, int retryNum, double nextDelayTimeSeconds, Exception exceptionToStore, CancellationToken cancellationToken)
         {
             string tableName = Constants.TransientRetryTableName;
 
@@ -101,7 +101,7 @@ namespace Microsoft.Health.DicomCast.TableStorage.Features.Storage
             try
             {
                 await table.ExecuteAsync(operation, cancellationToken);
-                _logger.LogInformation("Retryable error when processsing changefeed entry: {ChangeFeedSequence} for DICOM instance with StudyUID: {StudyUID}, SeriesUID: {SeriesUID}, InstanceUID: {InstanceUID}. Tried {retryNum} time(s). Waiting {seconds} seconds. Stored into table: {Table} in table storage.", changeFeedSequence, studyUid, seriesUid, instanceUid, retryNum, waitTime, tableName);
+                _logger.LogInformation("Retryable error when processsing changefeed entry: {ChangeFeedSequence} for DICOM instance with StudyUID: {StudyUID}, SeriesUID: {SeriesUID}, InstanceUID: {InstanceUID}. Tried {retryNum} time(s). Waiting {seconds} seconds. Stored into table: {Table} in table storage.", changeFeedSequence, studyUid, seriesUid, instanceUid, retryNum, nextDelayTimeSeconds, tableName);
             }
             catch
             {

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.TableStorage/Features/Storage/TableExceptionStore.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.TableStorage/Features/Storage/TableExceptionStore.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Health.DicomCast.TableStorage.Features.Storage
         }
 
         /// <inheritdoc/>
-        public async Task WriteRetryableExceptionAsync(ChangeFeedEntry changeFeedEntry, int retryNum, Exception exceptionToStore, CancellationToken cancellationToken)
+        public async Task WriteRetryableExceptionAsync(ChangeFeedEntry changeFeedEntry, int retryNum, double waitTime, Exception exceptionToStore, CancellationToken cancellationToken)
         {
             string tableName = Constants.TransientRetryTableName;
 
@@ -101,7 +101,7 @@ namespace Microsoft.Health.DicomCast.TableStorage.Features.Storage
             try
             {
                 await table.ExecuteAsync(operation, cancellationToken);
-                _logger.LogInformation("Retryable error when processsing changefeed entry: {ChangeFeedSequence} for DICOM instance with StudyUID: {StudyUID}, SeriesUID: {SeriesUID}, InstanceUID: {InstanceUID}. Tried {retryNum} time(s). Stored into table: {Table} in table storage.", changeFeedSequence, studyUid, seriesUid, instanceUid, retryNum, tableName);
+                _logger.LogInformation("Retryable error when processsing changefeed entry: {ChangeFeedSequence} for DICOM instance with StudyUID: {StudyUID}, SeriesUID: {SeriesUID}, InstanceUID: {InstanceUID}. Tried {retryNum} time(s). Waiting {seconds} seconds. Stored into table: {Table} in table storage.", changeFeedSequence, studyUid, seriesUid, instanceUid, retryNum, waitTime, tableName);
             }
             catch
             {


### PR DESCRIPTION
## Description
Update the retry policy to retry for a total of 15 times to allow for fhir server to come back up if it is down. It now does exponential back off until it reaches a wait time of 60 seconds, after that it will wait 60 seconds between each retry.

## Related issues
[AB#78067](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/78067)