### PR TITLE
Add query string validator.

### DIFF
--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Security/QueryStringValidatorMiddlewareTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Security/QueryStringValidatorMiddlewareTests.cs
@@ -1,0 +1,64 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Health.Dicom.Api.Features.Security;
+using Microsoft.Health.Dicom.Core.Exceptions;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Dicom.Api.UnitTests.Features.Security
+{
+    public class QueryStringValidatorMiddlewareTests
+    {
+        private readonly DefaultHttpContext _context;
+
+        public QueryStringValidatorMiddlewareTests()
+        {
+            _context = new DefaultHttpContext();
+        }
+
+        [Theory]
+        [InlineData("?<script>alert('test');</script>")]
+        [InlineData("?%3Cscript%3Ealert(%27test%27);%3C/script%3E")]
+        [InlineData("?%3cscript%3ealert(%27test%27);%3c/script%3e")]
+        public async Task WhenExecutingQueryStringValidatorMiddlewareMiddleware_GivenAnInvalidQueryString_TheExceptionShouldBeThrown(string queryString)
+        {
+            QueryStringValidatorMiddleware queryStringValidatorMiddleware = CreateQueryStringValidatorMiddleware(innerHttpContext => Task.CompletedTask);
+
+            _context.Request.QueryString = new QueryString(queryString);
+            await Assert.ThrowsAsync<InvalidQueryStringException>(() => queryStringValidatorMiddleware.Invoke(_context));
+        }
+
+        [Fact]
+        public async Task WhenExecutingQueryStringValidatorMiddlewareMiddleware_GivenAValidQueryString_TheNoExceptionShouldBeThrown()
+        {
+            QueryStringValidatorMiddleware queryStringValidatorMiddleware = CreateQueryStringValidatorMiddleware(innerHttpContext => Task.CompletedTask);
+
+            _context.Request.QueryString = new QueryString("?key=value");
+            await queryStringValidatorMiddleware.Invoke(_context);
+
+            Assert.Equal(200, _context.Response.StatusCode);
+            Assert.Null(_context.Response.ContentType);
+        }
+
+        [Fact]
+        public async Task WhenExecutingQueryStringValidatorMiddlewareMiddleware_GivenAnEmptyQueryString_TheNoExceptionShouldBeThrown()
+        {
+            QueryStringValidatorMiddleware queryStringValidatorMiddleware = CreateQueryStringValidatorMiddleware(innerHttpContext => Task.CompletedTask);
+
+            await queryStringValidatorMiddleware.Invoke(_context);
+
+            Assert.Equal(200, _context.Response.StatusCode);
+            Assert.Null(_context.Response.ContentType);
+        }
+
+        private QueryStringValidatorMiddleware CreateQueryStringValidatorMiddleware(RequestDelegate nextDelegate)
+        {
+            return Substitute.ForPartsOf<QueryStringValidatorMiddleware>(nextDelegate);
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Api/Features/Security/QueryStringValidatorMiddleware.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Security/QueryStringValidatorMiddleware.cs
@@ -13,8 +13,8 @@ namespace Microsoft.Health.Dicom.Api.Features.Security
 {
     internal class QueryStringValidatorMiddleware
     {
-        private const char UnencodedLessThan = '<';
-        private const string EnclodedLessThan = "%3c";
+        private const char UnEncodedLessThan = '<';
+        private const string EncodedLessThan = "%3c";
 
         private readonly RequestDelegate _next;
 
@@ -30,8 +30,8 @@ namespace Microsoft.Health.Dicom.Api.Features.Security
             EnsureArg.IsNotNull(context, nameof(context));
 
             if (context.Request.QueryString.HasValue
-                && (context.Request.QueryString.Value.Contains(UnencodedLessThan, StringComparison.InvariantCulture)
-                || context.Request.QueryString.Value.Contains(EnclodedLessThan, StringComparison.InvariantCultureIgnoreCase)))
+                && (context.Request.QueryString.Value.Contains(UnEncodedLessThan, StringComparison.InvariantCulture)
+                || context.Request.QueryString.Value.Contains(EncodedLessThan, StringComparison.InvariantCultureIgnoreCase)))
             {
                 throw new InvalidQueryStringException();
             }

--- a/src/Microsoft.Health.Dicom.Api/Features/Security/QueryStringValidatorMiddleware.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Security/QueryStringValidatorMiddleware.cs
@@ -1,0 +1,42 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using EnsureThat;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Health.Dicom.Core.Exceptions;
+
+namespace Microsoft.Health.Dicom.Api.Features.Security
+{
+    internal class QueryStringValidatorMiddleware
+    {
+        private const char UnencodedLessThan = '<';
+        private const string EnclodedLessThan = "%3c";
+
+        private readonly RequestDelegate _next;
+
+        public QueryStringValidatorMiddleware(RequestDelegate next)
+        {
+            EnsureArg.IsNotNull(next, nameof(next));
+
+            _next = next;
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            EnsureArg.IsNotNull(context, nameof(context));
+
+            if (context.Request.QueryString.HasValue
+                && (context.Request.QueryString.Value.Contains(UnencodedLessThan, StringComparison.InvariantCulture)
+                || context.Request.QueryString.Value.Contains(EnclodedLessThan, StringComparison.InvariantCultureIgnoreCase)))
+            {
+                throw new InvalidQueryStringException();
+            }
+
+            await _next(context);
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Api/Features/Security/QueryStringValidatorMiddlewareExtension.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Security/QueryStringValidatorMiddlewareExtension.cs
@@ -1,0 +1,19 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using EnsureThat;
+using Microsoft.Health.Dicom.Api.Features.Security;
+
+namespace Microsoft.AspNetCore.Builder
+{
+    internal static class QueryStringValidatorMiddlewareExtension
+    {
+        public static IApplicationBuilder UseQueryStringValidator(this IApplicationBuilder builder)
+        {
+            EnsureArg.IsNotNull(builder);
+            return builder.UseMiddleware<QueryStringValidatorMiddleware>();
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Api/Registration/DicomServerApplicationBuilderExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Api/Registration/DicomServerApplicationBuilderExtensions.cs
@@ -27,6 +27,8 @@ namespace Microsoft.AspNetCore.Builder
         {
             EnsureArg.IsNotNull(app, nameof(app));
 
+            app.UseQueryStringValidator();
+
             app.UseMvc();
 
             app.UseHealthChecksExtension(new PathString(KnownRoutes.HealthCheck));

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Dicom.Core {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class DicomCoreResource {
@@ -311,6 +311,15 @@ namespace Microsoft.Health.Dicom.Core {
         internal static string InvalidOffsetValue {
             get {
                 return ResourceManager.GetString("InvalidOffsetValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The query string included invalid characters..
+        /// </summary>
+        internal static string InvalidQueryString {
+            get {
+                return ResourceManager.GetString("InvalidQueryString", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -188,6 +188,9 @@ The first part date {1} should be lesser than or equal to the second part date {
   </data>
   <data name="InvalidOffsetValue" xml:space="preserve">
     <value>Invalid QIDO-RS query. Specified offset value '{0}' is not a valid integer.</value>
+  </data>
+  <data name="InvalidQueryString" xml:space="preserve">
+    <value>The query string included invalid characters.</value>
   </data>
   <data name="InvalidQueryStringValue" xml:space="preserve">
     <value>The following query parameter is invalid: {0}.</value>

--- a/src/Microsoft.Health.Dicom.Core/Exceptions/InvalidQueryStringException.cs
+++ b/src/Microsoft.Health.Dicom.Core/Exceptions/InvalidQueryStringException.cs
@@ -1,0 +1,17 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+
+namespace Microsoft.Health.Dicom.Core.Exceptions
+{
+    public class InvalidQueryStringException : ValidationException
+    {
+        public InvalidQueryStringException()
+            : base(string.Format(CultureInfo.InvariantCulture, DicomCoreResource.InvalidQueryString))
+        {
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Web/Microsoft.Health.Dicom.Web.csproj
+++ b/src/Microsoft.Health.Dicom.Web/Microsoft.Health.Dicom.Web.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="IdentityServer4" Version="4.1.2" />
     <PackageReference Include="IdentityServer4.Storage" Version="4.1.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.17.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.5" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.13" />

--- a/src/Microsoft.Health.Dicom.Web/Microsoft.Health.Dicom.Web.csproj
+++ b/src/Microsoft.Health.Dicom.Web/Microsoft.Health.Dicom.Web.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Health.Development.IdentityProvider" Version="$(HealthcareSharedPackageVersion)" />
     <PackageReference Include="Microsoft.Health.SqlServer" Version="$(HealthcareSharedPackageVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/scale-testing/Common/Common.csproj
+++ b/tools/scale-testing/Common/Common.csproj
@@ -8,7 +8,6 @@
     <PackageReference Include="Ensure.That" Version="10.0.0" />
     <PackageReference Include="fo-dicom" Version="4.0.7" NoWarn="NU1701" />
     <PackageReference Include="fo-dicom.json" Version="4.0.7" NoWarn="NU1701" />
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>


### PR DESCRIPTION
## Description
This PR adds a query string validator that denies. requests with a `<` or `%3c`

## Related issues
Addresses [AB#79711](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/79711).

## Testing
New unit tests added.
