### PR TITLE
Update STOW to support privateCreator

### DIFF
--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Extensions/DicomDatasetExtensionsTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Extensions/DicomDatasetExtensionsTests.cs
@@ -11,8 +11,6 @@ using System.Text;
 using Dicom;
 using Dicom.Serialization;
 using Microsoft.Health.Dicom.Core.Extensions;
-using Microsoft.Health.Dicom.Core.Features.CustomTag;
-using Microsoft.Health.Dicom.Tests.Common.Extensions;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -224,58 +222,6 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Extensions
 
                 return result.ToString();
             }
-        }
-
-        [Fact]
-        public void GivenADicomDatasetWithStandardTag_WhenGetDicomTagsIsCalled_ThenShouldReturnCorrectValue()
-        {
-            DicomTag dicomTag = DicomTag.DestinationAE;
-            _dicomDataset.AddOrUpdate(dicomTag, "123");
-            IndexTag indexTag = new IndexTag(dicomTag.BuildCustomTagStoreEntry());
-            var result = _dicomDataset.GetMatchingDicomTags(new IndexTag[] { indexTag });
-            Assert.Single(result);
-            Assert.Equal(dicomTag, result[indexTag]);
-        }
-
-        [Fact]
-        public void GivenADicomDatasetWithPrivateTag_WhenGetDicomTagsIsCalled_ThenShouldReturnCorrectValue()
-        {
-            DicomTag dicomTag = new DicomTag(0x0405, 0x1001, "PrivateCreator");
-            DicomElement element = new DicomCodeString(dicomTag, "123");
-            _dicomDataset.Add(element);
-            IndexTag indexTag = new IndexTag(dicomTag.BuildCustomTagStoreEntry(vr: element.ValueRepresentation.Code));
-            var result = _dicomDataset.GetMatchingDicomTags(new IndexTag[] { indexTag });
-            Assert.Single(result);
-            Assert.Equal(dicomTag, result[indexTag]);
-        }
-
-        [Fact]
-        public void GivenADicomDataSetWithoutTheStandardTag_WhenGetDicomTagsIsCalled_ThenShouldNotReturn()
-        {
-            DicomTag dicomTag = DicomTag.DestinationAE;
-            IndexTag indexTag = new IndexTag(dicomTag.BuildCustomTagStoreEntry());
-            var result = _dicomDataset.GetMatchingDicomTags(new IndexTag[] { indexTag });
-            Assert.Empty(result);
-        }
-
-        [Fact]
-        public void GivenADicomDataSetWithoutThePrivateTag_WhenGetDicomTagsIsCalled_ThenShouldNotReturn()
-        {
-            DicomTag dicomTag = new DicomTag(0x0405, 0x1001, "PrivateCreator");
-            IndexTag indexTag = new IndexTag(dicomTag.BuildCustomTagStoreEntry(vr: DicomVRCode.CS));
-            var result = _dicomDataset.GetMatchingDicomTags(new IndexTag[] { indexTag });
-            Assert.Empty(result);
-        }
-
-        [Fact]
-        public void GivenADicomDataSetWithThePrivateTagButDifferentVR_WhenGetDicomTagsIsCalled_ThenShouldNotReturn()
-        {
-            DicomTag dicomTag = new DicomTag(0x0405, 0x1001, "PrivateCreator");
-            DicomElement element = new DicomIntegerString(dicomTag, "123");
-            _dicomDataset.Add(element);
-            IndexTag indexTag = new IndexTag(dicomTag.BuildCustomTagStoreEntry(vr: DicomVRCode.CS));
-            var result = _dicomDataset.GetMatchingDicomTags(new IndexTag[] { indexTag });
-            Assert.Empty(result);
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/CustomTag/IndexTagTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/CustomTag/IndexTagTests.cs
@@ -1,0 +1,57 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Dicom;
+using Microsoft.Health.Dicom.Core.Features.CustomTag;
+using Microsoft.Health.Dicom.Tests.Common.Extensions;
+using Xunit;
+
+namespace Microsoft.Health.Dicom.Core.UnitTests.Features.CustomTag
+{
+    public class IndexTagTests
+    {
+        [Fact]
+        public void GivenCoreDicomTag_WhenInitialize_ThenShouldCreatedSuccessfully()
+        {
+            DicomTag tag = DicomTag.PatientName;
+            CustomTagLevel level = CustomTagLevel.Instance;
+            IndexTag indexTag = new IndexTag(tag, CustomTagLevel.Instance);
+            Assert.Equal(tag, indexTag.Tag);
+            Assert.Equal(DicomVR.PN, indexTag.VR);
+            Assert.Null(indexTag.CustomTagStoreEntry);
+            Assert.False(indexTag.IsCustomTag);
+            Assert.Equal(level, indexTag.Level);
+        }
+
+        [Fact]
+        public void GivenStandardCustomTag_WhenInitialize_ThenShouldCreatedSuccessfully()
+        {
+            DicomTag tag = DicomTag.AcquisitionDate;
+            CustomTagLevel level = CustomTagLevel.Series;
+            var storeEntry = tag.BuildCustomTagStoreEntry(level: level);
+            IndexTag indexTag = new IndexTag(storeEntry);
+            Assert.Equal(tag, indexTag.Tag);
+            Assert.Equal(DicomVR.DA, indexTag.VR);
+            Assert.Equal(storeEntry, indexTag.CustomTagStoreEntry);
+            Assert.True(indexTag.IsCustomTag);
+            Assert.Equal(level, indexTag.Level);
+        }
+
+        [Fact]
+        public void GivenPrivateCustomTag_WhenInitialize_ThenShouldCreatedSuccessfully()
+        {
+            DicomTag tag = new DicomTag(0x1205, 0x1003, "PrivateCreator1");
+            DicomVR vr = DicomVR.CS;
+            CustomTagLevel level = CustomTagLevel.Study;
+            var storeEntry = tag.BuildCustomTagStoreEntry(vr: vr.ToString(), privateCreator: tag.PrivateCreator.Creator, level: level);
+            IndexTag indexTag = new IndexTag(storeEntry);
+            Assert.Equal(tag, indexTag.Tag);
+            Assert.Equal(vr, indexTag.VR);
+            Assert.Equal(storeEntry, indexTag.CustomTagStoreEntry);
+            Assert.True(indexTag.IsCustomTag);
+            Assert.Equal(level, indexTag.Level);
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Core/Extensions/DicomDatasetExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Extensions/DicomDatasetExtensions.cs
@@ -9,7 +9,6 @@ using System.Globalization;
 using System.Linq;
 using Dicom;
 using EnsureThat;
-using Microsoft.Health.Dicom.Core.Features.CustomTag;
 using Microsoft.Health.Dicom.Core.Features.Model;
 
 namespace Microsoft.Health.Dicom.Core.Extensions
@@ -149,58 +148,6 @@ namespace Microsoft.Health.Dicom.Core.Extensions
             {
                 dicomDataset.Add(dicomTag, value);
             }
-        }
-
-        /// <summary>
-        /// Get matching DicomTags for index Tag from Dicom Dataset.
-        /// </summary>
-        /// <remarks>If indextag not exist in dataset, should not return.</remarks>
-        /// <param name="dicomDataset">The dicom dataset.</param>
-        /// <param name="indexTags">The index Tags.</param>
-        /// <returns>Mapping between IndexTag and DicomTag.</returns>
-        public static IDictionary<IndexTag, DicomTag> GetMatchingDicomTags(this DicomDataset dicomDataset, IEnumerable<IndexTag> indexTags)
-        {
-            EnsureArg.IsNotNull(dicomDataset, nameof(dicomDataset));
-            EnsureArg.IsNotNull(indexTags, nameof(indexTags));
-            IDictionary<IndexTag, DicomTag> result = new Dictionary<IndexTag, DicomTag>();
-            Dictionary<string, IndexTag> privateTags = new Dictionary<string, IndexTag>();
-            foreach (IndexTag indexTag in indexTags)
-            {
-                if (indexTag.Tag.IsPrivate)
-                {
-                    privateTags.Add(indexTag.Tag.GetPath(), indexTag);
-                }
-                else
-                {
-                    if (dicomDataset.Contains(indexTag.Tag))
-                    {
-                        result.Add(indexTag, indexTag.Tag);
-                    }
-                }
-            }
-
-            // Process Private tags
-            if (privateTags.Count != 0)
-            {
-                // IndexTag don't have privateCreator for private tag, need to fill that part from DicomDataset.
-                foreach (DicomItem item in dicomDataset)
-                {
-                    if (item.Tag.IsPrivate)
-                    {
-                        string tagPath = item.Tag.GetPath();
-                        if (privateTags.ContainsKey(tagPath))
-                        {
-                            IndexTag indexTag = privateTags[tagPath];
-                            if (indexTag.VR == item.ValueRepresentation)
-                            {
-                                result.Add(indexTag, item.Tag);
-                            }
-                        }
-                    }
-                }
-            }
-
-            return result;
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/CustomTag/IndexTag.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/CustomTag/IndexTag.cs
@@ -38,8 +38,8 @@ namespace Microsoft.Health.Dicom.Core.Features.CustomTag
         public IndexTag(CustomTagStoreEntry entry)
         {
             EnsureArg.IsNotNull(entry, nameof(entry));
-
-            Tag = DicomTag.Parse(entry.Path);
+            string fullPath = string.IsNullOrEmpty(entry.PrivateCreator) ? entry.Path : $"{entry.Path}:{entry.PrivateCreator}";
+            Tag = DicomTag.Parse(fullPath);
             VR = DicomVR.Parse(entry.VR);
             Level = entry.Level;
             CustomTagStoreEntry = entry;

--- a/src/Microsoft.Health.Dicom.Core/Features/Store/DicomDatasetValidator.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Store/DicomDatasetValidator.cs
@@ -12,7 +12,6 @@ using Dicom;
 using EnsureThat;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Dicom.Core.Configs;
-using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Core.Features.CustomTag;
 using Microsoft.Health.Dicom.Core.Features.Validation;
 
@@ -103,15 +102,14 @@ namespace Microsoft.Health.Dicom.Core.Features.Store
         private async Task ValidateIndexedItems(DicomDataset dicomDataset, CancellationToken cancellationToken)
         {
             IReadOnlyCollection<IndexTag> indexTags = await _indextagService.GetIndexTagsAsync(cancellationToken);
-            var tags = dicomDataset.GetMatchingDicomTags(indexTags);
-            ValidateTags(dicomDataset, tags.Values);
+            ValidateTags(dicomDataset, indexTags);
         }
 
-        private void ValidateTags(DicomDataset dicomDataset, IEnumerable<DicomTag> tags)
+        private void ValidateTags(DicomDataset dicomDataset, IEnumerable<IndexTag> tags)
         {
-            foreach (DicomTag indexableTag in tags)
+            foreach (IndexTag indexableTag in tags)
             {
-                DicomElement dicomElement = dicomDataset.GetDicomItem<DicomElement>(indexableTag);
+                DicomElement dicomElement = dicomDataset.GetDicomItem<DicomElement>(indexableTag.Tag);
 
                 if (dicomElement != null)
                 {

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/CustomTag/AddInstanceTableValuedParametersBuilder.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/CustomTag/AddInstanceTableValuedParametersBuilder.cs
@@ -42,37 +42,33 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.CustomTag
             List<InsertDateTimeCustomTagTableTypeV1Row> dateTimeRows = new List<InsertDateTimeCustomTagTableTypeV1Row>();
             List<InsertPersonNameCustomTagTableTypeV1Row> personNamRows = new List<InsertPersonNameCustomTagTableTypeV1Row>();
 
-            var tags = instance.GetMatchingDicomTags(indexTags);
-
-            foreach (var pair in tags)
+            foreach (var indexTag in indexTags)
             {
-                DicomTag matchingTag = pair.Value;
-                IndexTag indexTag = pair.Key;
                 CustomTagDataType dataType = CustomTagLimit.CustomTagVRAndDataTypeMapping[indexTag.VR.Code];
                 switch (dataType)
                 {
                     case CustomTagDataType.StringData:
-                        AddStringRow(instance, stringRows, matchingTag, indexTag);
+                        AddStringRow(instance, stringRows, indexTag);
 
                         break;
 
                     case CustomTagDataType.LongData:
-                        AddBigIntRow(instance, bigIntRows, matchingTag, indexTag);
+                        AddBigIntRow(instance, bigIntRows, indexTag);
 
                         break;
 
                     case CustomTagDataType.DoubleData:
-                        AddDoubleRow(instance, doubleRows, matchingTag, indexTag);
+                        AddDoubleRow(instance, doubleRows, indexTag);
 
                         break;
 
                     case CustomTagDataType.DateTimeData:
-                        AddDateTimeRow(instance, dateTimeRows, matchingTag, indexTag);
+                        AddDateTimeRow(instance, dateTimeRows, indexTag);
 
                         break;
 
                     case CustomTagDataType.PersonNameData:
-                        AddPersonNameRow(instance, personNamRows, matchingTag, indexTag);
+                        AddPersonNameRow(instance, personNamRows, indexTag);
 
                         break;
 
@@ -85,20 +81,20 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.CustomTag
             return new VLatest.AddInstanceTableValuedParameters(stringRows, bigIntRows, doubleRows, dateTimeRows, personNamRows);
         }
 
-        private static void AddPersonNameRow(DicomDataset instance, List<InsertPersonNameCustomTagTableTypeV1Row> personNamRows, DicomTag matchingTag, IndexTag indexTag)
+        private static void AddPersonNameRow(DicomDataset instance, List<InsertPersonNameCustomTagTableTypeV1Row> personNamRows, IndexTag indexTag)
         {
-            string personNameVal = instance.GetSingleValueOrDefault<string>(matchingTag);
+            string personNameVal = instance.GetSingleValueOrDefault<string>(indexTag.Tag);
             if (personNameVal != null)
             {
                 personNamRows.Add(new InsertPersonNameCustomTagTableTypeV1Row(indexTag.CustomTagStoreEntry.Key, personNameVal, (byte)indexTag.Level));
             }
         }
 
-        private static void AddDateTimeRow(DicomDataset instance, List<InsertDateTimeCustomTagTableTypeV1Row> dateTimeRows, DicomTag matchingTag, IndexTag indexTag)
+        private static void AddDateTimeRow(DicomDataset instance, List<InsertDateTimeCustomTagTableTypeV1Row> dateTimeRows, IndexTag indexTag)
         {
             DateTime? dateVal = DataTimeReaders.TryGetValue(
                              indexTag.VR,
-                             out Func<DicomDataset, DicomTag, DateTime?> reader) ? reader.Invoke(instance, matchingTag) : null;
+                             out Func<DicomDataset, DicomTag, DateTime?> reader) ? reader.Invoke(instance, indexTag.Tag) : null;
 
             if (dateVal.HasValue)
             {
@@ -106,18 +102,18 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.CustomTag
             }
         }
 
-        private static void AddDoubleRow(DicomDataset instance, List<InsertDoubleCustomTagTableTypeV1Row> doubleRows, DicomTag matchingTag, IndexTag indexTag)
+        private static void AddDoubleRow(DicomDataset instance, List<InsertDoubleCustomTagTableTypeV1Row> doubleRows, IndexTag indexTag)
         {
-            double? doubleVal = instance.GetSingleValueOrDefault<double>(matchingTag);
+            double? doubleVal = instance.GetSingleValueOrDefault<double>(indexTag.Tag);
             if (doubleVal.HasValue)
             {
                 doubleRows.Add(new InsertDoubleCustomTagTableTypeV1Row(indexTag.CustomTagStoreEntry.Key, doubleVal.Value, (byte)indexTag.Level));
             }
         }
 
-        private static void AddBigIntRow(DicomDataset instance, List<InsertBigIntCustomTagTableTypeV1Row> bigIntRows, DicomTag matchingTag, IndexTag indexTag)
+        private static void AddBigIntRow(DicomDataset instance, List<InsertBigIntCustomTagTableTypeV1Row> bigIntRows, IndexTag indexTag)
         {
-            long? longVal = instance.GetSingleValueOrDefault<long>(matchingTag);
+            long? longVal = instance.GetSingleValueOrDefault<long>(indexTag.Tag);
 
             if (longVal.HasValue)
             {
@@ -125,9 +121,9 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.CustomTag
             }
         }
 
-        private static void AddStringRow(DicomDataset instance, List<InsertStringCustomTagTableTypeV1Row> stringRows, DicomTag matchingTag, IndexTag indexTag)
+        private static void AddStringRow(DicomDataset instance, List<InsertStringCustomTagTableTypeV1Row> stringRows, IndexTag indexTag)
         {
-            string stringVal = instance.GetSingleValueOrDefault<string>(matchingTag);
+            string stringVal = instance.GetSingleValueOrDefault<string>(indexTag.Tag);
             if (stringVal != null)
             {
                 stringRows.Add(new InsertStringCustomTagTableTypeV1Row(indexTag.CustomTagStoreEntry.Key, stringVal, (byte)indexTag.Level));


### PR DESCRIPTION
## Description
1. Remove DicomDatasetExtensions.GetMatchingDicomTags
2. IndexTag consider PrivateCreator when parse into DicomTag
3. Update AddInstanceTableValuePrametersBuilder

## Related issues
Addresses [AB#80426](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/80426)
