### PR TITLE
Categorize tests that will be run in Dicom Service.

### DIFF
--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/ChangeFeedTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/ChangeFeedTests.cs
@@ -27,8 +27,8 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             _client = fixture.Client;
         }
 
-        [Trait("Category", "paas")]
         [Fact]
+        [Trait("Category", "bvt")]
         public async Task GivenASetOfDicomInstances_WhenRetrievingChangeFeed_ThenTheExpectedInstanceAreReturned()
         {
             var studyInstanceUid = TestUidGenerator.Generate();

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/ChangeFeedTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/ChangeFeedTests.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             _client = fixture.Client;
         }
 
+        [Trait("Category", "paas")]
         [Fact]
         public async Task GivenASetOfDicomInstances_WhenRetrievingChangeFeed_ThenTheExpectedInstanceAreReturned()
         {

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/DeleteTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/DeleteTests.cs
@@ -24,8 +24,8 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             _client = fixture.Client;
         }
 
-        [Trait("Category", "paas")]
         [Fact]
+        [Trait("Category", "bvt")]
         public async Task GivenAnExistingInstance_WhenDeletingInstance_TheServerShouldReturnNoContentAndAllLevelsShouldBeRemoved()
         {
             var studyInstanceUid = TestUidGenerator.Generate();

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/DeleteTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/DeleteTests.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             _client = fixture.Client;
         }
 
+        [Trait("Category", "paas")]
         [Fact]
         public async Task GivenAnExistingInstance_WhenDeletingInstance_TheServerShouldReturnNoContentAndAllLevelsShouldBeRemoved()
         {

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/DicomRetrieveMetadataTransactionTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/DicomRetrieveMetadataTransactionTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
         }
 
         [Fact]
-        [Trait("Category", "paas")]
+        [Trait("Category", "bvt")]
         public async Task GivenStoredDicomFile_WhenRetrievingMetadataForStudy_ThenMetadataIsRetrievedCorrectly()
         {
             string studyInstanceUid = TestUidGenerator.Generate();

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/DicomRetrieveMetadataTransactionTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/DicomRetrieveMetadataTransactionTests.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
         }
 
         [Fact]
+        [Trait("Category", "paas")]
         public async Task GivenStoredDicomFile_WhenRetrievingMetadataForStudy_ThenMetadataIsRetrievedCorrectly()
         {
             string studyInstanceUid = TestUidGenerator.Generate();

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/QueryTransactionTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/QueryTransactionTests.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
         }
 
+        [Trait("Category", "paas")]
         [Fact]
         public async Task GivenSearchRequest_AllStudyLevel_MatchResult()
         {

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/QueryTransactionTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/QueryTransactionTests.cs
@@ -49,8 +49,8 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
         }
 
-        [Trait("Category", "paas")]
         [Fact]
+        [Trait("Category", "bvt")]
         public async Task GivenSearchRequest_AllStudyLevel_MatchResult()
         {
             DicomDataset matchInstance = await PostDicomFileAsync(new DicomDataset()

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Instance.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Instance.cs
@@ -77,6 +77,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
         }
 
         [Fact]
+        [Trait("Category", "paas")]
         public async Task GivenUnsupportedInternalTransferSyntax_WhenRetrieveInstanceWithOriginalTransferSyntax_ThenServerShouldReturnOriginalContent()
         {
             var studyInstanceUid = TestUidGenerator.Generate();

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Instance.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Instance.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
         }
 
         [Fact]
-        [Trait("Category", "paas")]
+        [Trait("Category", "bvt")]
         public async Task GivenUnsupportedInternalTransferSyntax_WhenRetrieveInstanceWithOriginalTransferSyntax_ThenServerShouldReturnOriginalContent()
         {
             var studyInstanceUid = TestUidGenerator.Generate();

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/StoreTransactionTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/StoreTransactionTests.cs
@@ -210,6 +210,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
         }
 
         [Fact]
+        [Trait("Category", "paas")]
         public async Task GivenOneDifferentStudyInstanceUID_WhenStoringWithProvidedStudyInstanceUID_TheServerShouldReturnAccepted()
         {
             var studyInstanceUID1 = TestUidGenerator.Generate();
@@ -344,6 +345,8 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
         }
 
         [Fact]
+        [Trait("Category", "paas")]
+
         public async Task StoreSinglepart_ServerShouldReturnOK()
         {
             DicomFile dicomFile = Samples.CreateRandomDicomFile();

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/StoreTransactionTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/StoreTransactionTests.cs
@@ -210,7 +210,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
         }
 
         [Fact]
-        [Trait("Category", "paas")]
+        [Trait("Category", "bvt")]
         public async Task GivenOneDifferentStudyInstanceUID_WhenStoringWithProvidedStudyInstanceUID_TheServerShouldReturnAccepted()
         {
             var studyInstanceUID1 = TestUidGenerator.Generate();
@@ -345,8 +345,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
         }
 
         [Fact]
-        [Trait("Category", "paas")]
-
+        [Trait("Category", "bvt")]
         public async Task StoreSinglepart_ServerShouldReturnOK()
         {
             DicomFile dicomFile = Samples.CreateRandomDicomFile();


### PR DESCRIPTION
## Description
Mark E2E tests with Trait attribute. 
This will be used has a filter to select the tests run in PaaS

## Related issues
[AB#76726](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/76726)

## Testing
dotnet test --filter Category=bvt