### PR TITLE
Publish E2E tests to Feed 

### DIFF
--- a/build/publish-nuget.yml
+++ b/build/publish-nuget.yml
@@ -11,6 +11,16 @@ steps:
       downloadPath: '$(System.ArtifactsDirectory)'
       artifactName: 'nuget'
 
+  - task: NuGetAuthenticate@0
+    displayName: 'NuGet Authenticate'
+
+  - task: NuGetCommand@2
+    displayName: 'NuGet push'
+    inputs:
+      command: push
+      publishVstsFeed: 'InternalBuilds'
+      allowPackageConflicts: true
+      
   - task: DownloadBuildArtifacts@0
     inputs:
       buildType: 'current'

--- a/build/publish-nuget.yml
+++ b/build/publish-nuget.yml
@@ -25,5 +25,5 @@ steps:
       publishDirectory: '$(System.ArtifactsDirectory)/IntegrationTests'
       feedsToUsePublish: 'internal'
       vstsFeedPublish: 'DicomServer/Dicom-Public'
-      vstsFeedPackagePublish: 'DicomWebE2ETests'
+      vstsFeedPackagePublish: 'dicom-e2e-tests'
       versionOption: 'patch'

--- a/build/publish-nuget.yml
+++ b/build/publish-nuget.yml
@@ -11,21 +11,18 @@ steps:
       downloadPath: '$(System.ArtifactsDirectory)'
       artifactName: 'nuget'
 
-  - task: NuGetAuthenticate@0
-    displayName: 'NuGet Authenticate'
-
-  - task: NuGetCommand@2
-    displayName: 'NuGet push'
+  - task: DownloadBuildArtifacts@0
     inputs:
-      command: push
-      publishVstsFeed: 'InternalBuilds'
-      allowPackageConflicts: true
+      buildType: 'current'
+      downloadType: 'single'
+      downloadPath: '$(System.ArtifactsDirectory)'
+      artifactName: 'IntegrationTests'
 
   - task: UniversalPackages@0
     displayName: 'E2E test push'
     inputs:
       command: 'publish'
-      publishDirectory: '$(System.DefaultWorkingDirectory)/IntegrationTests'
+      publishDirectory: '$(System.ArtifactsDirectory)/IntegrationTests'
       feedsToUsePublish: 'internal'
       vstsFeedPublish: 'DicomServer/Dicom-Public'
       vstsFeedPackagePublish: 'DicomWebE2ETests'

--- a/build/publish-nuget.yml
+++ b/build/publish-nuget.yml
@@ -20,3 +20,13 @@ steps:
       command: push
       publishVstsFeed: 'InternalBuilds'
       allowPackageConflicts: true
+
+  - task: UniversalPackages@0
+    displayName: 'E2E test push'
+    inputs:
+      command: 'publish'
+      publishDirectory: '$(Build.ArtifactStagingDirectory)/IntegrationTests'
+      feedsToUsePublish: 'internal'
+      vstsFeedPublish: 'DicomServer/Dicom-Public'
+      vstsFeedPackagePublish: 'DicomWebE2ETests'
+      versionOption: 'patch'

--- a/build/publish-nuget.yml
+++ b/build/publish-nuget.yml
@@ -25,7 +25,7 @@ steps:
     displayName: 'E2E test push'
     inputs:
       command: 'publish'
-      publishDirectory: '$(Build.ArtifactStagingDirectory)/IntegrationTests'
+      publishDirectory: '$(System.DefaultWorkingDirectory)/IntegrationTests'
       feedsToUsePublish: 'internal'
       vstsFeedPublish: 'DicomServer/Dicom-Public'
       vstsFeedPackagePublish: 'DicomWebE2ETests'


### PR DESCRIPTION
## Description
Built E2E tests folder will be published to a public feed Dicom-public feed
It will be then be downloaded and used in PaaS CI to run these tests

## Related issues
[AB#76726](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/76726)

## Testing
https://microsofthealthoss.visualstudio.com/DicomServer/_build/results?buildId=9718&view=logs&j=a7dd5148-3b99-5440-3785-57fe2230e0cb&t=4ddefbae-1b1f-54cf-4279-39dacb605ee7
https://microsofthealthoss.visualstudio.com/DicomServer/_packaging?_a=feed&feed=Dicom-Public%40Local
