### PR TITLE
Update QIDO to use QueryTagService

### DIFF
--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Extensions/ExtendedQueryTagEntryExtensionsTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Extensions/ExtendedQueryTagEntryExtensionsTests.cs
@@ -31,8 +31,8 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Extensions
         [InlineData("   ")]
         public void GivenPrivateTagWithNonEmptyPrivateCreator_WhenNormalizing_ThenPrivateCreatorShouldBeNull(string privateCreator)
         {
-            DicomTag tag1 = new DicomTag(0x0405, 0x1001, "PrivateCreator1");
-            ExtendedQueryTagEntry normalized = tag1.BuildExtendedQueryTagEntry(vr: DicomVRCode.CS, privateCreator: privateCreator).Normalize(ExtendedQueryTagStatus.Ready);
+            DicomTag tag1 = new DicomTag(0x0405, 0x1001);
+            ExtendedQueryTagEntry normalized = new ExtendedQueryTagEntry() { Level = QueryTagLevel.Instance, Path = tag1.GetPath(), PrivateCreator = privateCreator, VR = DicomVRCode.CS }.Normalize(ExtendedQueryTagStatus.Ready);
             Assert.Null(normalized.PrivateCreator);
         }
 

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/QueryTagTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/QueryTagTests.cs
@@ -16,13 +16,12 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.ExtendedQueryTag
         public void GivenCoreDicomTag_WhenInitialize_ThenShouldCreatedSuccessfully()
         {
             DicomTag tag = DicomTag.PatientName;
-            QueryTagLevel level = QueryTagLevel.Instance;
-            QueryTag queryTag = new QueryTag(tag, QueryTagLevel.Instance);
+            QueryTag queryTag = new QueryTag(tag);
             Assert.Equal(tag, queryTag.Tag);
             Assert.Equal(DicomVR.PN, queryTag.VR);
             Assert.Null(queryTag.ExtendedQueryTagStoreEntry);
             Assert.False(queryTag.IsExtendedQueryTag);
-            Assert.Equal(level, queryTag.Level);
+            Assert.Equal(QueryTagLevel.Study, queryTag.Level);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Query/DicomQueryServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Query/DicomQueryServiceTests.cs
@@ -4,8 +4,8 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
-using Dicom;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Dicom.Core.Exceptions;
 using Microsoft.Health.Dicom.Core.Features.Common;
@@ -15,6 +15,7 @@ using Microsoft.Health.Dicom.Core.Features.Query;
 using Microsoft.Health.Dicom.Core.Features.Query.Model;
 using Microsoft.Health.Dicom.Core.Messages.Query;
 using Microsoft.Health.Dicom.Tests.Common;
+using Microsoft.Health.Dicom.Tests.Common.Comparers;
 using NSubstitute;
 using Xunit;
 
@@ -25,19 +26,20 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         private readonly QueryService _queryService;
         private readonly IQueryParser _queryParser;
         private readonly IQueryStore _queryStore;
-        private readonly IExtendedQueryTagStore _extendedQueryTagStore;
+        private readonly IQueryTagService _queryTagService;
+
 
         public DicomQueryServiceTests()
         {
             _queryParser = Substitute.For<IQueryParser>();
             _queryStore = Substitute.For<IQueryStore>();
-            _extendedQueryTagStore = Substitute.For<IExtendedQueryTagStore>();
+            _queryTagService = Substitute.For<IQueryTagService>();
+
             _queryService = new QueryService(
                 _queryParser,
                 _queryStore,
                 Substitute.For<IMetadataStore>(),
-                _extendedQueryTagStore,
-                new DicomTagParser());
+                _queryTagService);
         }
 
         [Theory]
@@ -84,16 +86,12 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
                 new ExtendedQueryTagStoreEntry(3, "00101005", "PN", null, QueryTagLevel.Study, ExtendedQueryTagStatus.Ready),
             };
 
-            _extendedQueryTagStore.GetExtendedQueryTagsAsync().ReturnsForAnyArgs(storeEntries);
+            var list = QueryTagService.CoreQueryTags.Concat(storeEntries.Select(item => new QueryTag(item))).ToList();
+            _queryTagService.GetQueryTagsAsync().ReturnsForAnyArgs(list);
             _queryStore.QueryAsync(Arg.Any<QueryExpression>(), Arg.Any<CancellationToken>()).ReturnsForAnyArgs(new QueryResult(new List<VersionedInstanceIdentifier>()));
             await _queryService.QueryAsync(request, CancellationToken.None);
 
-            Dictionary<DicomTag, ExtendedQueryTagFilterDetails> filterDetails = new Dictionary<DicomTag, ExtendedQueryTagFilterDetails>();
-            filterDetails.Add(DicomTag.ProcedureStepState, new ExtendedQueryTagFilterDetails(1, QueryTagLevel.Instance, DicomVR.CS, DicomTag.ProcedureStepState));
-            filterDetails.Add(DicomTag.Date, new ExtendedQueryTagFilterDetails(2, QueryTagLevel.Series, DicomVR.DA, DicomTag.Date));
-            filterDetails.Add(DicomTag.PatientBirthName, new ExtendedQueryTagFilterDetails(3, QueryTagLevel.Study, DicomVR.PN, DicomTag.PatientBirthName));
-
-            _queryParser.Received().Parse(request, Arg.Do<IDictionary<DicomTag, ExtendedQueryTagFilterDetails>>(x => Assert.Equal(x, filterDetails)));
+            _queryParser.Received().Parse(request, Arg.Do<IReadOnlyCollection<QueryTag>>(x => Assert.Equal(x, list, QueryTagComparer.Default)));
         }
 
         [Theory]
@@ -114,15 +112,11 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
                 new ExtendedQueryTagStoreEntry(3, "00101005", "PN", null, QueryTagLevel.Study, ExtendedQueryTagStatus.Ready),
             };
 
-            _extendedQueryTagStore.GetExtendedQueryTagsAsync().ReturnsForAnyArgs(storeEntries);
+            var list = QueryTagService.CoreQueryTags.Concat(storeEntries.Select(item => new QueryTag(item))).ToList();
             _queryStore.QueryAsync(Arg.Any<QueryExpression>(), Arg.Any<CancellationToken>()).ReturnsForAnyArgs(new QueryResult(new List<VersionedInstanceIdentifier>()));
             await _queryService.QueryAsync(request, CancellationToken.None);
 
-            Dictionary<DicomTag, ExtendedQueryTagFilterDetails> filterDetails = new Dictionary<DicomTag, ExtendedQueryTagFilterDetails>();
-            filterDetails.Add(DicomTag.Date, new ExtendedQueryTagFilterDetails(2, QueryTagLevel.Series, DicomVR.DA, DicomTag.Date));
-            filterDetails.Add(DicomTag.PatientBirthName, new ExtendedQueryTagFilterDetails(3, QueryTagLevel.Study, DicomVR.PN, DicomTag.PatientBirthName));
-
-            _queryParser.Received().Parse(request, Arg.Do<IDictionary<DicomTag, ExtendedQueryTagFilterDetails>>(x => Assert.Equal(x, filterDetails)));
+            _queryParser.Received().Parse(request, Arg.Do<IReadOnlyCollection<QueryTag>>(x => Assert.Equal(x, list, QueryTagComparer.Default)));
         }
 
         [Theory]
@@ -142,14 +136,11 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
                 new ExtendedQueryTagStoreEntry(3, "00101005", "PN", null, QueryTagLevel.Study, ExtendedQueryTagStatus.Ready),
             };
 
-            _extendedQueryTagStore.GetExtendedQueryTagsAsync().ReturnsForAnyArgs(storeEntries);
+            var list = QueryTagService.CoreQueryTags.Concat(storeEntries.Select(item => new QueryTag(item))).ToList();
             _queryStore.QueryAsync(Arg.Any<QueryExpression>(), Arg.Any<CancellationToken>()).ReturnsForAnyArgs(new QueryResult(new List<VersionedInstanceIdentifier>()));
             await _queryService.QueryAsync(request, CancellationToken.None);
 
-            Dictionary<DicomTag, ExtendedQueryTagFilterDetails> filterDetails = new Dictionary<DicomTag, ExtendedQueryTagFilterDetails>();
-            filterDetails.Add(DicomTag.PatientBirthName, new ExtendedQueryTagFilterDetails(3, QueryTagLevel.Study, DicomVR.PN, DicomTag.PatientBirthName));
-
-            _queryParser.Received().Parse(request, Arg.Do<IDictionary<DicomTag, ExtendedQueryTagFilterDetails>>(x => Assert.Equal(x, filterDetails)));
+            _queryParser.Received().Parse(request, Arg.Do<IReadOnlyCollection<QueryTag>>(x => Assert.Equal(x, list, QueryTagComparer.Default)));
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Query/QueryParserTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Query/QueryParserTests.cs
@@ -16,6 +16,7 @@ using Microsoft.Health.Dicom.Core.Features.Query;
 using Microsoft.Health.Dicom.Core.Features.Query.Model;
 using Microsoft.Health.Dicom.Core.Messages.Query;
 using Microsoft.Health.Dicom.Tests.Common;
+using Microsoft.Health.Dicom.Tests.Common.Extensions;
 using Xunit;
 
 namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
@@ -45,7 +46,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         public void GivenIncludeField_WithValueAll_CheckAllValue(string key, string value)
         {
             QueryExpression queryExpression = _queryParser
-                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), null);
+                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), QueryTagService.CoreQueryTags);
             Assert.True(queryExpression.IncludeFields.All);
         }
 
@@ -54,7 +55,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         public void GivenIncludeField_WithInvalidAttributeId_Throws(string key, string value)
         {
             Assert.Throws<QueryParseException>(() => _queryParser
-                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), null));
+                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), QueryTagService.CoreQueryTags));
         }
 
         [Theory]
@@ -71,7 +72,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         public void GivenIncludeField_WithUnknownAttributeId_Throws(string key, string value)
         {
             Assert.Throws<QueryParseException>(() => _queryParser
-                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), null));
+                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), QueryTagService.CoreQueryTags));
         }
 
         [Theory]
@@ -80,11 +81,11 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         public void GivenFilterCondition_ValidTag_CheckProperties(string key, string value)
         {
             QueryExpression queryExpression = _queryParser
-                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), null);
+                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), QueryTagService.CoreQueryTags);
             Assert.True(queryExpression.HasFilters);
             var singleValueCond = queryExpression.FilterConditions.First() as StringSingleValueMatchCondition;
             Assert.NotNull(singleValueCond);
-            Assert.True(singleValueCond.DicomTag == DicomTag.PatientName);
+            Assert.True(singleValueCond.QueryTag.Tag == DicomTag.PatientName);
             Assert.True(singleValueCond.Value == value);
         }
 
@@ -93,11 +94,11 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         public void GivenFilterCondition_ValidReferringPhysicianNameTag_CheckProperties(string key, string value)
         {
             QueryExpression queryExpression = _queryParser
-                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), null);
+                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), QueryTagService.CoreQueryTags);
             Assert.True(queryExpression.HasFilters);
             var singleValueCond = queryExpression.FilterConditions.First() as StringSingleValueMatchCondition;
             Assert.NotNull(singleValueCond);
-            Assert.Equal(DicomTag.ReferringPhysicianName, singleValueCond.DicomTag);
+            Assert.Equal(DicomTag.ReferringPhysicianName, singleValueCond.QueryTag.Tag);
             Assert.Equal(value, singleValueCond.Value);
         }
 
@@ -106,7 +107,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         public void GivenFilterCondition_WithNotSupportedTag_Throws(string key, string value)
         {
             Assert.Throws<QueryParseException>(() => _queryParser
-                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), null));
+                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), QueryTagService.CoreQueryTags));
         }
 
         [Theory]
@@ -117,7 +118,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         public void GivenFilterCondition_WithKnownTagButNotSupportedAtLevel_Throws(string key, string value, QueryResource resourceType)
         {
             Assert.Throws<QueryParseException>(() => _queryParser
-                .Parse(CreateRequest(GetQueryCollection(key, value), resourceType), null));
+                .Parse(CreateRequest(GetQueryCollection(key, value), resourceType), QueryTagService.CoreQueryTags));
         }
 
         [Theory]
