### PR TITLE
Mitigate SDL Bug from Newly Added Tool

### DIFF
--- a/build/analyze.yml
+++ b/build/analyze.yml
@@ -70,7 +70,7 @@ steps:
     SpotBugs: false
     TSLint: false
     WebScout: false
-    ToolLogsNotFoundAction: 'Error'
+    ToolLogsNotFoundAction: 'Standard'
 
 - task: PostAnalysis@2
   inputs:


### PR DESCRIPTION
## Description
A new tool "detekt" was added to the 1ES SDL tasks and "PublishSecurityAnalysisLogs" automatically checks for it. However, our settings currently throw an error if any task's output is missing. The 1ES team is rolling back this behavior, but in the meantime, we'll reduce this a message in stdout.

## Related issues
N/A

## Testing
PR pipeline passes
