### PR TITLE
Refactor GitVersion Usage

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -4,15 +4,3 @@ assembly-versioning-scheme: Major
 assembly-file-versioning-scheme: MajorMinorPatch
 ignore:
   sha: []
-branches:
-  main:
-    regex: ^(main|master)$
-    is-mainline: true
-    tag: ''
-    increment: Patch
-    prevent-increment-of-merged-branch-version: true
-    is-release-branch: true
-  feature:
-    regex: ^(dev|dependabot|feature|personal|revert|users)[/-]
-    tag: useBranchName
-    increment: Inherit

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -4,3 +4,10 @@ assembly-versioning-scheme: Major
 assembly-file-versioning-scheme: MajorMinorPatch
 ignore:
   sha: []
+branches:
+  main:
+    is-release-branch: true
+  feature:
+    regex: ^(dependabot|dev|feature(s)?|personal|user(s)?)[/-]
+  hotfix:
+    tag: useBranchName

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -5,36 +5,14 @@ assembly-file-versioning-scheme: MajorMinorPatch
 ignore:
   sha: []
 branches:
-  master:
-    regex: ^master$|^main$
+  main:
+    regex: ^(main|master)$
+    is-mainline: true
     tag: ''
     increment: Patch
     prevent-increment-of-merged-branch-version: true
-    track-merge-target: false
-    tracks-release-branches: false
     is-release-branch: true
-  pull-request:
-    regex: ^(pull|pull\-requests|pr)[/-]
-    tag: pr
-    increment: Inherit
-    prevent-increment-of-merged-branch-version: false
-    tag-number-pattern: '[/-](?<number>\d+)[-/]'
-    track-merge-target: false
-    tracks-release-branches: false
-    is-release-branch: false
-  hotfix:
-    regex: ^hotfix(es)?[/-]
-    tag: useBranchName
-    increment: Patch
-    prevent-increment-of-merged-branch-version: false
-    track-merge-target: false
-    tracks-release-branches: false
-    is-release-branch: false
   feature:
-    regex: ^(personal|dev|feature|dependabot|auto\-nuget\-update)[/-]
+    regex: ^(dev|dependabot|feature|personal|revert|users)[/-]
     tag: useBranchName
-    increment: Patch
-    prevent-increment-of-merged-branch-version: false
-    track-merge-target: false
-    tracks-release-branches: false
-    is-release-branch: false
+    increment: Inherit

--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -28,11 +28,11 @@ stages:
   dependsOn:
   - UpdateVersion
   variables:
-    assemblySemVer: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.assemblySemVer']]
-    assemblySemFileVer: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.assemblySemFileVer']]
-    informationalVersion: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.informationalVersion']]
-    majorMinorPatch: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.majorMinorPatch']]
-    nuGetVersion: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.nuGetVersion']]
+    assemblySemVer: $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.assemblySemVer']]
+    assemblySemFileVer: $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.assemblySemFileVer']]
+    informationalVersion: $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.informationalVersion']]
+    majorMinorPatch: $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.majorMinorPatch']]
+    nuGetVersion: $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.nuGetVersion']]
   jobs:
   - job: Windows
     pool:

--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -28,11 +28,11 @@ stages:
   dependsOn:
   - UpdateVersion
   variables:
-    assemblySemVer: $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.assemblySemVer']]
-    assemblySemFileVer: $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.assemblySemFileVer']]
-    informationalVersion: $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.informationalVersion']]
-    majorMinorPatch: $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.majorMinorPatch']]
-    nuGetVersion: $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.nuGetVersion']]
+    assemblySemVer: $[stageDependencies.UpdateVersion.Semver.outputs['DicomVersion.GitVersion.AssemblySemVer']]
+    assemblySemFileVer: $[stageDependencies.UpdateVersion.Semver.outputs['DicomVersion.GitVersion.AssemblySemFileVer']]
+    informationalVersion: $[stageDependencies.UpdateVersion.Semver.outputs['DicomVersion.GitVersion.InformationalVersion']]
+    majorMinorPatch: $[stageDependencies.UpdateVersion.Semver.outputs['DicomVersion.GitVersion.MajorMinorPatch']]
+    nuGetVersion: $[stageDependencies.UpdateVersion.Semver.outputs['DicomVersion.GitVersion.SemVer']]
   jobs:
   - job: Windows
     pool:

