### PR TITLE
Update Get-AzKeyValueSecret due to breaking change in latest powershell

### DIFF
--- a/build/run-e2e-tests.yml
+++ b/build/run-e2e-tests.yml
@@ -21,9 +21,8 @@ jobs:
         foreach($secret in $secrets)
         {
             $environmentVariableName = $secret.Name.Replace("--","_")
-
-            $secretValue = Get-AzKeyVaultSecret -VaultName $(deploymentName)-ts -Name $secret.Name
-            Write-Host "##vso[task.setvariable variable=$($environmentVariableName)]$($secretValue.SecretValueText)"
+            $secretValue = Get-AzKeyVaultSecret -VaultName $(deploymentName)-ts -Name $secret.Name -AsPlainText
+            Write-Host "##vso[task.setvariable variable=$($environmentVariableName)]$($secretValue)"
         }
 
         Write-Host "##vso[task.setvariable variable=Resource]$(testEnvironmentUrl)"

--- a/build/run-integration-tests.yml
+++ b/build/run-integration-tests.yml
@@ -19,8 +19,8 @@ jobs:
         foreach ($secret in $secrets)
         {
             $environmentVariableName = $secret.Name.Replace("--",":")
-            $secretValue = Get-AzKeyVaultSecret -VaultName $(deploymentName) -Name $secret.Name
-            Write-Host "##vso[task.setvariable variable=$($environmentVariableName)]$($secretValue.SecretValueText)"
+            $secretValue = Get-AzKeyVaultSecret -VaultName $(deploymentName) -Name $secret.Name -AsPlainText
+            Write-Host "##vso[task.setvariable variable=$($environmentVariableName)]$($secretValue)"
         }
         
         dotnet dev-certs https


### PR DESCRIPTION
## Description
Update Get-AzKeyValueSecret due to breaking change in latest powershell: Return from Get-AzKeyVaultSecret doesn't have property SecretValueText.

## Related issues
Addresses [AB#80078](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/80078)

## Testing
Test with this run.