@@ -127,124 +128,105 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         public void GivenFilterCondition_WithValidQueryString_ParseSucceeds(string queryString, QueryResource resourceType)
         {
             EnsureArg.IsNotNull(queryString, nameof(queryString));
-            _queryParser.Parse(CreateRequest(GetQueryCollection(queryString), resourceType), null);
+            _queryParser.Parse(CreateRequest(GetQueryCollection(queryString), resourceType), QueryTagService.CoreQueryTags);
+        }
+
+        [Fact]
+        public void GivenExtendedQueryPrivateTag_WithUrl_ParseSucceeds()
+        {
+            DicomTag tag = new DicomTag(0x0405, 0x1001, "PrivateCreator1");
+            string value = "Test";
+            var queryString = $"{tag.GetPath()}={value}";
+            QueryTag queryTag = new QueryTag(tag.BuildExtendedQueryTagStoreEntry(vr: DicomVRCode.CS, level: QueryTagLevel.Study));
+
+            QueryExpression queryExpression = _queryParser.Parse(CreateRequest(GetQueryCollection(queryString), QueryResource.AllStudies), new[] { queryTag });
+            Assert.Equal(queryTag, queryExpression.FilterConditions.First().QueryTag);
         }
 
         [Fact]
         public void GivenExtendedQueryDateTag_WithUrl_ParseSucceeds()
         {
             var queryString = "Date=19510910-20200220";
-            var extendedQueryTags = new Dictionary<DicomTag, ExtendedQueryTagFilterDetails>();
-            var filterDetails = new ExtendedQueryTagFilterDetails(1, QueryTagLevel.Instance, DicomTag.Date.GetDefaultVR(), DicomTag.Date);
-            extendedQueryTags.Add(DicomTag.Date, filterDetails);
-            EnsureArg.IsNotNull(queryString, nameof(queryString));
-            QueryExpression queryExpression = _queryParser.Parse(CreateRequest(GetQueryCollection(queryString), QueryResource.AllStudies), extendedQueryTags);
-            Assert.Contains(filterDetails, queryExpression.QueriedExtendedQueryTagFilterDetails);
-            Assert.Equal(filterDetails, queryExpression.FilterConditions.First().ExtendedQueryTagFilterDetails);
+            QueryTag queryTag = new QueryTag(DicomTag.Date.BuildExtendedQueryTagStoreEntry(level: QueryTagLevel.Study));
+
+            QueryExpression queryExpression = _queryParser.Parse(CreateRequest(GetQueryCollection(queryString), QueryResource.AllStudies), new[] { queryTag });
+            Assert.Equal(queryTag, queryExpression.FilterConditions.First().QueryTag);
         }
 
         [Fact]
         public void GivenExtendedQueryPersonNameTag_WithUrl_ParseSucceeds()
         {
             var queryString = "PatientBirthName=Joe&fuzzyMatching=true&limit=50";
-            var extendedQueryTags = new Dictionary<DicomTag, ExtendedQueryTagFilterDetails>();
-            var filterDetails = new ExtendedQueryTagFilterDetails(1, QueryTagLevel.Series, DicomTag.PatientBirthName.GetDefaultVR(), DicomTag.PatientBirthName);
-            extendedQueryTags.Add(DicomTag.PatientBirthName, filterDetails);
-            EnsureArg.IsNotNull(queryString, nameof(queryString));
-            QueryExpression queryExpression = _queryParser.Parse(CreateRequest(GetQueryCollection(queryString), QueryResource.AllSeries), extendedQueryTags);
-            Assert.Contains(filterDetails, queryExpression.QueriedExtendedQueryTagFilterDetails);
+            QueryTag queryTag = new QueryTag(DicomTag.PatientBirthName.BuildExtendedQueryTagStoreEntry(level: QueryTagLevel.Series));
+
+            QueryExpression queryExpression = _queryParser.Parse(CreateRequest(GetQueryCollection(queryString), QueryResource.AllSeries), new[] { queryTag });
+            Assert.Equal(queryTag, queryExpression.FilterConditions.First().QueryTag);
         }
 
         [Fact]
         public void GivenExtendedQueryStringTag_WithUrl_ParseSucceeds()
         {
             var queryString = "ModelGroupUID=abc";
-            var extendedQueryTags = new Dictionary<DicomTag, ExtendedQueryTagFilterDetails>();
-            var filterDetails = new ExtendedQueryTagFilterDetails(1, QueryTagLevel.Series, DicomTag.ModelGroupUID.GetDefaultVR(), DicomTag.ModelGroupUID);
-            extendedQueryTags.Add(DicomTag.ModelGroupUID, filterDetails);
-            EnsureArg.IsNotNull(queryString, nameof(queryString));
-            QueryExpression queryExpression = _queryParser.Parse(CreateRequest(GetQueryCollection(queryString), QueryResource.AllSeries), extendedQueryTags);
-            Assert.Contains(filterDetails, queryExpression.QueriedExtendedQueryTagFilterDetails);
-            Assert.Equal(filterDetails, queryExpression.FilterConditions.First().ExtendedQueryTagFilterDetails);
+            QueryTag queryTag = new QueryTag(DicomTag.ModelGroupUID.BuildExtendedQueryTagStoreEntry(level: QueryTagLevel.Series));
+            QueryExpression queryExpression = _queryParser.Parse(CreateRequest(GetQueryCollection(queryString), QueryResource.AllSeries), new[] { queryTag });
+            Assert.Equal(queryTag, queryExpression.FilterConditions.First().QueryTag);
         }
 
         [Fact]
         public void GivenExtendedQueryStringTag_WithTagPathUrl_ParseSucceeds()
         {
             var queryString = "00687004=abc";
-            var extendedQueryTags = new Dictionary<DicomTag, ExtendedQueryTagFilterDetails>();
-            var filterDetails = new ExtendedQueryTagFilterDetails(1, QueryTagLevel.Series, DicomTag.ModelGroupUID.GetDefaultVR(), DicomTag.ModelGroupUID);
-            extendedQueryTags.Add(DicomTag.ModelGroupUID, filterDetails);
-            EnsureArg.IsNotNull(queryString, nameof(queryString));
-            QueryExpression queryExpression = _queryParser.Parse(CreateRequest(GetQueryCollection(queryString), QueryResource.AllSeries), extendedQueryTags);
-            Assert.Contains(filterDetails, queryExpression.QueriedExtendedQueryTagFilterDetails);
-            Assert.Equal(filterDetails, queryExpression.FilterConditions.First().ExtendedQueryTagFilterDetails);
+            QueryTag queryTag = new QueryTag(DicomTag.ModelGroupUID.BuildExtendedQueryTagStoreEntry(level: QueryTagLevel.Series));
+            QueryExpression queryExpression = _queryParser.Parse(CreateRequest(GetQueryCollection(queryString), QueryResource.AllSeries), new[] { queryTag });
+            Assert.Equal(queryTag, queryExpression.FilterConditions.First().QueryTag);
         }
 
         [Fact]
         public void GivenExtendedQueryLongTag_WithUrl_ParseSucceeds()
         {
             var queryString = "NumberOfAssessmentObservations=50";
-            var extendedQueryTags = new Dictionary<DicomTag, ExtendedQueryTagFilterDetails>();
-            var filterDetails = new ExtendedQueryTagFilterDetails(1, QueryTagLevel.Series, DicomTag.NumberOfAssessmentObservations.GetDefaultVR(), DicomTag.NumberOfAssessmentObservations);
-            extendedQueryTags.Add(DicomTag.NumberOfAssessmentObservations, filterDetails);
-            EnsureArg.IsNotNull(queryString, nameof(queryString));
-            QueryExpression queryExpression = _queryParser.Parse(CreateRequest(GetQueryCollection(queryString), QueryResource.AllSeries), extendedQueryTags);
-            Assert.Contains(filterDetails, queryExpression.QueriedExtendedQueryTagFilterDetails);
-            Assert.Equal(filterDetails, queryExpression.FilterConditions.First().ExtendedQueryTagFilterDetails);
+            QueryTag queryTag = new QueryTag(DicomTag.NumberOfAssessmentObservations.BuildExtendedQueryTagStoreEntry(level: QueryTagLevel.Series));
+            QueryExpression queryExpression = _queryParser.Parse(CreateRequest(GetQueryCollection(queryString), QueryResource.AllSeries), new[] { queryTag });
+            Assert.Equal(queryTag, queryExpression.FilterConditions.First().QueryTag);
         }
 
         [Fact]
         public void GivenExtendedQueryDoubleTag_WithUrl_ParseSucceeds()
         {
             var queryString = "FloatingPointValue=1.1";
-            var extendedQueryTags = new Dictionary<DicomTag, ExtendedQueryTagFilterDetails>();
-            var filterDetails = new ExtendedQueryTagFilterDetails(1, QueryTagLevel.Series, DicomTag.FloatingPointValue.GetDefaultVR(), DicomTag.FloatingPointValue);
-            extendedQueryTags.Add(DicomTag.FloatingPointValue, filterDetails);
-            EnsureArg.IsNotNull(queryString, nameof(queryString));
-            QueryExpression queryExpression = _queryParser.Parse(CreateRequest(GetQueryCollection(queryString), QueryResource.AllSeries), extendedQueryTags);
-            Assert.Contains(filterDetails, queryExpression.QueriedExtendedQueryTagFilterDetails);
-            Assert.Equal(filterDetails, queryExpression.FilterConditions.First().ExtendedQueryTagFilterDetails);
+            QueryTag queryTag = new QueryTag(DicomTag.FloatingPointValue.BuildExtendedQueryTagStoreEntry(level: QueryTagLevel.Series));
+            QueryExpression queryExpression = _queryParser.Parse(CreateRequest(GetQueryCollection(queryString), QueryResource.AllSeries), new[] { queryTag });
+            Assert.Equal(queryTag, queryExpression.FilterConditions.First().QueryTag);
         }
 
         [Fact]
         public void GivenExtendedQueryDoubleTagWithInvalidValue_WithUrl_ParseFails()
         {
             var queryString = "FloatingPointValue=abc";
-            var extendedQueryTags = new Dictionary<DicomTag, ExtendedQueryTagFilterDetails>();
-            var filterDetails = new ExtendedQueryTagFilterDetails(1, QueryTagLevel.Series, DicomTag.FloatingPointValue.GetDefaultVR(), DicomTag.FloatingPointValue);
-            extendedQueryTags.Add(DicomTag.FloatingPointValue, filterDetails);
-            EnsureArg.IsNotNull(queryString, nameof(queryString));
+            QueryTag queryTag = new QueryTag(DicomTag.FloatingPointValue.BuildExtendedQueryTagStoreEntry(level: QueryTagLevel.Series));
             Assert.Throws<QueryParseException>(() => _queryParser
-                .Parse(CreateRequest(GetQueryCollection(queryString), QueryResource.AllStudies), extendedQueryTags));
+                .Parse(CreateRequest(GetQueryCollection(queryString), QueryResource.AllStudies), new[] { queryTag }));
         }
 
         [Fact]
         public void GivenNonExistingExtendedQueryStringTag_WithUrl_ParseFails()
         {
             var queryString = "ModelGroupUID=abc";
-            var extendedQueryTags = new Dictionary<DicomTag, ExtendedQueryTagFilterDetails>();
-            var filterDetails = new ExtendedQueryTagFilterDetails(1, QueryTagLevel.Series, DicomTag.FloatingPointValue.GetDefaultVR(), DicomTag.FloatingPointValue);
-            extendedQueryTags.Add(DicomTag.FloatingPointValue, filterDetails);
-            EnsureArg.IsNotNull(queryString, nameof(queryString));
+            QueryTag queryTag = new QueryTag(DicomTag.FloatingPointValue.BuildExtendedQueryTagStoreEntry(level: QueryTagLevel.Series));
             Assert.Throws<QueryParseException>(() => _queryParser
-                .Parse(CreateRequest(GetQueryCollection(queryString), QueryResource.AllStudies), extendedQueryTags));
+                .Parse(CreateRequest(GetQueryCollection(queryString), QueryResource.AllStudies), new[] { queryTag }));
         }
 
         [Fact]
         public void GivenCombinationOfExtendedQueryAndStandardTags_WithUrl_ParseSucceeds()
         {
             var queryString = "PatientName=Joe&FloatingPointValue=1.1&StudyDate=19510910-20200220&00687004=abc";
-            var extendedQueryTags = new Dictionary<DicomTag, ExtendedQueryTagFilterDetails>();
-            var filterDetails1 = new ExtendedQueryTagFilterDetails(1, QueryTagLevel.Series, DicomTag.FloatingPointValue.GetDefaultVR(), DicomTag.FloatingPointValue);
-            extendedQueryTags.Add(DicomTag.FloatingPointValue, filterDetails1);
-            var filterDetails2 = new ExtendedQueryTagFilterDetails(1, QueryTagLevel.Series, DicomTag.ModelGroupUID.GetDefaultVR(), DicomTag.ModelGroupUID);
-            extendedQueryTags.Add(DicomTag.ModelGroupUID, filterDetails2);
-            EnsureArg.IsNotNull(queryString, nameof(queryString));
-            QueryExpression queryExpression = _queryParser.Parse(CreateRequest(GetQueryCollection(queryString), QueryResource.AllSeries), extendedQueryTags);
+            QueryTag queryTag1 = new QueryTag(DicomTag.FloatingPointValue.BuildExtendedQueryTagStoreEntry(level: QueryTagLevel.Series));
+            QueryTag queryTag2 = new QueryTag(DicomTag.ModelGroupUID.BuildExtendedQueryTagStoreEntry(level: QueryTagLevel.Series));
+            QueryExpression queryExpression = _queryParser.Parse(CreateRequest(GetQueryCollection(queryString), QueryResource.AllSeries), QueryTagService.CoreQueryTags.Concat(new[] { queryTag1, queryTag2 }).ToList());
             Assert.Equal(4, queryExpression.FilterConditions.Count);
-            Assert.Contains(filterDetails1, queryExpression.QueriedExtendedQueryTagFilterDetails);
-            Assert.Contains(filterDetails2, queryExpression.QueriedExtendedQueryTagFilterDetails);
+            Assert.Contains(queryTag1, queryExpression.FilterConditions.Select(x => x.QueryTag));
+            Assert.Contains(queryTag2, queryExpression.FilterConditions.Select(x => x.QueryTag));
         }
 
         [Theory]