--- a/build/.vsts-pr.yml
+++ b/build/.vsts-pr.yml
@@ -28,11 +28,11 @@ stages:
   dependsOn:
   - UpdateVersion
   variables:
-    assemblySemVer: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.assemblySemVer']]
-    assemblySemFileVer: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.assemblySemFileVer']]
-    informationalVersion: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.informationalVersion']]
-    majorMinorPatch: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.majorMinorPatch']]
-    nuGetVersion: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.nuGetVersion']]
+    assemblySemVer: $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.assemblySemVer']]
+    assemblySemFileVer: $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.assemblySemFileVer']]
+    informationalVersion: $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.informationalVersion']]
+    majorMinorPatch: $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.majorMinorPatch']]
+    nuGetVersion: $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.nuGetVersion']]
   jobs:
   - job: Windows
     pool:

--- a/build/.vsts-pr.yml
+++ b/build/.vsts-pr.yml
@@ -20,7 +20,7 @@ stages:
     - powershell: |
         $buildNumber = "$(GitVersion.SemVer)" -replace "\.", ""
         Write-Host "##vso[build.updatebuildnumber]$buildNumber"
-        Write-Host "Updated  build number to '$buildNumber"
+        Write-Host "Updated build number to '$buildNumber'"
       name: SetBuildVersion
 
 - stage: BuildRunUnitTests

--- a/build/.vsts-pr.yml
+++ b/build/.vsts-pr.yml
@@ -18,7 +18,7 @@ stages:
     steps:
     - template: ./update-semver.yml
     - powershell: |
-        $buildNumber = "$(GitVersion.semVer)" -replace "\.", ""
+        $buildNumber = "$(GitVersion.SemVer)" -replace "\.", ""
         Write-Host "##vso[build.updatebuildnumber]$buildNumber"
         Write-Host "Updated  build number to '$buildNumber"
       name: SetBuildVersion
@@ -28,11 +28,11 @@ stages:
   dependsOn:
   - UpdateVersion
   variables:
-    assemblySemVer: $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.assemblySemVer']]
-    assemblySemFileVer: $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.assemblySemFileVer']]
-    informationalVersion: $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.informationalVersion']]
-    majorMinorPatch: $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.majorMinorPatch']]
-    nuGetVersion: $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.nuGetVersion']]
+    assemblySemVer: $[stageDependencies.UpdateVersion.Semver.outputs['DicomVersion.GitVersion.AssemblySemVer']]
+    assemblySemFileVer: $[stageDependencies.UpdateVersion.Semver.outputs['DicomVersion.GitVersion.AssemblySemFileVer']]
+    informationalVersion: $[stageDependencies.UpdateVersion.Semver.outputs['DicomVersion.GitVersion.InformationalVersion']]
+    majorMinorPatch: $[stageDependencies.UpdateVersion.Semver.outputs['DicomVersion.GitVersion.MajorMinorPatch']]
+    nuGetVersion: $[stageDependencies.UpdateVersion.Semver.outputs['DicomVersion.GitVersion.SemVer']]
   jobs:
   - job: Windows
     pool:

--- a/build/update-semver.yml
+++ b/build/update-semver.yml
@@ -15,12 +15,12 @@ steps:
       dotnet tool install GitVersion.Tool --version 5.6.6 --configfile nuget.config
       $GitVersion = dotnet tool run dotnet-gitversion /config GitVersion.yml /output json /nofetch | ConvertFrom-Json
 
