### PR TITLE
Fix bug: Invalid private  TagPath "Unknown" is accepted

### DIFF
--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Common/DicomTagParserTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Common/DicomTagParserTests.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Common
             yield return new object[] { DicomTag.AcquisitionDateTime.DictionaryEntry.Keyword.ToLowerInvariant() }; // keyword in lower case
             yield return new object[] { "0018B001" }; // unknown tag
             yield return new object[] { "0018B001A1" }; // longer than 8
+            yield return new object[] { "Unknown" }; // bug https://microsofthealth.visualstudio.com/Health/_workitems/edit/80766
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Common/DicomTagParserTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Common/DicomTagParserTests.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Common
             yield return new object[] { DicomTag.AcquisitionDateTime.GetPath().ToLowerInvariant(), DicomTag.AcquisitionDateTime }; // attribute id on lower case
             yield return new object[] { DicomTag.AcquisitionDateTime.DictionaryEntry.Keyword, DicomTag.AcquisitionDateTime }; // keyword
             yield return new object[] { "12051003", DicomTag.Parse("12051003") }; // private tag
+            yield return new object[] { "24010010", DicomTag.Parse("24010010") }; // Private Identification code
         }
 
         public static IEnumerable<object[]> GetInvalidTags()
@@ -56,6 +57,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Common
             yield return new object[] { "0018B001" }; // unknown tag
             yield return new object[] { "0018B001A1" }; // longer than 8
             yield return new object[] { "Unknown" }; // bug https://microsofthealth.visualstudio.com/Health/_workitems/edit/80766
+            yield return new object[] { "PrivateCreator" }; // Key word to Private Identification code
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Common/DicomTagParserTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Common/DicomTagParserTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Common
             yield return new object[] { null }; // attribute id on lower case
             yield return new object[] { DicomTag.AcquisitionDateTime.DictionaryEntry.Keyword.ToLowerInvariant() }; // keyword in lower case
             yield return new object[] { "0018B001" }; // unknown tag
-            yield return new object[] { "0018B001A1" }; // longer than 8
+            yield return new object[] { "0018B001A1" }; // longer than 8.
             yield return new object[] { "Unknown" }; // bug https://microsofthealth.visualstudio.com/Health/_workitems/edit/80766
             yield return new object[] { "PrivateCreator" }; // Key word to Private Identification code.
         }

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Common/DicomTagParserTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Common/DicomTagParserTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Common
             yield return new object[] { "0018B001" }; // unknown tag
             yield return new object[] { "0018B001A1" }; // longer than 8
             yield return new object[] { "Unknown" }; // bug https://microsofthealth.visualstudio.com/Health/_workitems/edit/80766
-            yield return new object[] { "PrivateCreator" }; // Key word to Private Identification code
+            yield return new object[] { "PrivateCreator" }; // Key word to Private Identification code.
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Common/DicomTagParser.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Common/DicomTagParser.cs
@@ -27,6 +27,9 @@ namespace Microsoft.Health.Dicom.Core.Features.Common
                 return false;
             }
 
+            // DicomDictionary.Default contains private tags by default which we don't need       
+            DicomDictionary.EnsureDefaultDictionariesLoaded(false);
+
             // Try Keyword match, returns null if not found
             DicomTag dicomTag = DicomDictionary.Default[dicomTagPath];
 

--- a/src/Microsoft.Health.Dicom.Core/Features/Common/DicomTagParser.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Common/DicomTagParser.cs
@@ -27,11 +27,8 @@ namespace Microsoft.Health.Dicom.Core.Features.Common
                 return false;
             }
 
-            // DicomDictionary.Default contains private tags by default which we don't need       
-            DicomDictionary.EnsureDefaultDictionariesLoaded(false);
 
-            // Try Keyword match, returns null if not found
-            DicomTag dicomTag = DicomDictionary.Default[dicomTagPath];
+            DicomTag dicomTag = ParseDicomTagKeyword(dicomTagPath);
 
             if (dicomTag == null)
             {
@@ -40,6 +37,20 @@ namespace Microsoft.Health.Dicom.Core.Features.Common
 
             dicomTags = new DicomTag[] { dicomTag };
             return dicomTag != null;
+        }
+
+        private static DicomTag ParseDicomTagKeyword(string keyword)
+        {
+            // Try Keyword match, returns null if not found
+            DicomTag dicomTag = DicomDictionary.Default[keyword];
+
+            if (dicomTag == null)
+            {
+                return null;
+            }
+
+            // We don't accept private tag from keywrod
+            return dicomTag.IsPrivate ? null : dicomTag;
         }
 
         private static DicomTag ParseDicomTagNumber(string s)

--- a/src/Microsoft.Health.Dicom.Core/Features/Common/DicomTagParser.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Common/DicomTagParser.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Common
             }
 
 
-            DicomTag dicomTag = ParseDicomTagKeyword(dicomTagPath);
+            DicomTag dicomTag = ParseStardandDicomTagKeyword(dicomTagPath);
 
             if (dicomTag == null)
             {
@@ -39,18 +39,13 @@ namespace Microsoft.Health.Dicom.Core.Features.Common
             return dicomTag != null;
         }
 
-        private static DicomTag ParseDicomTagKeyword(string keyword)
+        private static DicomTag ParseStardandDicomTagKeyword(string keyword)
         {
             // Try Keyword match, returns null if not found
             DicomTag dicomTag = DicomDictionary.Default[keyword];
 
-            if (dicomTag == null)
-            {
-                return null;
-            }
-
             // We don't accept private tag from keywrod
-            return dicomTag.IsPrivate ? null : dicomTag;
+            return (dicomTag != null && dicomTag.IsPrivate) ? null : dicomTag;
         }
 
         private static DicomTag ParseDicomTagNumber(string s)


### PR DESCRIPTION
## Description
Fix bug: Invalid private  TagPath "Unknown" is accepted

## Related issues
Addresses [AB#80766](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/80766)

## Testing
All automation tests pass

## Notes
The reason why EnsureDefaultDictionariesLoaded(false) doesnt' work:
* that method is widely used. One popular is DicomTag.Parse. So it's very hard to make sure it's always initialized without private tags.