### PR TITLE
Enable Extended Query Tag End to end test on PR pipeline

### DIFF
--- a/build/deploy.yml
+++ b/build/deploy.yml
@@ -26,6 +26,7 @@ jobs:
         $additionalProperties = @{
             "SqlServer__DeleteAllDataOnStartup" = "true"
             "DicomServer__Security__Authorization__Enabled" = "true"
+            "DicomServer__Features__EnableExtendedQueryTags" = "true"
         }
     
         $templateParameters = @{

--- a/src/Microsoft.Health.Dicom.Client/DicomWebClient.cs
+++ b/src/Microsoft.Health.Dicom.Client/DicomWebClient.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Health.Dicom.Client
     {
         private const string TransferSyntaxHeaderName = "transfer-syntax";
 
-        private const string BaseExtendedQueryTagUri = "/tags";
+        private const string BaseExtendedQueryTagUri = "/extendedquerytags";
 
         private readonly JsonSerializerSettings _jsonSerializerSettings;
 

--- a/src/Microsoft.Health.Dicom.Client/Models/ExtendedQueryTag.cs
+++ b/src/Microsoft.Health.Dicom.Client/Models/ExtendedQueryTag.cs
@@ -30,5 +30,10 @@ namespace Microsoft.Health.Dicom.Client.Models
         /// Status of this tag.
         /// </summary>
         public ExtendedQueryTagStatus Status { get; set; }
+
+        /// <summary>
+        /// Identification code of private tag implementer.
+        /// </summary>
+        public string PrivateCreator { get; set; }
     }
 }

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/ExtendedQueryTagTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/ExtendedQueryTagTests.cs
@@ -28,13 +28,18 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             _client = fixture.Client;
         }
 
-        [Fact(Skip = "Feature Not Enabled")]
+        [Fact]
         public async Task GivenValidExtendedQueryTags_WhenGoThroughEndToEndScenario_ThenShouldSucceed()
         {
             // Prepare 3 extended query tags.
             // One is private tag on Instance level
-            DicomTag privateTag = new DicomTag(0x0407, 0x1001, "PrivateCreator1");
-            ExtendedQueryTag privateQueryTag = new ExtendedQueryTag { Path = privateTag.GetPath(), VR = DicomVRCode.SS, Level = QueryTagLevel.Instance };
+            // To add private tag, need to add identification code element at first.
+            DicomTag identificationCodeTag = new DicomTag(0x0407, 0x0010);
+            string privateCreatorName = "PrivateCreator1";
+            DicomElement identificationCodeElement = new DicomLongString(identificationCodeTag, privateCreatorName);
+
+            DicomTag privateTag = new DicomTag(0x0407, 0x1001, privateCreatorName);
+            ExtendedQueryTag privateQueryTag = new ExtendedQueryTag { Path = privateTag.GetPath(), VR = DicomVRCode.SS, Level = QueryTagLevel.Instance, PrivateCreator = privateTag.PrivateCreator.Creator };
 
             // One is standard tag on Series level
             DicomTag standardTagSeries = DicomTag.ManufacturerModelName;
@@ -56,19 +61,22 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
 
             // One is on seriesUid1 and instanceUid1
             DicomDataset dataset1 = Samples.CreateRandomInstanceDataset(studyInstanceUid: studyUid, seriesInstanceUid: seriesUid1, sopInstanceUid: instanceUid1);
-            dataset1.Add(new DicomSignedShort(privateTag, 1));
+            dataset1.Add(identificationCodeElement);
+            dataset1.AddOrUpdate(new DicomSignedShort(privateTag, 1));
             dataset1.Add(standardTagSeries, "ManufacturerModelName1");
             dataset1.Add(standardTagStudy, "0");
 
             // One is on seriesUid1 and instanceUid2
             DicomDataset dataset2 = Samples.CreateRandomInstanceDataset(studyInstanceUid: studyUid, seriesInstanceUid: seriesUid1, sopInstanceUid: instanceUid2);
-            dataset2.Add(new DicomSignedShort(privateTag, 2));
+            dataset2.Add(identificationCodeElement);
+            dataset2.AddOrUpdate(new DicomSignedShort(privateTag, 2));
             dataset2.Add(standardTagSeries, "ManufacturerModelName2");
             dataset2.Add(standardTagStudy, "0");
 
             // One is on seriesUid2 and instanceUid3
             DicomDataset dataset3 = Samples.CreateRandomInstanceDataset(studyInstanceUid: studyUid, seriesInstanceUid: seriesUid2, sopInstanceUid: instanceUid3);
-            dataset3.Add(new DicomSignedShort(privateTag, 3));
+            dataset3.Add(identificationCodeElement);
+            dataset3.AddOrUpdate(new DicomSignedShort(privateTag, 3));
             dataset3.Add(standardTagSeries, "ManufacturerModelName3");
             dataset3.Add(standardTagStudy, "1");
             try

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/ExtendedQueryTagTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/ExtendedQueryTagTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
     public class ExtendedQueryTagTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
     {
         private readonly IDicomWebClient _client;
-
+        private const string PrivateCreatorName = "PrivateCreator1";
         public ExtendedQueryTagTests(HttpIntegrationTestFixture<Startup> fixture)
         {
             EnsureArg.IsNotNull(fixture, nameof(fixture));
@@ -35,10 +35,10 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             // One is private tag on Instance level
             // To add private tag, need to add identification code element at first.
             DicomTag identificationCodeTag = new DicomTag(0x0407, 0x0010);
-            string privateCreatorName = "PrivateCreator1";
-            DicomElement identificationCodeElement = new DicomLongString(identificationCodeTag, privateCreatorName);
 
-            DicomTag privateTag = new DicomTag(0x0407, 0x1001, privateCreatorName);
+            DicomElement identificationCodeElement = new DicomLongString(identificationCodeTag, PrivateCreatorName);
+
+            DicomTag privateTag = new DicomTag(0x0407, 0x1001, PrivateCreatorName);
             ExtendedQueryTag privateQueryTag = new ExtendedQueryTag { Path = privateTag.GetPath(), VR = DicomVRCode.SS, Level = QueryTagLevel.Instance, PrivateCreator = privateTag.PrivateCreator.Creator };
 
             // One is standard tag on Series level


### PR DESCRIPTION
## Description
Enable Extended Query Tag End to end test on PR pipeline

## Related issues
Addresses [AB#80541](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/80541)

## Testing
Locally test pass