-      Write-Host "##vso[task.setvariable variable=semVer]$(GitVersion.semVer)"
-      Write-Host "##vso[task.setvariable variable=informationalVersion;isOutput=true]$(GitVersion.informationalVersion)"
-      Write-Host "##vso[task.setvariable variable=majorMinorPatch;isOutput=true]$(GitVersion.majorMinorPatch)"
-      Write-Host "##vso[task.setvariable variable=nuGetVersion;isOutput=true]$(GitVersion.semVer)"
-      Write-Host "##vso[task.setvariable variable=assemblySemVer;isOutput=true]$(GitVersion.assemblySemVer)"
-      Write-Host "##vso[task.setvariable variable=assemblySemFileVer;isOutput=true]$(GitVersion.assemblySemFileVer)"
+      Write-Host "##vso[task.setvariable variable=semVer]$($GitVersion.semVer)"
+      Write-Host "##vso[task.setvariable variable=informationalVersion;isOutput=true]$($GitVersion.informationalVersion)"
+      Write-Host "##vso[task.setvariable variable=majorMinorPatch;isOutput=true]$($GitVersion.majorMinorPatch)"
+      Write-Host "##vso[task.setvariable variable=nuGetVersion;isOutput=true]$($GitVersion.semVer)"
+      Write-Host "##vso[task.setvariable variable=assemblySemVer;isOutput=true]$($GitVersion.assemblySemVer)"
+      Write-Host "##vso[task.setvariable variable=assemblySemFileVer;isOutput=true]$($GitVersion.assemblySemFileVer)"
     failOnStderr: true
     showWarnings: true
     pwsh: true

--- a/build/update-semver.yml
+++ b/build/update-semver.yml
@@ -20,6 +20,7 @@ steps:
       $GitVersion
 
       # Create variables
+      # (Avoid using variable syntax for Azure Pipelines)
       $semVer = $GitVersion.semVer
       $informationalVersion = $GitVersion.informationalVersion
       $majorMinorPatch = $GitVersion.majorMinorPatch
@@ -27,7 +28,7 @@ steps:
       $assemblySemFileVer = $GitVersion.assemblySemFileVer
 
       # Define output variables
-      Write-Host "##vso[task.setvariable variable=semVer;isOutput=true]$semVer"
+      Write-Host "##vso[task.setvariable variable=semVer]$semVer"
       Write-Host "##vso[task.setvariable variable=informationalVersion;isOutput=true]$informationalVersion"
       Write-Host "##vso[task.setvariable variable=majorMinorPatch;isOutput=true]$majorMinorPatch"
       Write-Host "##vso[task.setvariable variable=nuGetVersion;isOutput=true]$semVer"
@@ -37,13 +38,3 @@ steps:
     showWarnings: true
     pwsh: true
     workingDirectory: '$(Build.SourcesDirectory)'
-
-- powershell: |
-    Write-Host '----------Variables to use for build----------'
-    Write-Host 'semVer: $(semVer)'
-    Write-Host 'informationalVersion: $(informationalVersion)'
-    Write-Host 'majorMinorPatch: $(majorMinorPatch)'
-    Write-Host 'assemblySemVer: $(assemblySemVer)'
-    Write-Host 'assemblySemFileVer: $(assemblySemFileVer)'
-    Write-Host 'nuGetVersion: $(nuGetVersion)'
-  name: PrintVariablesFromGitVersion

--- a/build/update-semver.yml
+++ b/build/update-semver.yml
@@ -8,8 +8,8 @@ steps:
 - script: |
     pushd '$(Build.SourcesDirectory)'
     dotnet new tool-manifest
-    dotnet tool install GitVersion.Tool --version 5.6.6 --configfile 'nuget.config'
-    dotnet tool run GitVersion.Tool /config 'GitVersion.yml' /output buildserver /nofetch
+    dotnet tool install GitVersion.Tool --version 5.6.6 --configfile nuget.config
+    dotnet tool run GitVersion.Tool /config GitVersion.yml /output buildserver /nofetch
     popd
   name: 'GitVersion'
   displayName: 'Run GitVersion'

--- a/build/update-semver.yml
+++ b/build/update-semver.yml
@@ -11,16 +11,28 @@ steps:
   inputs:
     targetType: 'inline'
     script: |
