### PR TITLE
Add DICOM Cast NuGet to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,15 @@ updates:
       time: "09:00"
       timezone: "America/Los_Angeles"
     open-pull-requests-limit: 30
-  
+
+  - package-ecosystem: "nuget"
+    directory: "/converter/dicom-cast"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 30
+
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Description
- Add DICOM Cast projects to Dependabot config for NuGet

## Related issues
N/A

## Testing
PR Approval