@@ -253,7 +235,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         public void GivenFilterCondition_WithDuplicateQueryParam_Throws(string queryString)
         {
             Assert.Throws<QueryParseException>(() => _queryParser
-                .Parse(CreateRequest(GetQueryCollection(queryString), QueryResource.AllStudies), null));
+                .Parse(CreateRequest(GetQueryCollection(queryString), QueryResource.AllStudies), QueryTagService.CoreQueryTags));
         }
 
         [Theory]
@@ -263,7 +245,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         public void GivenFilterCondition_WithInvalidAttributeIdStringValue_Throws(string queryString)
         {
             Assert.Throws<QueryParseException>(() => _queryParser
-                .Parse(CreateRequest(GetQueryCollection(queryString), QueryResource.AllStudies), null));
+                .Parse(CreateRequest(GetQueryCollection(queryString), QueryResource.AllStudies), QueryTagService.CoreQueryTags));
         }
 
         [Theory]
@@ -272,7 +254,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         public void GivenOffset_WithNotIntValue_Throws(string key, string value)
         {
             Assert.Throws<QueryParseException>(() => _queryParser
-                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), null));
+                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), QueryTagService.CoreQueryTags));
         }
 
         [Theory]
@@ -280,7 +262,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         public void GivenOffset_WithIntValue_CheckOffset(string key, int value)
         {
             QueryExpression queryExpression = _queryParser
-                .Parse(CreateRequest(GetQueryCollection(key, value.ToString()), QueryResource.AllStudies), null);
+                .Parse(CreateRequest(GetQueryCollection(key, value.ToString()), QueryResource.AllStudies), QueryTagService.CoreQueryTags);
             Assert.True(queryExpression.Offset == value);
         }
 
@@ -290,7 +272,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         public void GivenLimit_WithInvalidValue_Throws(string key, string value)
         {
             Assert.Throws<QueryParseException>(() => _queryParser
-                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), null));
+                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), QueryTagService.CoreQueryTags));
         }
 
         [Theory]
@@ -298,7 +280,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         public void GivenLimit_WithMaxValueExceeded_Throws(string key, string value)
         {
             Assert.Throws<QueryParseException>(() => _queryParser
-                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), null));
+                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), QueryTagService.CoreQueryTags));
         }
 
         [Theory]
@@ -306,7 +288,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         public void GivenLimit_WithValidValue_CheckLimit(string key, int value)
         {
             QueryExpression queryExpression = _queryParser
-                .Parse(CreateRequest(GetQueryCollection(key, value.ToString()), QueryResource.AllStudies), null);
+                .Parse(CreateRequest(GetQueryCollection(key, value.ToString()), QueryResource.AllStudies), QueryTagService.CoreQueryTags);
             Assert.True(queryExpression.Limit == value);
         }
 
@@ -315,7 +297,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         public void GivenLimit_WithZero_ThrowsException(string key, int value)
         {
             Assert.Throws<QueryParseException>(() => _queryParser
-                .Parse(CreateRequest(GetQueryCollection(key, value.ToString()), QueryResource.AllStudies), null));
+                .Parse(CreateRequest(GetQueryCollection(key, value.ToString()), QueryResource.AllStudies), QueryTagService.CoreQueryTags));
         }
 
         [Theory]
@@ -324,7 +306,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         public void GivenFilterCondition_WithInvalidAttributeId_Throws(string key, string value)
         {
             Assert.Throws<QueryParseException>(() => _queryParser
-                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), null));
+                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), QueryTagService.CoreQueryTags));
         }
 
         [Theory]
@@ -332,7 +314,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         public void GivenFuzzyMatch_WithValidValue_Check(string key, string value)
         {
             QueryExpression queryExpression = _queryParser
-                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), null);
+                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), QueryTagService.CoreQueryTags);
             Assert.True(queryExpression.FuzzyMatching);
         }
 
@@ -341,7 +323,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         public void GivenFuzzyMatch_InvalidValue_Throws(string key, string value)
         {
             Assert.Throws<QueryParseException>(() => _queryParser
-                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), null));
+                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), QueryTagService.CoreQueryTags));
         }
 
         [Theory]
@@ -350,10 +332,10 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         {
             EnsureArg.IsNotNull(value, nameof(value));
             QueryExpression queryExpression = _queryParser
-                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), null);
+                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), QueryTagService.CoreQueryTags);
             var cond = queryExpression.FilterConditions.First() as DateRangeValueMatchCondition;
             Assert.NotNull(cond);
-            Assert.True(cond.DicomTag == DicomTag.StudyDate);
+            Assert.True(cond.QueryTag.Tag == DicomTag.StudyDate);
             Assert.True(cond.Minimum == DateTime.ParseExact(value.Split('-')[0], QueryParser.DateTagValueFormat, null));
             Assert.True(cond.Maximum == DateTime.ParseExact(value.Split('-')[1], QueryParser.DateTagValueFormat, null));
         }
@@ -367,7 +349,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         public void GivenDateTag_WithInvalidDate_Throw(string key, string value)
         {
             Assert.Throws<QueryParseException>(() => _queryParser
-                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllSeries), null));
+                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllSeries), QueryTagService.CoreQueryTags));
         }
 
         [Fact]