+      # Derive version using the tool GitVersion
       dotnet new tool-manifest
       dotnet tool install GitVersion.Tool --version 5.6.6 --configfile nuget.config
       $GitVersion = dotnet tool run dotnet-gitversion /config GitVersion.yml /output json /nofetch | ConvertFrom-Json
 
-      Write-Host "##vso[task.setvariable variable=semVer]$($GitVersion.semVer)"
-      Write-Host "##vso[task.setvariable variable=informationalVersion;isOutput=true]$($GitVersion.informationalVersion)"
-      Write-Host "##vso[task.setvariable variable=majorMinorPatch;isOutput=true]$($GitVersion.majorMinorPatch)"
-      Write-Host "##vso[task.setvariable variable=nuGetVersion;isOutput=true]$($GitVersion.semVer)"
-      Write-Host "##vso[task.setvariable variable=assemblySemVer;isOutput=true]$($GitVersion.assemblySemVer)"
-      Write-Host "##vso[task.setvariable variable=assemblySemFileVer;isOutput=true]$($GitVersion.assemblySemFileVer)"
+      # Print
+      $GitVersion
+
+      # Create variables
+      $semVer = $GitVersion.semVer
+      $informationalVersion = $GitVersion.informationalVersion
+      $majorMinorPatch = $GitVersion.majorMinorPatch
+      $assemblySemVer = $GitVersion.assemblySemVer
+      $assemblySemFileVer = $GitVersion.assemblySemFileVer
+
+      # Define output variables
+      Write-Host "##vso[task.setvariable variable=semVer;isOutput=true]$semVer"
+      Write-Host "##vso[task.setvariable variable=informationalVersion;isOutput=true]$informationalVersion"
+      Write-Host "##vso[task.setvariable variable=majorMinorPatch;isOutput=true]$majorMinorPatch"
+      Write-Host "##vso[task.setvariable variable=nuGetVersion;isOutput=true]$semVer"
+      Write-Host "##vso[task.setvariable variable=assemblySemVer;isOutput=true]$assemblySemVer"
+      Write-Host "##vso[task.setvariable variable=assemblySemFileVer;isOutput=true]$assemblySemFileVer"
     failOnStderr: true
     showWarnings: true
     pwsh: true

--- a/build/update-semver.yml
+++ b/build/update-semver.yml
@@ -1,14 +1,13 @@
 steps:
 - task: UseDotNet@2
-  displayName: 'Use .NET Core sdk (for GitVersion)'
+  displayName: 'Use .NET Core Runtime'
   inputs:
-    packageType: sdk
-    version: 2.1.x
-    
-- task: GitVersion@5
-  displayName: 'GitVersion'
-  inputs:
-    configFilePath: '$(Build.SourcesDirectory)/GitVersion.yml'
+    packageType: runtime
+    version: 5.x
+
+- script: |
+    dotnet tool install GitVersion.Tool --version 5.6.6 --configfile '$(Build.SourcesDirectory)/nuget.config'
+    dotnet tool run GitVersion.Tool '$(Build.SourcesDirectory)' /config '$(Build.SourcesDirectory)/GitVersion.yml' /output buildserver /nofetch
 
 # Can set these: https://github.com/GitTools/actions/blob/master/gitversion/execute/action.yml
 - powershell: |

--- a/build/update-semver.yml
+++ b/build/update-semver.yml
@@ -13,21 +13,18 @@ steps:
     script: |
       dotnet new tool-manifest
       dotnet tool install GitVersion.Tool --version 5.6.6 --configfile nuget.config
-      dotnet tool run dotnet-gitversion /config GitVersion.yml /output buildserver /nofetch
+      $GitVersion = dotnet tool run dotnet-gitversion /config GitVersion.yml /output json /nofetch | ConvertFrom-Json
+
+      Write-Host "##vso[task.setvariable variable=semVer]$(GitVersion.semVer)"
+      Write-Host "##vso[task.setvariable variable=informationalVersion;isOutput=true]$(GitVersion.informationalVersion)"
+      Write-Host "##vso[task.setvariable variable=majorMinorPatch;isOutput=true]$(GitVersion.majorMinorPatch)"
+      Write-Host "##vso[task.setvariable variable=nuGetVersion;isOutput=true]$(GitVersion.semVer)"
+      Write-Host "##vso[task.setvariable variable=assemblySemVer;isOutput=true]$(GitVersion.assemblySemVer)"
+      Write-Host "##vso[task.setvariable variable=assemblySemFileVer;isOutput=true]$(GitVersion.assemblySemFileVer)"
     failOnStderr: true
     showWarnings: true
     pwsh: true
     workingDirectory: '$(Build.SourcesDirectory)'
