### PR TITLE
Return BadRequest when ExtendedQueryTag is disabled

### DIFF
--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Controllers/ExtendedQueryTagControllerTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Controllers/ExtendedQueryTagControllerTests.cs
@@ -1,0 +1,36 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Dicom;
+using MediatR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Dicom.Api.Controllers;
+using Microsoft.Health.Dicom.Core.Exceptions;
+using Microsoft.Health.Dicom.Core.Extensions;
+using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Dicom.Api.UnitTests.Extensions
+{
+    public class ExtendedQueryTagControllerTests
+    {
+
+        [Fact]
+        public async Task GivenFeatureIsDisabled_WhenCallingApi_ThenShouldThrowException()
+        {
+            IMediator _mediator = Substitute.For<IMediator>();
+            var featureConfig = Options.Create(new Core.Configs.FeatureConfiguration() { EnableExtendedQueryTags = false });
+            ExtendedQueryTagController controller = new ExtendedQueryTagController(_mediator, NullLogger<ExtendedQueryTagController>.Instance, featureConfig);
+            await Assert.ThrowsAsync<ExtendedQueryTagFeatureDisabledException>(() => controller.GetTagAsync(DicomTag.PageNumberVector.GetPath()));
+            await Assert.ThrowsAsync<ExtendedQueryTagFeatureDisabledException>(() => controller.GetAllTagsAsync());
+            await Assert.ThrowsAsync<ExtendedQueryTagFeatureDisabledException>(() => controller.PostAsync(Array.Empty<ExtendedQueryTagEntry>()));
+            await Assert.ThrowsAsync<ExtendedQueryTagFeatureDisabledException>(() => controller.DeleteAsync(DicomTag.PageNumberVector.GetPath()));
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
@@ -152,6 +152,15 @@ namespace Microsoft.Health.Dicom.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Extended Query Tag feature is disabled..
+        /// </summary>
+        internal static string ExtendedQueryTagFeatureDisabled {
+            get {
+                return ResourceManager.GetString("ExtendedQueryTagFeatureDisabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The specified extended query tag with tag path {0} cannot be found..
         /// </summary>
         internal static string ExtendedQueryTagNotFound {

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
@@ -352,4 +352,7 @@ The first part date {1} should be lesser than or equal to the second part date {
     <value>The private creator is not empty for private identification code '{0}'.</value>
     <comment>{0} Dicom Tag.</comment>
   </data>
+  <data name="ExtendedQueryTagFeatureDisabled" xml:space="preserve">
+    <value>Extended Query Tag feature is disabled.</value>
+  </data>
 </root>

--- a/src/Microsoft.Health.Dicom.Core/Exceptions/ExtendedQueryTagFeatureDisabledException.cs
+++ b/src/Microsoft.Health.Dicom.Core/Exceptions/ExtendedQueryTagFeatureDisabledException.cs
@@ -1,0 +1,20 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+
+namespace Microsoft.Health.Dicom.Core.Exceptions
+{
+    /// <summary>
+    /// Exception that is thrown when extended query tag feature is disabled.
+    /// </summary>
+    public class ExtendedQueryTagFeatureDisabledException : BadRequestException
+    {
+        public ExtendedQueryTagFeatureDisabledException()
+            : base(string.Format(CultureInfo.InvariantCulture, DicomCoreResource.ExtendedQueryTagFeatureDisabled))
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Description
Return BadRequest when ExtendedQueryTag is disabled

## Related issues
Addresses [AB#80934](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/80934)

 