@@ -375,7 +357,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         {
             var testStudyInstanceUid = TestUidGenerator.Generate();
             QueryExpression queryExpression = _queryParser
-                .Parse(CreateRequest(GetQueryCollection(new Dictionary<string, string>()), QueryResource.AllSeries, testStudyInstanceUid), null);
+                .Parse(CreateRequest(GetQueryCollection(new Dictionary<string, string>()), QueryResource.AllSeries, testStudyInstanceUid), QueryTagService.CoreQueryTags);
             Assert.Equal(1, queryExpression.FilterConditions.Count);
             var cond = queryExpression.FilterConditions.First() as StringSingleValueMatchCondition;
             Assert.NotNull(cond);
@@ -387,14 +369,14 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         public void GivenPatientNameFilterCondition_WithFuzzyMatchingTrue_FuzzyMatchConditionAdded(string queryString, QueryResource resourceType)
         {
             EnsureArg.IsNotNull(queryString, nameof(queryString));
-            QueryExpression queryExpression = _queryParser.Parse(CreateRequest(GetQueryCollection(queryString), resourceType), null);
+            QueryExpression queryExpression = _queryParser.Parse(CreateRequest(GetQueryCollection(queryString), resourceType), QueryTagService.CoreQueryTags);
 
             Assert.Equal(2, queryExpression.FilterConditions.Count);
 
-            var studyDateFilterCondition = queryExpression.FilterConditions.FirstOrDefault(c => c.DicomTag == DicomTag.StudyDate) as DateSingleValueMatchCondition;
+            var studyDateFilterCondition = queryExpression.FilterConditions.FirstOrDefault(c => c.QueryTag.Tag == DicomTag.StudyDate) as DateSingleValueMatchCondition;
             Assert.NotNull(studyDateFilterCondition);
 
-            QueryFilterCondition patientNameCondition = queryExpression.FilterConditions.FirstOrDefault(c => c.DicomTag == DicomTag.PatientName);
+            QueryFilterCondition patientNameCondition = queryExpression.FilterConditions.FirstOrDefault(c => c.QueryTag.Tag == DicomTag.PatientName);
             Assert.NotNull(patientNameCondition);
 
             var fuzzyCondition = patientNameCondition as PersonNameFuzzyMatchCondition;
@@ -405,7 +387,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         private void VerifyIncludeFieldsForValidAttributeIds(string key, string value)
         {
             QueryExpression queryExpression = _queryParser
-                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), null);
+                .Parse(CreateRequest(GetQueryCollection(key, value), QueryResource.AllStudies), QueryTagService.CoreQueryTags);
             Assert.False(queryExpression.HasFilters);
             Assert.False(queryExpression.IncludeFields.All);
             Assert.True(queryExpression.IncludeFields.DicomTags.Count == value.Split(',').Length);

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Query/QueryResponseBuilderTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Query/QueryResponseBuilderTests.cs
@@ -6,9 +6,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using Dicom;
+using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 using Microsoft.Health.Dicom.Core.Features.Query;
 using Microsoft.Health.Dicom.Core.Features.Query.Model;
 using Microsoft.Health.Dicom.Tests.Common;
+using Microsoft.Health.Dicom.Tests.Common.Extensions;
 using Xunit;
 
 namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
@@ -19,9 +21,10 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         public void GivenStudyLevel_WithIncludeField_ValidReturned()
         {
             var includeField = new QueryIncludeField(false, new List<DicomTag>() { DicomTag.StudyDescription, DicomTag.IssuerOfPatientID });
+            var queryTag = new QueryTag(DicomTag.PatientAge.BuildExtendedQueryTagStoreEntry(level: QueryTagLevel.Study));
             var filters = new List<QueryFilterCondition>()
             {
-                new StringSingleValueMatchCondition(DicomTag.PatientAge, "35"),
+                new StringSingleValueMatchCondition(queryTag, "35"),
             };
             var query = new QueryExpression(QueryResource.AllStudies, includeField, false, 0, 0, filters);
             var responseBuilder = new QueryResponseBuilder(query);
@@ -41,9 +44,10 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         public void GivenStudySeriesLevel_WithIncludeField_ValidReturned()
         {
             var includeField = new QueryIncludeField(false, new List<DicomTag>() { DicomTag.StudyDescription, DicomTag.Modality });
+            var queryTag = new QueryTag(DicomTag.StudyInstanceUID.BuildExtendedQueryTagStoreEntry(level: QueryTagLevel.Study));
             var filters = new List<QueryFilterCondition>()
             {
-                new StringSingleValueMatchCondition(DicomTag.StudyInstanceUID, "35"),
+                new StringSingleValueMatchCondition(queryTag, "35"),
             };
             var query = new QueryExpression(QueryResource.StudySeries, includeField, false, 0, 0, filters);
             var responseBuilder = new QueryResponseBuilder(query);
@@ -100,7 +104,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
             var includeField = new QueryIncludeField(false, new List<DicomTag>() { DicomTag.Modality });
             var filters = new List<QueryFilterCondition>()
             {
-                new StringSingleValueMatchCondition(DicomTag.StudyInstanceUID, "35"),
+                new StringSingleValueMatchCondition(new QueryTag(DicomTag.StudyInstanceUID), "35"),
             };
             var query = new QueryExpression(QueryResource.StudyInstances, includeField, false, 0, 0, filters);
             var responseBuilder = new QueryResponseBuilder(query);
@@ -119,10 +123,11 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         public void GivenStudySeriesInstanceLevel_WithIncludeField_ValidReturned()
         {
             var includeField = new QueryIncludeField(false, new List<DicomTag>() { });
+
             var filters = new List<QueryFilterCondition>()
             {
-                new StringSingleValueMatchCondition(DicomTag.StudyInstanceUID, "35"),
-                new StringSingleValueMatchCondition(DicomTag.SeriesInstanceUID, "351"),
+                new StringSingleValueMatchCondition(new QueryTag(DicomTag.StudyInstanceUID), "35"),
+                new StringSingleValueMatchCondition(new QueryTag(DicomTag.SeriesInstanceUID), "351"),
             };
             var query = new QueryExpression(QueryResource.StudySeriesInstances, includeField, false, 0, 0, filters);
             var responseBuilder = new QueryResponseBuilder(query);

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
@@ -549,7 +549,7 @@ namespace Microsoft.Health.Dicom.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid QIDO-RS query. AttributeId {0} is not queryable at {1} resource level. .
+        ///   Looks up a localized string similar to Invalid QIDO-RS query. AttributeId {0} is not queryable. .
         /// </summary>
         internal static string UnsupportedSearchParameter {
             get {

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
@@ -242,8 +242,8 @@ The first part date {1} should be lesser than or equal to the second part date {
     <comment>{0} is the specified content type. E.g., application/dicom</comment>
   </data>
   <data name="UnsupportedSearchParameter" xml:space="preserve">
-    <value>Invalid QIDO-RS query. AttributeId {0} is not queryable at {1} resource level. </value>
-    <comment>{0} AttributeId name. {1} Query resource level.</comment>
+    <value>Invalid QIDO-RS query. AttributeId {0} is not queryable. </value>
+    <comment>{0} AttributeId name.</comment>
   </data>
   <data name="UnsupportedTranscoding" xml:space="preserve">
     <value>The specified transcoding is not supported.</value>

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/ExtendedQueryTagEntryValidator.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/ExtendedQueryTagEntryValidator.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
             DicomTag tag = ParseTag(tagEntry.Path);
 
             // cannot be any tag we already support
-            if (QueryLimit.AllInstancesTags.Contains(tag))
+            if (QueryLimit.CoreTags.Contains(tag))
             {
                 throw new ExtendedQueryTagEntryValidationException(
                    string.Format(CultureInfo.InvariantCulture, DicomCoreResource.InvalidExtendedQueryTag, tagEntry.Path));

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/QueryTag.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/QueryTag.cs
@@ -6,6 +6,7 @@
 using Dicom;
 using EnsureThat;
 using Microsoft.Health.Dicom.Core.Extensions;
+using Microsoft.Health.Dicom.Core.Features.Query;
 
 namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
 {
@@ -18,15 +19,14 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         /// Initializes a new instance of the <see cref="QueryTag"/> class.
         /// </summary>
         /// <remarks>Used for constuctoring from core dicom tag.PatientName e.g. </remarks>
-        /// <param name="tag">The core dicom Tag.</param>
-        /// <param name="level">The tag level.</param>
-        public QueryTag(DicomTag tag, QueryTagLevel level)
+        /// <param name="tag">The core dicom Tag.</param>        
+        public QueryTag(DicomTag tag)
         {
             EnsureArg.IsNotNull(tag, nameof(tag));
 
             Tag = tag;
             VR = tag.GetDefaultVR();
-            Level = level;
+            Level = QueryLimit.GetQueryTagLevel(tag);
             ExtendedQueryTagStoreEntry = null;
         }
 
@@ -69,5 +69,14 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         /// Gets the underlying extendedQueryTagStoreEntry for extended query tag.
         /// </summary>
         public ExtendedQueryTagStoreEntry ExtendedQueryTagStoreEntry { get; }
+
+        /// <summary>
+        /// Gets name of this query tag.
+        /// </summary>
+        /// <returns></returns>
+        public string GetName()
+        {
+            return Tag.DictionaryEntry == DicomDictionary.UnknownTag ? Tag.GetPath() : Tag.DictionaryEntry.Keyword;
+        }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/QueryTagService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/QueryTagService.cs
@@ -56,11 +56,7 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
 
         private static IReadOnlyList<QueryTag> GetCoreQueryTags()
         {
-            List<QueryTag> coreTags = new List<QueryTag>();
-            coreTags.AddRange(QueryLimit.AllStudiesTags.Select(tag => new QueryTag(tag, QueryTagLevel.Study)));
-            coreTags.AddRange(QueryLimit.StudySeriesTags.Select(tag => new QueryTag(tag, QueryTagLevel.Series)));
-            coreTags.AddRange(QueryLimit.StudySeriesInstancesTags.Select(tag => new QueryTag(tag, QueryTagLevel.Instance)));
-            return coreTags;
+            return QueryLimit.CoreTags.Select(tag => new QueryTag(tag)).ToList();
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Query/IQueryParser.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Query/IQueryParser.cs
@@ -4,7 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
-using Dicom;
+using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 using Microsoft.Health.Dicom.Core.Features.Query.Model;
 using Microsoft.Health.Dicom.Core.Messages.Query;
 
@@ -12,6 +12,6 @@ namespace Microsoft.Health.Dicom.Core.Features.Query
 {
     public interface IQueryParser
     {
-        QueryExpression Parse(QueryResourceRequest request, IDictionary<DicomTag, ExtendedQueryTagFilterDetails> supportedExtendedQueryTags = null);
+        QueryExpression Parse(QueryResourceRequest request, IReadOnlyCollection<QueryTag> queryTags);
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Query/Model/FilterConditions/DateRangeValueMatchCondition.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Query/Model/FilterConditions/DateRangeValueMatchCondition.cs
@@ -3,14 +3,14 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 using System;
-using Dicom;
 using EnsureThat;
+using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 
 namespace Microsoft.Health.Dicom.Core.Features.Query
 {
     public class DateRangeValueMatchCondition : RangeValueMatchCondition<DateTime>
     {
-        internal DateRangeValueMatchCondition(DicomTag tag, DateTime minimum, DateTime maximum)
+        internal DateRangeValueMatchCondition(QueryTag tag, DateTime minimum, DateTime maximum)
             : base(tag, minimum, maximum)
         {
         }

--- a/src/Microsoft.Health.Dicom.Core/Features/Query/Model/FilterConditions/DateSingleValueMatchCondition.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Query/Model/FilterConditions/DateSingleValueMatchCondition.cs
@@ -3,14 +3,14 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 using System;
-using Dicom;
 using EnsureThat;
+using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 
 namespace Microsoft.Health.Dicom.Core.Features.Query
 {
     public class DateSingleValueMatchCondition : SingleValueMatchCondition<DateTime>
     {
-        internal DateSingleValueMatchCondition(DicomTag tag, DateTime value)
+        internal DateSingleValueMatchCondition(QueryTag tag, DateTime value)
             : base(tag, value)
         {
         }

--- a/src/Microsoft.Health.Dicom.Core/Features/Query/Model/FilterConditions/DoubleSingleValueMatchCondition.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Query/Model/FilterConditions/DoubleSingleValueMatchCondition.cs
@@ -2,14 +2,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
-using Dicom;
 using EnsureThat;
+using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 
 namespace Microsoft.Health.Dicom.Core.Features.Query
 {
     public class DoubleSingleValueMatchCondition : SingleValueMatchCondition<double>
     {
-        internal DoubleSingleValueMatchCondition(DicomTag tag, double value)
+        internal DoubleSingleValueMatchCondition(QueryTag tag, double value)
             : base(tag, value)
         {
         }

--- a/src/Microsoft.Health.Dicom.Core/Features/Query/Model/FilterConditions/LongSingleValueMatchCondition.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Query/Model/FilterConditions/LongSingleValueMatchCondition.cs
@@ -2,14 +2,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
-using Dicom;
 using EnsureThat;
+using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 
 namespace Microsoft.Health.Dicom.Core.Features.Query
 {
     public class LongSingleValueMatchCondition : SingleValueMatchCondition<long>
     {
-        internal LongSingleValueMatchCondition(DicomTag tag, long value)
+        internal LongSingleValueMatchCondition(QueryTag tag, long value)
             : base(tag, value)
         {
         }

--- a/src/Microsoft.Health.Dicom.Core/Features/Query/Model/FilterConditions/PersonNameFuzzyMatchCondition.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Query/Model/FilterConditions/PersonNameFuzzyMatchCondition.cs
@@ -2,14 +2,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
-using Dicom;
 using EnsureThat;
+using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 
 namespace Microsoft.Health.Dicom.Core.Features.Query
 {
     public class PersonNameFuzzyMatchCondition : SingleValueMatchCondition<string>
     {
-        internal PersonNameFuzzyMatchCondition(DicomTag tag, string value)
+        internal PersonNameFuzzyMatchCondition(QueryTag tag, string value)
             : base(tag, value)
         {
         }

--- a/src/Microsoft.Health.Dicom.Core/Features/Query/Model/FilterConditions/QueryFilterCondition.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Query/Model/FilterConditions/QueryFilterCondition.cs
@@ -2,20 +2,22 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
-using Dicom;
+using EnsureThat;
+using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 
 namespace Microsoft.Health.Dicom.Core.Features.Query
 {
     public abstract class QueryFilterCondition
     {
-        protected QueryFilterCondition(DicomTag tag)
+        protected QueryFilterCondition(QueryTag queryTag)
         {
-            DicomTag = tag;
+            EnsureArg.IsNotNull(queryTag, nameof(queryTag));
+            QueryTag = queryTag;
         }
 
-        public DicomTag DicomTag { get; }
 
-        public ExtendedQueryTagFilterDetails ExtendedQueryTagFilterDetails { get; set; }
+
+        public QueryTag QueryTag { get; set; }
 
         public abstract void Accept(QueryFilterConditionVisitor visitor);
     }

--- a/src/Microsoft.Health.Dicom.Core/Features/Query/Model/FilterConditions/RangeValueMatchCondition.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Query/Model/FilterConditions/RangeValueMatchCondition.cs
@@ -2,13 +2,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
-using Dicom;
+using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 
 namespace Microsoft.Health.Dicom.Core.Features.Query
 {
     public abstract class RangeValueMatchCondition<T> : QueryFilterCondition
     {
-        internal RangeValueMatchCondition(DicomTag tag, T minimum, T maximum)
+        internal RangeValueMatchCondition(QueryTag tag, T minimum, T maximum)
             : base(tag)
         {
             Minimum = minimum;

--- a/src/Microsoft.Health.Dicom.Core/Features/Query/Model/FilterConditions/SingleValueMatchCondition.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Query/Model/FilterConditions/SingleValueMatchCondition.cs
@@ -2,13 +2,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
-using Dicom;
+using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 
 namespace Microsoft.Health.Dicom.Core.Features.Query
 {
     public abstract class SingleValueMatchCondition<T> : QueryFilterCondition
     {
-        internal SingleValueMatchCondition(DicomTag tag, T value)
+        internal SingleValueMatchCondition(QueryTag tag, T value)
             : base(tag)
         {
             Value = value;

--- a/src/Microsoft.Health.Dicom.Core/Features/Query/Model/FilterConditions/StringSingleValueMatchCondition.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Query/Model/FilterConditions/StringSingleValueMatchCondition.cs
@@ -2,14 +2,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
-using Dicom;
 using EnsureThat;
+using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 
 namespace Microsoft.Health.Dicom.Core.Features.Query
 {
     public class StringSingleValueMatchCondition : SingleValueMatchCondition<string>
     {
-        internal StringSingleValueMatchCondition(DicomTag tag, string value)
+        internal StringSingleValueMatchCondition(QueryTag tag, string value)
             : base(tag, value)
         {
         }

--- a/src/Microsoft.Health.Dicom.Core/Features/Query/Model/QueryExpression.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Query/Model/QueryExpression.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Health.Dicom.Core.Messages;
@@ -21,8 +20,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Query.Model
             bool fuzzyMatching,
             int limit,
             int offset,
-            IReadOnlyCollection<QueryFilterCondition> filterConditions,
-            IReadOnlyCollection<ExtendedQueryTagFilterDetails> queriedExtendedQueryTagFilterDetails = null)
+            IReadOnlyCollection<QueryFilterCondition> filterConditions)
         {
             QueryResource = resourceType;
             IncludeFields = includeFields;
@@ -30,8 +28,6 @@ namespace Microsoft.Health.Dicom.Core.Features.Query.Model
             Limit = limit;
             Offset = offset;
             FilterConditions = filterConditions;
-            QueriedExtendedQueryTagFilterDetails = queriedExtendedQueryTagFilterDetails ?? Array.Empty<ExtendedQueryTagFilterDetails>();
-
             SetIELevel();
          }
 
@@ -49,11 +45,6 @@ namespace Microsoft.Health.Dicom.Core.Features.Query.Model
         /// Dicom tags to include in query result
         /// </summary>
         public QueryIncludeField IncludeFields { get; }
-
-        /// <summary>
-        /// Filter details associated with the extended query tags being queried.
-        /// </summary>
-        public IReadOnlyCollection<ExtendedQueryTagFilterDetails> QueriedExtendedQueryTagFilterDetails { get; }
 
         /// <summary>
         /// If true do Fuzzy matching of PN tag types

--- a/src/Microsoft.Health.Dicom.Core/Features/Query/QueryParser.TagValueParser.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Query/QueryParser.TagValueParser.cs
@@ -4,8 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using Dicom;
-using Microsoft.Health.Dicom.Core.Extensions;
+using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 
 namespace Microsoft.Health.Dicom.Core.Features.Query
 {
@@ -14,17 +13,17 @@ namespace Microsoft.Health.Dicom.Core.Features.Query
     /// </summary>
     public partial class QueryParser
     {
-        private static QueryFilterCondition ParseDateTagValue(DicomTag dicomTag, string value, DicomVR vr = null)
+        private static QueryFilterCondition ParseDateTagValue(QueryTag queryTag, string value)
         {
-            if (QueryLimit.IsValidRangeQueryTag(dicomTag, vr))
+            if (QueryLimit.IsValidRangeQueryTag(queryTag))
             {
                 var splitString = value.Split('-');
                 if (splitString.Length == 2)
                 {
                     string minDate = splitString[0].Trim();
                     string maxDate = splitString[1].Trim();
-                    DateTime parsedMinDate = ParseDate(minDate, dicomTag.DictionaryEntry.Keyword);
-                    DateTime parsedMaxDate = ParseDate(maxDate, dicomTag.DictionaryEntry.Keyword);
+                    DateTime parsedMinDate = ParseDate(minDate, queryTag.GetName());
+                    DateTime parsedMaxDate = ParseDate(maxDate, queryTag.GetName());
 
                     if (parsedMinDate > parsedMaxDate)
                     {
@@ -35,44 +34,44 @@ namespace Microsoft.Health.Dicom.Core.Features.Query
                             maxDate));
                     }
 
-                    return new DateRangeValueMatchCondition(dicomTag, parsedMinDate, parsedMaxDate);
+                    return new DateRangeValueMatchCondition(queryTag, parsedMinDate, parsedMaxDate);
                 }
             }
 
-            DateTime parsedDate = ParseDate(value, dicomTag.DictionaryEntry.Keyword);
-            return new DateSingleValueMatchCondition(dicomTag, parsedDate);
+            DateTime parsedDate = ParseDate(value, queryTag.GetName());
+            return new DateSingleValueMatchCondition(queryTag, parsedDate);
         }
 
-        private static QueryFilterCondition ParseStringTagValue(DicomTag dicomTag, string value, DicomVR vr = null)
+        private static QueryFilterCondition ParseStringTagValue(QueryTag queryTag, string value)
         {
-            return new StringSingleValueMatchCondition(dicomTag, value);
+            return new StringSingleValueMatchCondition(queryTag, value);
         }
 
-        private static QueryFilterCondition ParseDoubleTagValue(DicomTag dicomTag, string value, DicomVR vr = null)
+        private static QueryFilterCondition ParseDoubleTagValue(QueryTag queryTag, string value)
         {
             if (!double.TryParse(value, out double val))
             {
-                throw new QueryParseException(string.Format(DicomCoreResource.InvalidDoubleValue, value, dicomTag.GetPath()));
+                throw new QueryParseException(string.Format(DicomCoreResource.InvalidDoubleValue, value, queryTag.GetName()));
             }
 
-            return new DoubleSingleValueMatchCondition(dicomTag, val);
+            return new DoubleSingleValueMatchCondition(queryTag, val);
         }
 
-        private static QueryFilterCondition ParseLongTagValue(DicomTag dicomTag, string value, DicomVR vr = null)
+        private static QueryFilterCondition ParseLongTagValue(QueryTag queryTag, string value)
         {
             if (!long.TryParse(value, out long val))
             {
-                throw new QueryParseException(string.Format(DicomCoreResource.InvalidLongValue, value, dicomTag.GetPath()));
+                throw new QueryParseException(string.Format(DicomCoreResource.InvalidLongValue, value, queryTag.GetName()));
             }
 
-            return new LongSingleValueMatchCondition(dicomTag, val);
+            return new LongSingleValueMatchCondition(queryTag, val);
         }
 
-        private static DateTime ParseDate(string date, string tagKeyword)
+        private static DateTime ParseDate(string date, string tagName)
         {
             if (!DateTime.TryParseExact(date, DateTagValueFormat, null, System.Globalization.DateTimeStyles.None, out DateTime parsedDate))
             {
-                throw new QueryParseException(string.Format(DicomCoreResource.InvalidDateValue, date, tagKeyword));
+                throw new QueryParseException(string.Format(DicomCoreResource.InvalidDateValue, date, tagName));
             }
 
             return parsedDate;

--- a/src/Microsoft.Health.Dicom.Core/Features/Query/QueryParser.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Query/QueryParser.cs
@@ -9,7 +9,9 @@ using System.Linq;
 using Dicom;
 using EnsureThat;
 using Microsoft.Extensions.Primitives;
+using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Core.Features.Common;
+using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 using Microsoft.Health.Dicom.Core.Features.Query.Model;
 using Microsoft.Health.Dicom.Core.Messages.Query;
 
@@ -28,8 +30,8 @@ namespace Microsoft.Health.Dicom.Core.Features.Query
         private readonly Dictionary<string, Action<KeyValuePair<string, StringValues>>> _paramParsers =
             new Dictionary<string, Action<KeyValuePair<string, StringValues>>>(StringComparer.OrdinalIgnoreCase);
 
-        private readonly Dictionary<DicomVR, Func<DicomTag, string, DicomVR, QueryFilterCondition>> _valueParsers =
-            new Dictionary<DicomVR, Func<DicomTag, string, DicomVR, QueryFilterCondition>>();
+        private readonly Dictionary<DicomVR, Func<QueryTag, string, QueryFilterCondition>> _valueParsers =
+            new Dictionary<DicomVR, Func<QueryTag, string, QueryFilterCondition>>();
 
         public const string DateTagValueFormat = "yyyyMMdd";
 
@@ -66,13 +68,13 @@ namespace Microsoft.Health.Dicom.Core.Features.Query
             _valueParsers.Add(DicomVR.FD, ParseDoubleTagValue);
         }
 
-        public QueryExpression Parse(QueryResourceRequest request, IDictionary<DicomTag, ExtendedQueryTagFilterDetails> supportedExtendedQueryTags)
+        public QueryExpression Parse(QueryResourceRequest request, IReadOnlyCollection<QueryTag> queryTags)
         {
             EnsureArg.IsNotNull(request, nameof(request));
-
-            var queriedExtendedQueryTags = new HashSet<ExtendedQueryTagFilterDetails>();
+            EnsureArg.IsNotNull(queryTags, nameof(queryTags));
 
             _parsedQuery = new QueryExpressionImp();
+            queryTags = GetQualifiedQueryTags(queryTags, request.QueryResourceType);
 
             foreach (KeyValuePair<string, StringValues> queryParam in request.RequestQuery)
             {
@@ -86,20 +88,14 @@ namespace Microsoft.Health.Dicom.Core.Features.Query
                 }
 
                 // filter conditions with attributeId as key
-                if (ParseFilterCondition(queryParam, request.QueryResourceType, supportedExtendedQueryTags, out QueryFilterCondition condition))
+                if (ParseFilterCondition(queryParam, queryTags, out QueryFilterCondition condition))
                 {
-                    if (_parsedQuery.FilterConditionTags.Contains(condition.DicomTag))
+                    if (_parsedQuery.FilterConditions.Any(item => item.QueryTag.Tag == condition.QueryTag.Tag))
                     {
                         throw new QueryParseException(string.Format(DicomCoreResource.DuplicateQueryParam, queryParam.Key));
                     }
 
-                    _parsedQuery.FilterConditionTags.Add(condition.DicomTag);
                     _parsedQuery.FilterConditions.Add(condition);
-
-                    if (condition.ExtendedQueryTagFilterDetails != null)
-                    {
-                        queriedExtendedQueryTags.Add(condition.ExtendedQueryTagFilterDetails);
-                    }
 
                     continue;
                 }
@@ -110,13 +106,13 @@ namespace Microsoft.Health.Dicom.Core.Features.Query
             // add UIDs as filter conditions
             if (request.StudyInstanceUid != null)
             {
-                var condition = new StringSingleValueMatchCondition(DicomTag.StudyInstanceUID, request.StudyInstanceUid);
+                var condition = new StringSingleValueMatchCondition(new QueryTag(DicomTag.StudyInstanceUID), request.StudyInstanceUid);
                 _parsedQuery.FilterConditions.Add(condition);
             }
 
             if (request.SeriesInstanceUid != null)
             {
-                var condition = new StringSingleValueMatchCondition(DicomTag.SeriesInstanceUID, request.SeriesInstanceUid);
+                var condition = new StringSingleValueMatchCondition(new QueryTag(DicomTag.SeriesInstanceUID), request.SeriesInstanceUid);
                 _parsedQuery.FilterConditions.Add(condition);
             }
 
@@ -128,8 +124,23 @@ namespace Microsoft.Health.Dicom.Core.Features.Query
                 _parsedQuery.FuzzyMatch,
                 _parsedQuery.Limit,
                 _parsedQuery.Offset,
-                _parsedQuery.FilterConditions,
-                queriedExtendedQueryTags);
+                _parsedQuery.FilterConditions);
+        }
+
+        private static IReadOnlyCollection<QueryTag> GetQualifiedQueryTags(IReadOnlyCollection<QueryTag> queryTags, QueryResource queryResource)
+        {
+            return queryTags.Where(tag =>
+            {
+                // extended query tag need to Ready to be used.
+                if (tag.IsExtendedQueryTag && tag.ExtendedQueryTagStoreEntry.Status != ExtendedQueryTagStatus.Ready)
+                {
+                    return false;
+                }
+
+                // tag level should be qualified
+                return QueryLimit.QueryResourceTypeToQueryLevelsMapping[queryResource].Contains(tag.Level);
+
+            }).ToList();
         }
 
         private static void PostProcessFilterConditions(QueryExpressionImp parsedQuery)
@@ -140,10 +151,10 @@ namespace Microsoft.Health.Dicom.Core.Features.Query
                 for (int i = 0; i < parsedQuery.FilterConditions.Count; i++)
                 {
                     QueryFilterCondition cond = parsedQuery.FilterConditions[i];
-                    if (QueryLimit.IsValidFuzzyMatchingQueryTag(cond.DicomTag, cond.ExtendedQueryTagFilterDetails?.VR))
+                    if (QueryLimit.IsValidFuzzyMatchingQueryTag(cond.QueryTag))
                     {
                         var s = cond as StringSingleValueMatchCondition;
-                        parsedQuery.FilterConditions[i] = new PersonNameFuzzyMatchCondition(s.DicomTag, s.Value);
+                        parsedQuery.FilterConditions[i] = new PersonNameFuzzyMatchCondition(s.QueryTag, s.Value);
                     }
                 }
             }
@@ -151,8 +162,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Query
 
         private bool ParseFilterCondition(
             KeyValuePair<string, StringValues> queryParameter,
-            QueryResource resourceType,
-            IDictionary<DicomTag, ExtendedQueryTagFilterDetails> supportedExtendedQueryTags,
+            IEnumerable<QueryTag> queryTags,
             out QueryFilterCondition condition)
         {
             condition = null;
@@ -164,8 +174,8 @@ namespace Microsoft.Health.Dicom.Core.Features.Query
                 return false;
             }
 
-            ExtendedQueryTagFilterDetails extendedQueryTagFilterDetails;
-            ValidateIfTagSupported(dicomTag, attributeId, resourceType, supportedExtendedQueryTags, out extendedQueryTagFilterDetails);
+            QueryTag queryTag;
+            ValidateIfTagSupported(dicomTag, attributeId, queryTags, out queryTag);
 
             // parse tag value
             if (queryParameter.Value.Count != 1)
@@ -179,13 +189,12 @@ namespace Microsoft.Health.Dicom.Core.Features.Query
                 throw new QueryParseException(string.Format(DicomCoreResource.QueryEmptyAttributeValue, attributeId));
             }
 
-            var tagTypeCode = extendedQueryTagFilterDetails == null ? dicomTag.DictionaryEntry.ValueRepresentations.FirstOrDefault() : extendedQueryTagFilterDetails.VR;
-            if (_valueParsers.TryGetValue(tagTypeCode, out Func<DicomTag, string, DicomVR, QueryFilterCondition> valueParser))
+            if (_valueParsers.TryGetValue(queryTag.VR, out Func<QueryTag, string, QueryFilterCondition> valueParser))
             {
-                condition = valueParser(dicomTag, trimmedValue, tagTypeCode);
+                condition = valueParser(queryTag, trimmedValue);
             }
 
-            condition.ExtendedQueryTagFilterDetails = extendedQueryTagFilterDetails;
+            condition.QueryTag = queryTag;
 
             return condition != null;
         }
@@ -202,21 +211,22 @@ namespace Microsoft.Health.Dicom.Core.Features.Query
             return false;
         }
 
-        private static void ValidateIfTagSupported(DicomTag dicomTag, string attributeId, QueryResource resourceType, IDictionary<DicomTag, ExtendedQueryTagFilterDetails> supportedExtendedQueryTags, out ExtendedQueryTagFilterDetails extendedQueryTagFilterDetails)
+        private static void ValidateIfTagSupported(DicomTag dicomTag, string attributeId, IEnumerable<QueryTag> queryTags, out QueryTag queryTag)
         {
-            extendedQueryTagFilterDetails = null;
-            HashSet<DicomTag> supportedQueryTags = QueryLimit.QueryResourceTypeToTagsMapping[resourceType];
-
-            if (!supportedQueryTags.Contains(dicomTag))
+            queryTag = queryTags.FirstOrDefault(item =>
             {
-                if (supportedExtendedQueryTags != null && supportedExtendedQueryTags.TryGetValue(dicomTag, out extendedQueryTagFilterDetails))
+                // private tag from request doesn't have private creator, should do path comparison.
+                if (dicomTag.IsPrivate)
                 {
-                    return;
+                    return item.Tag.GetPath() == dicomTag.GetPath();
                 }
 
-                string genericResourceType = resourceType >= QueryResource.AllInstances ? "instance" : (resourceType >= QueryResource.AllSeries ? "series" : "study");
+                return item.Tag == dicomTag;
+            });
 
-                throw new QueryParseException(string.Format(DicomCoreResource.UnsupportedSearchParameter, attributeId, genericResourceType));
+            if (queryTag == null)
+            {
+                throw new QueryParseException(string.Format(DicomCoreResource.UnsupportedSearchParameter, attributeId));
             }
         }
 
@@ -226,7 +236,6 @@ namespace Microsoft.Health.Dicom.Core.Features.Query
             {
                 IncludeFields = new HashSet<DicomTag>();
                 FilterConditions = new List<QueryFilterCondition>();
-                FilterConditionTags = new HashSet<DicomTag>();
             }
 
             public HashSet<DicomTag> IncludeFields { get; set; }
@@ -241,7 +250,6 @@ namespace Microsoft.Health.Dicom.Core.Features.Query
 
             public bool AllValue { get; set; }
 
-            public HashSet<DicomTag> FilterConditionTags { get; set; }
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Query/QueryResponseBuilder.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Query/QueryResponseBuilder.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Query
 
             foreach (var cond in queryExpression.FilterConditions)
             {
-                _tagsToReturn.Add(cond.DicomTag);
+                _tagsToReturn.Add(cond.QueryTag.Tag);
             }
         }
     }

--- a/src/Microsoft.Health.Dicom.SqlServer.UnitTests/Features/Query/SqlQueryGeneratorTests.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer.UnitTests/Features/Query/SqlQueryGeneratorTests.cs
@@ -8,11 +8,11 @@ using System.Reflection;
 using System.Text;
 using Dicom;
 using Microsoft.Data.SqlClient;
-using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 using Microsoft.Health.Dicom.Core.Features.Query;
 using Microsoft.Health.Dicom.Core.Features.Query.Model;
 using Microsoft.Health.Dicom.SqlServer.Features.Query;
+using Microsoft.Health.Dicom.Tests.Common.Extensions;
 using Microsoft.Health.SqlServer;
 using Microsoft.Health.SqlServer.Features.Storage;
 using Xunit;
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Dicom.SqlServer.UnitTests.Features.Query
 
             var filters = new List<QueryFilterCondition>()
             {
-                new DateRangeValueMatchCondition(DicomTag.StudyDate, minDate, maxDate),
+                new DateRangeValueMatchCondition(new QueryTag(DicomTag.StudyDate), minDate, maxDate),
             };
             var query = new QueryExpression(QueryResource.AllStudies, includeField, false, 0, 0, filters);
 
@@ -59,7 +59,7 @@ AND a.StudyKey = f.StudyKey";
             var includeField = new QueryIncludeField(false, new List<DicomTag>());
             var filters = new List<QueryFilterCondition>()
             {
-                new StringSingleValueMatchCondition(DicomTag.Modality, "123"),
+                new StringSingleValueMatchCondition(new QueryTag(DicomTag.Modality), "123"),
             };
             var query = new QueryExpression(QueryResource.AllInstances, includeField, false, 0, 0, filters);
 
@@ -89,14 +89,14 @@ ON i.SeriesKey = se.SeriesKey";
         {
             var stringBuilder = new IndentedStringBuilder(new StringBuilder());
             var includeField = new QueryIncludeField(false, new List<DicomTag>());
-            var filter = new StringSingleValueMatchCondition(DicomTag.ModelGroupUID, "123");
-            var filterDetails = new ExtendedQueryTagFilterDetails(1, QueryTagLevel.Study, DicomTag.ModelGroupUID.GetDefaultVR(), DicomTag.ModelGroupUID);
-            filter.ExtendedQueryTagFilterDetails = filterDetails;
+            var queryTag = new QueryTag(DicomTag.ModelGroupUID.BuildExtendedQueryTagStoreEntry(level: QueryTagLevel.Study));
+            var filter = new StringSingleValueMatchCondition(queryTag, "123");
+            filter.QueryTag = queryTag;
             var filters = new List<QueryFilterCondition>()
             {
                 filter,
             };
-            var query = new QueryExpression(QueryResource.AllStudies, includeField, false, 0, 0, filters, new List<ExtendedQueryTagFilterDetails>() { filterDetails });
+            var query = new QueryExpression(QueryResource.AllStudies, includeField, false, 0, 0, filters);
 
             SqlParameterCollection sqlParameterCollection = CreateSqlParameterCollection();
             var parm = new SqlQueryParameterManager(sqlParameterCollection);
@@ -110,7 +110,7 @@ WHERE";
 AND cts1.TagValue=@p1";
 
             string builtString = stringBuilder.ToString();
-            Assert.Equal(filterDetails.Key.ToString(), sqlParameterCollection[0].Value.ToString());
+            Assert.Equal(queryTag.ExtendedQueryTagStoreEntry.Key.ToString(), sqlParameterCollection[0].Value.ToString());
             Assert.Equal(filter.Value.ToString(), sqlParameterCollection[1].Value.ToString());
             Assert.Contains(expectedExtendedQueryTagTableFilter, builtString);
             Assert.Contains(expectedFilters, builtString);
@@ -121,14 +121,14 @@ AND cts1.TagValue=@p1";
         {
             var stringBuilder = new IndentedStringBuilder(new StringBuilder());
             var includeField = new QueryIncludeField(false, new List<DicomTag>());
-            var filter = new LongSingleValueMatchCondition(DicomTag.NumberOfAssessmentObservations, 123);
-            var filterDetails = new ExtendedQueryTagFilterDetails(1, QueryTagLevel.Study, DicomTag.NumberOfAssessmentObservations.GetDefaultVR(), DicomTag.NumberOfAssessmentObservations);
-            filter.ExtendedQueryTagFilterDetails = filterDetails;
+            var queryTag = new QueryTag(DicomTag.NumberOfAssessmentObservations.BuildExtendedQueryTagStoreEntry(level: QueryTagLevel.Study));
+            var filter = new LongSingleValueMatchCondition(queryTag, 123);
+            filter.QueryTag = queryTag;
             var filters = new List<QueryFilterCondition>()
             {
                 filter,
             };
-            var query = new QueryExpression(QueryResource.AllStudies, includeField, false, 0, 0, filters, new List<ExtendedQueryTagFilterDetails>() { filterDetails });
+            var query = new QueryExpression(QueryResource.AllStudies, includeField, false, 0, 0, filters);
 
             SqlParameterCollection sqlParameterCollection = CreateSqlParameterCollection();
             var parm = new SqlQueryParameterManager(sqlParameterCollection);
@@ -142,7 +142,7 @@ WHERE";
 AND ctl1.TagValue=@p1";
 
             string builtString = stringBuilder.ToString();
-            Assert.Equal(filterDetails.Key.ToString(), sqlParameterCollection[0].Value.ToString());
+            Assert.Equal(queryTag.ExtendedQueryTagStoreEntry.Key.ToString(), sqlParameterCollection[0].Value.ToString());
             Assert.Equal(filter.Value.ToString(), sqlParameterCollection[1].Value.ToString());
             Assert.Contains(expectedExtendedQueryTagTableFilter, builtString);
             Assert.Contains(expectedFilters, builtString);
@@ -153,14 +153,14 @@ AND ctl1.TagValue=@p1";
         {
             var stringBuilder = new IndentedStringBuilder(new StringBuilder());
             var includeField = new QueryIncludeField(false, new List<DicomTag>());
-            var filter = new DoubleSingleValueMatchCondition(DicomTag.FloatingPointValue, 123D);
-            var filterDetails = new ExtendedQueryTagFilterDetails(1, QueryTagLevel.Study, DicomTag.FloatingPointValue.GetDefaultVR(), DicomTag.FloatingPointValue);
-            filter.ExtendedQueryTagFilterDetails = filterDetails;
+            var queryTag = new QueryTag(DicomTag.FloatingPointValue.BuildExtendedQueryTagStoreEntry(level: QueryTagLevel.Study));
+            var filter = new DoubleSingleValueMatchCondition(queryTag, 123D);
+            filter.QueryTag = queryTag;
             var filters = new List<QueryFilterCondition>()
             {
                 filter,
             };
-            var query = new QueryExpression(QueryResource.AllStudies, includeField, false, 0, 0, filters, new List<ExtendedQueryTagFilterDetails>() { filterDetails });
+            var query = new QueryExpression(QueryResource.AllStudies, includeField, false, 0, 0, filters);
 
             SqlParameterCollection sqlParameterCollection = CreateSqlParameterCollection();
             var parm = new SqlQueryParameterManager(sqlParameterCollection);
@@ -174,7 +174,7 @@ WHERE";
 AND ctd1.TagValue=@p1";
 
             string builtString = stringBuilder.ToString();
-            Assert.Equal(filterDetails.Key.ToString(), sqlParameterCollection[0].Value.ToString());
+            Assert.Equal(queryTag.ExtendedQueryTagStoreEntry.Key.ToString(), sqlParameterCollection[0].Value.ToString());
             Assert.Equal(filter.Value.ToString(), sqlParameterCollection[1].Value.ToString());
             Assert.Contains(expectedExtendedQueryTagTableFilter, builtString);
             Assert.Contains(expectedFilters, builtString);
@@ -185,14 +185,15 @@ AND ctd1.TagValue=@p1";
         {
             var stringBuilder = new IndentedStringBuilder(new StringBuilder());
             var includeField = new QueryIncludeField(false, new List<DicomTag>());
-            var filter = new DateRangeValueMatchCondition(DicomTag.Date, DateTime.ParseExact("19510910", QueryParser.DateTagValueFormat, null), DateTime.ParseExact("19571110", QueryParser.DateTagValueFormat, null));
-            var filterDetails = new ExtendedQueryTagFilterDetails(1, QueryTagLevel.Study, DicomTag.Date.GetDefaultVR(), DicomTag.Date);
-            filter.ExtendedQueryTagFilterDetails = filterDetails;
+            var queryTag = new QueryTag(DicomTag.Date.BuildExtendedQueryTagStoreEntry(level: QueryTagLevel.Study));
+            var filter = new DateRangeValueMatchCondition(queryTag, DateTime.ParseExact("19510910", QueryParser.DateTagValueFormat, null), DateTime.ParseExact("19571110", QueryParser.DateTagValueFormat, null));
+
+            filter.QueryTag = queryTag;
             var filters = new List<QueryFilterCondition>()
             {
                 filter,
             };
-            var query = new QueryExpression(QueryResource.AllStudies, includeField, false, 0, 0, filters, new List<ExtendedQueryTagFilterDetails>() { filterDetails });
+            var query = new QueryExpression(QueryResource.AllStudies, includeField, false, 0, 0, filters);
 
             SqlParameterCollection sqlParameterCollection = CreateSqlParameterCollection();
             var parm = new SqlQueryParameterManager(sqlParameterCollection);
@@ -206,7 +207,7 @@ WHERE";
 AND ctdt1.TagValue BETWEEN @p1 AND @p2";
 
             string builtString = stringBuilder.ToString();
-            Assert.Equal(filterDetails.Key.ToString(), sqlParameterCollection[0].Value.ToString());
+            Assert.Equal(queryTag.ExtendedQueryTagStoreEntry.Key.ToString(), sqlParameterCollection[0].Value.ToString());
             Assert.Equal(filter.Minimum.ToString("yyyy-MM-dd"), sqlParameterCollection[1].Value.ToString());
             Assert.Equal(filter.Maximum.ToString("yyyy-MM-dd"), sqlParameterCollection[2].Value.ToString());
             Assert.Contains(expectedExtendedQueryTagTableFilter, builtString);
@@ -218,16 +219,16 @@ AND ctdt1.TagValue BETWEEN @p1 AND @p2";
         {
             var stringBuilder = new IndentedStringBuilder(new StringBuilder());
             var includeField = new QueryIncludeField(false, new List<DicomTag>());
-            var extendedQueryTagFilter = new StringSingleValueMatchCondition(DicomTag.ModelGroupUID, "123");
-            var filterDetails = new ExtendedQueryTagFilterDetails(1, QueryTagLevel.Series, DicomTag.ModelGroupUID.GetDefaultVR(), DicomTag.ModelGroupUID);
-            extendedQueryTagFilter.ExtendedQueryTagFilterDetails = filterDetails;
-            var filter = new StringSingleValueMatchCondition(DicomTag.Modality, "abc");
+            var queryTag = new QueryTag(DicomTag.ModelGroupUID.BuildExtendedQueryTagStoreEntry(level: QueryTagLevel.Series));
+            var extendedQueryTagFilter = new StringSingleValueMatchCondition(queryTag, "123");
+            extendedQueryTagFilter.QueryTag = queryTag;
+            var filter = new StringSingleValueMatchCondition(new QueryTag(DicomTag.Modality), "abc");
             var filters = new List<QueryFilterCondition>()
             {
                 filter,
                 extendedQueryTagFilter,
             };
-            var query = new QueryExpression(QueryResource.StudySeries, includeField, false, 0, 0, filters, new List<ExtendedQueryTagFilterDetails>() { filterDetails });
+            var query = new QueryExpression(QueryResource.StudySeries, includeField, false, 0, 0, filters);
 
             SqlParameterCollection sqlParameterCollection = CreateSqlParameterCollection();
             var parm = new SqlQueryParameterManager(sqlParameterCollection);
@@ -243,7 +244,7 @@ WHERE";
 AND cts1.TagValue=@p2";
 
             string builtString = stringBuilder.ToString();
-            Assert.Equal(filterDetails.Key.ToString(), sqlParameterCollection[1].Value.ToString());
+            Assert.Equal(queryTag.ExtendedQueryTagStoreEntry.Key.ToString(), sqlParameterCollection[1].Value.ToString());
             Assert.Equal(extendedQueryTagFilter.Value.ToString(), sqlParameterCollection[2].Value.ToString());
             Assert.Contains(expectedExtendedQueryTagTableFilter, builtString);
             Assert.Contains(expectedFilter, builtString);
@@ -255,18 +256,18 @@ AND cts1.TagValue=@p2";
         {
             var stringBuilder = new IndentedStringBuilder(new StringBuilder());
             var includeField = new QueryIncludeField(false, new List<DicomTag>());
-            var filter1 = new StringSingleValueMatchCondition(DicomTag.ModelGroupUID, "abc");
-            var filterDetails1 = new ExtendedQueryTagFilterDetails(1, QueryTagLevel.Series, DicomTag.ModelGroupUID.GetDefaultVR(), DicomTag.ModelGroupUID);
-            filter1.ExtendedQueryTagFilterDetails = filterDetails1;
-            var filter2 = new StringSingleValueMatchCondition(DicomTag.ContainerDescription, "description");
-            var filterDetails2 = new ExtendedQueryTagFilterDetails(2, QueryTagLevel.Series, DicomTag.ContainerDescription.GetDefaultVR(), DicomTag.ContainerDescription);
-            filter2.ExtendedQueryTagFilterDetails = filterDetails2;
+            var queryTag1 = new QueryTag(DicomTag.ModelGroupUID.BuildExtendedQueryTagStoreEntry(level: QueryTagLevel.Series));
+            var filter1 = new StringSingleValueMatchCondition(queryTag1, "abc");
+            filter1.QueryTag = queryTag1;
+            var queryTag2 = new QueryTag(DicomTag.ContainerDescription.BuildExtendedQueryTagStoreEntry(key: 2, level: QueryTagLevel.Series));
+            var filter2 = new StringSingleValueMatchCondition(queryTag2, "description");
+            filter2.QueryTag = queryTag2;
             var filters = new List<QueryFilterCondition>()
             {
                 filter1,
                 filter2,
             };
-            var query = new QueryExpression(QueryResource.AllInstances, includeField, false, 0, 0, filters, new List<ExtendedQueryTagFilterDetails>() { filterDetails1, filterDetails2 });
+            var query = new QueryExpression(QueryResource.AllInstances, includeField, false, 0, 0, filters);
 
             SqlParameterCollection sqlParameterCollection = CreateSqlParameterCollection();
             var parm = new SqlQueryParameterManager(sqlParameterCollection);
@@ -289,9 +290,9 @@ AND cts2.TagKey=@p2
 AND cts2.TagValue=@p3";
 
             string builtString = stringBuilder.ToString();
-            Assert.Equal(filterDetails1.Key.ToString(), sqlParameterCollection[0].Value.ToString());
+            Assert.Equal(queryTag1.ExtendedQueryTagStoreEntry.Key.ToString(), sqlParameterCollection[0].Value.ToString());
             Assert.Equal(filter1.Value.ToString(), sqlParameterCollection[1].Value.ToString());
-            Assert.Equal(filterDetails2.Key.ToString(), sqlParameterCollection[2].Value.ToString());
+            Assert.Equal(queryTag2.ExtendedQueryTagStoreEntry.Key.ToString(), sqlParameterCollection[2].Value.ToString());
             Assert.Equal(filter2.Value.ToString(), sqlParameterCollection[3].Value.ToString());
             Assert.Contains(expectedExtendedQueryTagTableFilter, builtString);
             Assert.Contains(expectedFilters, builtString);
@@ -302,22 +303,24 @@ AND cts2.TagValue=@p3";
         {
             var stringBuilder = new IndentedStringBuilder(new StringBuilder());
             var includeField = new QueryIncludeField(false, new List<DicomTag>());
-            var filter1 = new StringSingleValueMatchCondition(DicomTag.ModelGroupUID, "abc");
-            var filterDetails1 = new ExtendedQueryTagFilterDetails(1, QueryTagLevel.Instance, DicomTag.ModelGroupUID.GetDefaultVR(), DicomTag.ModelGroupUID);
-            filter1.ExtendedQueryTagFilterDetails = filterDetails1;
-            var filter2 = new StringSingleValueMatchCondition(DicomTag.ContainerDescription, "description");
-            var filterDetails2 = new ExtendedQueryTagFilterDetails(2, QueryTagLevel.Series, DicomTag.ContainerDescription.GetDefaultVR(), DicomTag.ContainerDescription);
-            filter2.ExtendedQueryTagFilterDetails = filterDetails2;
-            var filter3 = new LongSingleValueMatchCondition(DicomTag.NumberOfAssessmentObservations, 123);
-            var filterDetails3 = new ExtendedQueryTagFilterDetails(4, QueryTagLevel.Study, DicomTag.NumberOfAssessmentObservations.GetDefaultVR(), DicomTag.NumberOfAssessmentObservations);
-            filter3.ExtendedQueryTagFilterDetails = filterDetails3;
+            var queryTag1 = new QueryTag(DicomTag.ModelGroupUID.BuildExtendedQueryTagStoreEntry(key: 1, level: QueryTagLevel.Instance));
+            var filter1 = new StringSingleValueMatchCondition(queryTag1, "abc");
+            filter1.QueryTag = queryTag1;
+
+            var queryTag2 = new QueryTag(DicomTag.ContainerDescription.BuildExtendedQueryTagStoreEntry(key: 2, level: QueryTagLevel.Series));
+            var filter2 = new StringSingleValueMatchCondition(queryTag2, "description");
+            filter2.QueryTag = queryTag2;
+
+            var queryTag3 = new QueryTag(DicomTag.NumberOfAssessmentObservations.BuildExtendedQueryTagStoreEntry(key: 4, level: QueryTagLevel.Study));
+            var filter3 = new LongSingleValueMatchCondition(queryTag3, 123);
+            filter3.QueryTag = queryTag3;
             var filters = new List<QueryFilterCondition>()
             {
                 filter1,
                 filter2,
                 filter3,
             };
-            var query = new QueryExpression(QueryResource.AllInstances, includeField, false, 0, 0, filters, new List<ExtendedQueryTagFilterDetails>() { filterDetails1, filterDetails2, filterDetails3 });
+            var query = new QueryExpression(QueryResource.AllInstances, includeField, false, 0, 0, filters);
 
             SqlParameterCollection sqlParameterCollection = CreateSqlParameterCollection();
             var parm = new SqlQueryParameterManager(sqlParameterCollection);
@@ -345,11 +348,11 @@ AND ctl4.TagKey=@p4
 AND ctl4.TagValue=@p5";
 
             string builtString = stringBuilder.ToString();
-            Assert.Equal(filterDetails1.Key.ToString(), sqlParameterCollection[0].Value.ToString());
+            Assert.Equal(queryTag1.ExtendedQueryTagStoreEntry.Key.ToString(), sqlParameterCollection[0].Value.ToString());
             Assert.Equal(filter1.Value.ToString(), sqlParameterCollection[1].Value.ToString());
-            Assert.Equal(filterDetails2.Key.ToString(), sqlParameterCollection[2].Value.ToString());
+            Assert.Equal(queryTag2.ExtendedQueryTagStoreEntry.Key.ToString(), sqlParameterCollection[2].Value.ToString());
             Assert.Equal(filter2.Value.ToString(), sqlParameterCollection[3].Value.ToString());
-            Assert.Equal(filterDetails3.Key.ToString(), sqlParameterCollection[4].Value.ToString());
+            Assert.Equal(queryTag3.ExtendedQueryTagStoreEntry.Key.ToString(), sqlParameterCollection[4].Value.ToString());
             Assert.Equal(filter3.Value.ToString(), sqlParameterCollection[5].Value.ToString());
             Assert.Contains(expectedExtendedQueryTagTableFilter, builtString);
             Assert.Contains(expectedFilters, builtString);
@@ -362,7 +365,7 @@ AND ctl4.TagValue=@p5";
             var includeField = new QueryIncludeField(false, new List<DicomTag>());
             var filters = new List<QueryFilterCondition>()
             {
-                new PersonNameFuzzyMatchCondition(DicomTag.PatientName, "Fall 6"),
+                new PersonNameFuzzyMatchCondition(new QueryTag(DicomTag.PatientName), "Fall 6"),
             };
             var query = new QueryExpression(QueryResource.AllStudies, includeField, true, 10, 0, filters);
             SqlParameterCollection sqlParameterCollection = CreateSqlParameterCollection();
@@ -382,14 +385,14 @@ AND ctl4.TagValue=@p5";
         {
             var stringBuilder = new IndentedStringBuilder(new StringBuilder());
             var includeField = new QueryIncludeField(false, new List<DicomTag>());
-            var filter = new PersonNameFuzzyMatchCondition(DicomTag.ConsultingPhysicianName, "Fall 6");
-            var filterDetails = new ExtendedQueryTagFilterDetails(1, QueryTagLevel.Series, DicomTag.ConsultingPhysicianName.GetDefaultVR(), DicomTag.ConsultingPhysicianName);
-            filter.ExtendedQueryTagFilterDetails = filterDetails;
+            var queryTag = new QueryTag(DicomTag.ConsultingPhysicianName.BuildExtendedQueryTagStoreEntry(level: QueryTagLevel.Series));
+            var filter = new PersonNameFuzzyMatchCondition(queryTag, "Fall 6");
+            filter.QueryTag = queryTag;
             var filters = new List<QueryFilterCondition>()
             {
                 filter,
             };
-            var query = new QueryExpression(QueryResource.AllInstances, includeField, true, 10, 0, filters, new List<ExtendedQueryTagFilterDetails>() { filterDetails });
+            var query = new QueryExpression(QueryResource.AllInstances, includeField, true, 10, 0, filters);
             SqlParameterCollection sqlParameterCollection = CreateSqlParameterCollection();
             var parm = new SqlQueryParameterManager(sqlParameterCollection);
             new SqlQueryGenerator(stringBuilder, query, parm);
@@ -399,7 +402,7 @@ AND ctl4.TagValue=@p5";
             string expectedFilters = @"AND ctpn1.TagKey=@p0
 AND CONTAINS(ctpn1.TagValueWords, @p1)";
 
-            Assert.Equal(filterDetails.Key.ToString(), sqlParameterCollection[0].Value.ToString());
+            Assert.Equal(queryTag.ExtendedQueryTagStoreEntry.Key.ToString(), sqlParameterCollection[0].Value.ToString());
             Assert.Equal(expectedParam, sqlParameterCollection[1].Value.ToString());
             Assert.Contains(expectedFilters, stringBuilder.ToString());
         }

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Query/DicomTagSqlEntry.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Query/DicomTagSqlEntry.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using Dicom;
+using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 using Microsoft.Health.Dicom.SqlServer.Features.Schema.Model;
 using Microsoft.Health.SqlServer.Features.Schema.Model;
 
@@ -12,7 +13,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.Query
 {
     internal class DicomTagSqlEntry
     {
-        private static Dictionary<DicomTag, DicomTagSqlEntry> _tagToSqlMappingCache = new Dictionary<DicomTag, DicomTagSqlEntry>()
+        private static readonly IReadOnlyDictionary<DicomTag, DicomTagSqlEntry> CoreQueryTagToSqlMapping = new Dictionary<DicomTag, DicomTagSqlEntry>()
         {
                 { DicomTag.StudyInstanceUID, new DicomTagSqlEntry(SqlTableType.StudyTable, VLatest.Study.StudyInstanceUid) },
                 { DicomTag.StudyDate, new DicomTagSqlEntry(SqlTableType.StudyTable, VLatest.Study.StudyDate) },
@@ -27,7 +28,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.Query
                 { DicomTag.SOPInstanceUID, new DicomTagSqlEntry(SqlTableType.InstanceTable, VLatest.Instance.SopInstanceUid) },
         };
 
-        private static Dictionary<DicomVR, DicomTagSqlEntry> _extendedQueryTagToSqlMappingCache = new Dictionary<DicomVR, DicomTagSqlEntry>()
+        private static readonly IReadOnlyDictionary<DicomVR, DicomTagSqlEntry> ExtendedQueryTagVRToSqlMapping = new Dictionary<DicomVR, DicomTagSqlEntry>()
         {
                 { DicomVR.DA, new DicomTagSqlEntry(SqlTableType.ExtendedQueryTagDateTimeTable, VLatest.ExtendedQueryTagDateTime.TagValue, null, VLatest.ExtendedQueryTagDateTime.TagKey, true) },
                 { DicomVR.AE, new DicomTagSqlEntry(SqlTableType.ExtendedQueryTagStringTable, VLatest.ExtendedQueryTagString.TagValue, null, VLatest.ExtendedQueryTagString.TagKey, true) },
@@ -66,14 +67,9 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.Query
 
         public bool IsExtendedQueryTag { get; }
 
-        public static DicomTagSqlEntry GetDicomTagSqlEntry(DicomTag dicomTag, DicomVR extendedQueryTagVR = null)
+        public static DicomTagSqlEntry GetDicomTagSqlEntry(QueryTag queryTag)
         {
-            if (_tagToSqlMappingCache.ContainsKey(dicomTag))
-            {
-                return _tagToSqlMappingCache[dicomTag];
-            }
-
-            return _extendedQueryTagToSqlMappingCache[extendedQueryTagVR];
+            return queryTag.IsExtendedQueryTag ? ExtendedQueryTagVRToSqlMapping[queryTag.VR] : CoreQueryTagToSqlMapping[queryTag.Tag];
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Tests.Common/Comparers/ExtendedQueryTagStoreEntryEqualityComparer.cs
+++ b/src/Microsoft.Health.Dicom.Tests.Common/Comparers/ExtendedQueryTagStoreEntryEqualityComparer.cs
@@ -10,11 +10,11 @@ using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 
 namespace Microsoft.Health.Dicom.Tests.Common.Comparers
 {
-    public class ExtendedQueryTagEntryEqualityComparer : IEqualityComparer<ExtendedQueryTagEntry>
+    public class ExtendedQueryTagStoreEntryEqualityComparer : IEqualityComparer<ExtendedQueryTagStoreEntry>
     {
-        public static ExtendedQueryTagEntryEqualityComparer Default => new ExtendedQueryTagEntryEqualityComparer();
+        public static ExtendedQueryTagStoreEntryEqualityComparer Default => new ExtendedQueryTagStoreEntryEqualityComparer();
 
-        public bool Equals(ExtendedQueryTagEntry x, ExtendedQueryTagEntry y)
+        public bool Equals(ExtendedQueryTagStoreEntry x, ExtendedQueryTagStoreEntry y)
         {
             if (x == null || y == null)
             {
@@ -25,18 +25,20 @@ namespace Microsoft.Health.Dicom.Tests.Common.Comparers
                 && string.Equals(x.VR, y.VR, StringComparison.OrdinalIgnoreCase)
                 && x.PrivateCreator == y.PrivateCreator
                 && x.Level == y.Level
-                && x.Status == y.Status;
+                && x.Status == y.Status
+                && x.Key == y.Key;
         }
 
-        public int GetHashCode(ExtendedQueryTagEntry extendedQueryTagEntry)
+        public int GetHashCode(ExtendedQueryTagStoreEntry extendedQueryTagStoreEntry)
         {
-            EnsureArg.IsNotNull(extendedQueryTagEntry, nameof(extendedQueryTagEntry));
+            EnsureArg.IsNotNull(extendedQueryTagStoreEntry, nameof(extendedQueryTagStoreEntry));
             return HashCode.Combine(
-                extendedQueryTagEntry.Path,
-                extendedQueryTagEntry.VR,
-                extendedQueryTagEntry.PrivateCreator,
-                extendedQueryTagEntry.Level,
-                extendedQueryTagEntry.Status);
+                extendedQueryTagStoreEntry.Path,
+                extendedQueryTagStoreEntry.VR,
+                extendedQueryTagStoreEntry.PrivateCreator,
+                extendedQueryTagStoreEntry.Level,
+                extendedQueryTagStoreEntry.Status,
+                extendedQueryTagStoreEntry.Key);
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Tests.Common/Comparers/QueryTagComparer.cs
+++ b/src/Microsoft.Health.Dicom.Tests.Common/Comparers/QueryTagComparer.cs
@@ -1,0 +1,40 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using EnsureThat;
+using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
+
+namespace Microsoft.Health.Dicom.Tests.Common.Comparers
+{
+    public class QueryTagComparer : IEqualityComparer<QueryTag>
+    {
+        public static QueryTagComparer Default => new QueryTagComparer();
+
+        public bool Equals(QueryTag x, QueryTag y)
+        {
+            if (x == null || y == null)
+            {
+                return x == y;
+            }
+
+            return x.Tag == y.Tag &&
+                x.VR == y.VR
+                && x.Level == y.Level
+                && ExtendedQueryTagStoreEntryEqualityComparer.Default.Equals(x.ExtendedQueryTagStoreEntry, y.ExtendedQueryTagStoreEntry);
+        }
+
+        public int GetHashCode(QueryTag queryTag)
+        {
+            EnsureArg.IsNotNull(queryTag, nameof(queryTag));
+            return HashCode.Combine(
+                queryTag.Tag,
+                queryTag.VR,
+                queryTag.Level,
+                queryTag.ExtendedQueryTagStoreEntry);
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Tests.Common/Extensions/DicomTagExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Tests.Common/Extensions/DicomTagExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Health.Dicom.Tests.Common.Extensions
             return new ExtendedQueryTagEntry { Path = tag.GetPath(), VR = vr ?? tag.GetDefaultVR()?.Code, PrivateCreator = privateCreator, Level = level, Status = status };
         }
 
-        public static ExtendedQueryTagStoreEntry BuildExtendedQueryTagStoreEntry(this DicomTag tag, int key = 1, string vr = null, string privateCreator = null, QueryTagLevel level = QueryTagLevel.Series, ExtendedQueryTagStatus status = ExtendedQueryTagStatus.Adding)
+        public static ExtendedQueryTagStoreEntry BuildExtendedQueryTagStoreEntry(this DicomTag tag, int key = 1, string vr = null, string privateCreator = null, QueryTagLevel level = QueryTagLevel.Series, ExtendedQueryTagStatus status = ExtendedQueryTagStatus.Ready)
         {
             return new ExtendedQueryTagStoreEntry(key: key, path: tag.GetPath(), vr: vr ?? tag.GetDefaultVR().Code, privateCreator: privateCreator, level: level, status: status);
         }

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/ExtendedQueryTagStoreTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/ExtendedQueryTagStoreTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             DicomTag tag1 = DicomTag.DeviceSerialNumber;
             DicomTag tag2 = new DicomTag(0x0405, 0x1001, "PrivateCreator1");
             ExtendedQueryTagEntry extendedQueryTagEntry1 = tag1.BuildExtendedQueryTagEntry();
-            ExtendedQueryTagEntry extendedQueryTagEntry2 = tag2.BuildExtendedQueryTagEntry(vr: DicomVRCode.CS, privateCreator: tag2.PrivateCreator.Creator);
+            ExtendedQueryTagEntry extendedQueryTagEntry2 = tag2.BuildExtendedQueryTagEntry(vr: DicomVRCode.CS);
             await _extendedQueryTagStore.AddExtendedQueryTagsAsync(new ExtendedQueryTagEntry[] { extendedQueryTagEntry1, extendedQueryTagEntry2 });
 
             try


### PR DESCRIPTION
## Description
Update QIDO to use QueryTagService, otherwise Custom Tag services won't work after schema upgrade through schema manager

## Related issues
Addresses [AB#80932](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/80932)

## Testing
All automated tests pass.