-
-# Can set these: https://github.com/GitTools/actions/blob/master/gitversion/execute/action.yml
-- powershell: |
-    Write-Host "##vso[task.setvariable variable=semVer]$(GitVersion.semVer)"
-    Write-Host "##vso[task.setvariable variable=informationalVersion;isOutput=true]$(GitVersion.informationalVersion)"
-    Write-Host "##vso[task.setvariable variable=majorMinorPatch;isOutput=true]$(GitVersion.majorMinorPatch)"
-    Write-Host "##vso[task.setvariable variable=nuGetVersion;isOutput=true]$(GitVersion.semVer)"
-    Write-Host "##vso[task.setvariable variable=assemblySemVer;isOutput=true]$(GitVersion.assemblySemVer)"
-    Write-Host "##vso[task.setvariable variable=assemblySemFileVer;isOutput=true]$(GitVersion.assemblySemFileVer)"
-  name: SetVariablesFromGitVersion
 
 - powershell: |
     Write-Host '----------Variables to use for build----------'

--- a/build/update-semver.yml
+++ b/build/update-semver.yml
@@ -5,13 +5,19 @@ steps:
     packageType: sdk
     version: 5.x
 
-- script: |
-    pushd '$(Build.SourcesDirectory)'
-    dotnet tool install GitVersion.Tool --version 5.6.6 --configfile nuget.config --tool-path dotnet-tools
-    dotnet-tools\dotnet-gitversion.exe /config GitVersion.yml /output buildserver /nofetch
-    popd
+- task: PowerShell@2
   name: 'GitVersion'
   displayName: 'Run GitVersion'
+  inputs:
+    targetType: 'inline'
+    script: |
+      dotnet new tool-manifest
+      dotnet tool install GitVersion.Tool --version 5.6.6 --configfile nuget.config
+      dotnet tool run dotnet-gitversion /config GitVersion.yml /output buildserver /nofetch
+    failOnStderr: true
+    showWarnings: true
+    pwsh: true
+    workingDirectory: '$(Build.SourcesDirectory)'
 
 # Can set these: https://github.com/GitTools/actions/blob/master/gitversion/execute/action.yml
 - powershell: |

--- a/build/update-semver.yml
+++ b/build/update-semver.yml
@@ -1,13 +1,18 @@
 steps:
 - task: UseDotNet@2
-  displayName: 'Use .NET Core Runtime'
+  displayName: 'Use .NET Core 5.x'
   inputs:
-    packageType: runtime
+    packageType: sdk
     version: 5.x
 
 - script: |
-    dotnet tool install GitVersion.Tool --version 5.6.6 --configfile '$(Build.SourcesDirectory)/nuget.config'
-    dotnet tool run GitVersion.Tool '$(Build.SourcesDirectory)' /config '$(Build.SourcesDirectory)/GitVersion.yml' /output buildserver /nofetch
+    pushd '$(Build.SourcesDirectory)'
+    dotnet new tool-manifest
+    dotnet tool install GitVersion.Tool --version 5.6.6 --configfile 'nuget.config'
+    dotnet tool run GitVersion.Tool /config 'GitVersion.yml' /output buildserver /nofetch
+    popd
+  name: 'GitVersion'
+  displayName: 'Run GitVersion'
 
 # Can set these: https://github.com/GitTools/actions/blob/master/gitversion/execute/action.yml
 - powershell: |

--- a/build/update-semver.yml
+++ b/build/update-semver.yml
@@ -1,40 +1,15 @@
 steps:
-- task: UseDotNet@2
-  displayName: 'Use .NET Core 5.x'
+- task: gitversion/setup@0
+  displayName: 'Setup GitVersion'
   inputs:
-    packageType: sdk
-    version: 5.x
+    versionSpec: '5.x'
 
-- task: PowerShell@2
-  name: 'GitVersion'
+# All variables from the GitVersion task are prefixed by "GitVersion." (eg. GitVersion.SemVer)
+- task: gitversion/execute@0
+  name: 'DicomVersion'
   displayName: 'Run GitVersion'
   inputs:
-    targetType: 'inline'
-    script: |
-      # Derive version using the tool GitVersion
-      dotnet new tool-manifest
-      dotnet tool install GitVersion.Tool --version 5.6.6 --configfile nuget.config
-      $GitVersion = dotnet tool run dotnet-gitversion /config GitVersion.yml /output json /nofetch | ConvertFrom-Json
+    configFilePath: 'GitVersion.yml'
+    targetPath: '$(Build.SourcesDirectory)'
+    useConfigFile: true
 
-      # Print
-      $GitVersion
-
-      # Create variables
-      # (Avoid using variable syntax for Azure Pipelines)
-      $semVer = $GitVersion.semVer
-      $informationalVersion = $GitVersion.informationalVersion
-      $majorMinorPatch = $GitVersion.majorMinorPatch
-      $assemblySemVer = $GitVersion.assemblySemVer
-      $assemblySemFileVer = $GitVersion.assemblySemFileVer
-
-      # Define output variables
-      Write-Host "##vso[task.setvariable variable=semVer]$semVer"
-      Write-Host "##vso[task.setvariable variable=informationalVersion;isOutput=true]$informationalVersion"
-      Write-Host "##vso[task.setvariable variable=majorMinorPatch;isOutput=true]$majorMinorPatch"
-      Write-Host "##vso[task.setvariable variable=nuGetVersion;isOutput=true]$semVer"
-      Write-Host "##vso[task.setvariable variable=assemblySemVer;isOutput=true]$assemblySemVer"
-      Write-Host "##vso[task.setvariable variable=assemblySemFileVer;isOutput=true]$assemblySemFileVer"
-    failOnStderr: true
-    showWarnings: true
-    pwsh: true
-    workingDirectory: '$(Build.SourcesDirectory)'

--- a/build/update-semver.yml
+++ b/build/update-semver.yml
@@ -9,7 +9,7 @@ steps:
     pushd '$(Build.SourcesDirectory)'
     dotnet new tool-manifest
     dotnet tool install GitVersion.Tool --version 5.6.6 --configfile nuget.config
-    dotnet tool run GitVersion.Tool /config GitVersion.yml /output buildserver /nofetch
+    dotnet-gitversion /config GitVersion.yml /output buildserver /nofetch
     popd
   name: 'GitVersion'
   displayName: 'Run GitVersion'

--- a/build/update-semver.yml
+++ b/build/update-semver.yml
@@ -7,9 +7,8 @@ steps:
 
 - script: |
     pushd '$(Build.SourcesDirectory)'
-    dotnet new tool-manifest
-    dotnet tool install GitVersion.Tool --version 5.6.6 --configfile nuget.config
-    dotnet-gitversion /config GitVersion.yml /output buildserver /nofetch
+    dotnet tool install GitVersion.Tool --version 5.6.6 --configfile nuget.config --tool-path dotnet-tools
+    dotnet-tools\dotnet-gitversion.exe /config GitVersion.yml /output buildserver /nofetch
     popd
   name: 'GitVersion'
   displayName: 'Run GitVersion'


### PR DESCRIPTION
## Description
GitVersion seems to be erroneously labeling our main, and part of the effort to fix this is to:
1. Simplify the configuration to only specify what is necessary for mainline development using the GitHubFlow
2. Use the latest Azure Pipelines extension which simply installs and runs the dotnet tool `GitVersion.Tool`

## Related issues
[AB#80668](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/80668)

## Testing
Verify locally and in feature branch PR
