### PR TITLE
When VR doesn't match, skip the dicom element

### DIFF
--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Extensions/DicomDatasetExtensionsTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Extensions/DicomDatasetExtensionsTests.cs
@@ -21,6 +21,16 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Extensions
         private readonly DicomDataset _dicomDataset = new DicomDataset();
 
         [Fact]
+        public void GivenDicomTagWithDifferentVR_WhenGetSingleOrDefaultIsCalled_ThenShouldReturnNull()
+        {
+            DicomTag tag = DicomTag.AbortReason;
+            DicomVR expectedVR = DicomVR.CS;
+            DicomElement element = new DicomLongString(tag, "Value");
+            _dicomDataset.Add(element);
+            Assert.Null(_dicomDataset.GetSingleValueOrDefault<string>(tag, expectedVR));
+        }
+
+        [Fact]
         public void GivenDicomTagDoesNotExist_WhenGetSingleOrDefaultIsCalled_ThenDefaultValueShouldBeReturned()
         {
             Assert.Equal(default, _dicomDataset.GetSingleValueOrDefault<string>(DicomTag.StudyInstanceUID));

--- a/src/Microsoft.Health.Dicom.Core/Extensions/DicomDatasetExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Extensions/DicomDatasetExtensions.cs
@@ -37,10 +37,19 @@ namespace Microsoft.Health.Dicom.Core.Extensions
         /// <typeparam name="T">The value type.</typeparam>
         /// <param name="dicomDataset">The dataset to get the VR value from.</param>
         /// <param name="dicomTag">The DICOM tag.</param>
+        /// <param name="expectedVR">Expected VR of the element.</param>
+        /// <remarks>If expectedVR is provided, and not match, will return default<typeparamref name="T"/></remarks>
         /// <returns>The value if the value exists; otherwise, the default value for the type <typeparamref name="T"/>.</returns>
-        public static T GetSingleValueOrDefault<T>(this DicomDataset dicomDataset, DicomTag dicomTag)
+        public static T GetSingleValueOrDefault<T>(this DicomDataset dicomDataset, DicomTag dicomTag, DicomVR expectedVR = null)
         {
             EnsureArg.IsNotNull(dicomDataset, nameof(dicomDataset));
+
+            // If VR doesn't match, return default(T)
+            if (expectedVR != null && dicomDataset.GetDicomItem<DicomElement>(dicomTag)?.ValueRepresentation != expectedVR)
+            {
+                return default;
+            }
+
             return dicomDataset.GetSingleValueOrDefault<T>(dicomTag, default);
         }
 
@@ -49,11 +58,13 @@ namespace Microsoft.Health.Dicom.Core.Extensions
         /// </summary>
         /// <param name="dicomDataset">The dataset to get the VR value from.</param>
         /// <param name="dicomTag">The DICOM tag.</param>
+        /// <param name="expectedVR">Expected VR of the element.</param>
+        /// /// <remarks>If expectedVR is provided, and not match, will return null.</remarks>
         /// <returns>An instance of <see cref="DateTime"/> if the value exists and comforms to the DA format; otherwise <c>null</c>.</returns>
-        public static DateTime? GetStringDateAsDate(this DicomDataset dicomDataset, DicomTag dicomTag)
+        public static DateTime? GetStringDateAsDate(this DicomDataset dicomDataset, DicomTag dicomTag, DicomVR expectedVR = null)
         {
             EnsureArg.IsNotNull(dicomDataset, nameof(dicomDataset));
-            string stringDate = dicomDataset.GetSingleValueOrDefault<string>(dicomTag, default);
+            string stringDate = dicomDataset.GetSingleValueOrDefault<string>(dicomTag, expectedVR: expectedVR);
             return DateTime.TryParseExact(stringDate, DateFormatDA, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime result) ? result : null;
         }
 

--- a/src/Microsoft.Health.Dicom.Core/Features/Store/DicomDatasetValidator.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Store/DicomDatasetValidator.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Store
             {
                 DicomElement dicomElement = dicomDataset.GetDicomItem<DicomElement>(queryTag.Tag);
 
-                if (dicomElement != null)
+                if (dicomElement != null && dicomElement.ValueRepresentation == queryTag.VR)
                 {
                     _minimumValidator.Validate(dicomElement);
                 }

--- a/src/Microsoft.Health.Dicom.SqlServer.UnitTests/Features/ExtendedQueryTag/AddInstanceTableValuedParametersBuilderTests.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer.UnitTests/Features/ExtendedQueryTag/AddInstanceTableValuedParametersBuilderTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Health.Dicom.SqlServer.UnitTests.Features.Query
         {
             DicomDataset dataset = new DicomDataset();
             dataset.Add(element);
-            QueryTag tag = new QueryTag(element.Tag.BuildExtendedQueryTagStoreEntry());
+            QueryTag tag = new QueryTag(element.Tag.BuildExtendedQueryTagStoreEntry(vr: element.ValueRepresentation.Code));
             var parameters = AddInstanceTableValuedParametersBuilder.Build(dataset, new QueryTag[] { tag });
 
             ExtendedQueryTagDataType dataType = ExtendedQueryTagLimit.ExtendedQueryTagVRAndDataTypeMapping[element.ValueRepresentation.Code];

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/AddInstanceTableValuedParametersBuilder.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/AddInstanceTableValuedParametersBuilder.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
     /// </summary>
     internal static class AddInstanceTableValuedParametersBuilder
     {
-        private static readonly Dictionary<DicomVR, Func<DicomDataset, DicomTag, DateTime?>> DataTimeReaders = new Dictionary<DicomVR, Func<DicomDataset, DicomTag, DateTime?>>()
+        private static readonly Dictionary<DicomVR, Func<DicomDataset, DicomTag, DicomVR, DateTime?>> DataTimeReaders = new Dictionary<DicomVR, Func<DicomDataset, DicomTag, DicomVR, DateTime?>>()
         {
             { DicomVR.DA, Core.Extensions.DicomDatasetExtensions.GetStringDateAsDate },
         };
@@ -83,7 +83,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
 
         private static void AddPersonNameRow(DicomDataset instance, List<InsertPersonNameExtendedQueryTagTableTypeV1Row> personNamRows, QueryTag queryTag)
         {
-            string personNameVal = instance.GetSingleValueOrDefault<string>(queryTag.Tag);
+            string personNameVal = instance.GetSingleValueOrDefault<string>(queryTag.Tag, expectedVR: queryTag.VR);
             if (personNameVal != null)
             {
                 personNamRows.Add(new InsertPersonNameExtendedQueryTagTableTypeV1Row(queryTag.ExtendedQueryTagStoreEntry.Key, personNameVal, (byte)queryTag.Level));
@@ -94,7 +94,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
         {
             DateTime? dateVal = DataTimeReaders.TryGetValue(
                              queryTag.VR,
-                             out Func<DicomDataset, DicomTag, DateTime?> reader) ? reader.Invoke(instance, queryTag.Tag) : null;
+                             out Func<DicomDataset, DicomTag, DicomVR, DateTime?> reader) ? reader.Invoke(instance, queryTag.Tag, queryTag.VR) : null;
 
             if (dateVal.HasValue)
             {
@@ -104,7 +104,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
 
         private static void AddDoubleRow(DicomDataset instance, List<InsertDoubleExtendedQueryTagTableTypeV1Row> doubleRows, QueryTag queryTag)
         {
-            double? doubleVal = instance.GetSingleValueOrDefault<double>(queryTag.Tag);
+            double? doubleVal = instance.GetSingleValueOrDefault<double>(queryTag.Tag, expectedVR: queryTag.VR);
             if (doubleVal.HasValue)
             {
                 doubleRows.Add(new InsertDoubleExtendedQueryTagTableTypeV1Row(queryTag.ExtendedQueryTagStoreEntry.Key, doubleVal.Value, (byte)queryTag.Level));
@@ -113,7 +113,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
 
         private static void AddLongRow(DicomDataset instance, List<InsertLongExtendedQueryTagTableTypeV1Row> longRows, QueryTag queryTag)
         {
-            long? longVal = instance.GetSingleValueOrDefault<long>(queryTag.Tag);
+            long? longVal = instance.GetSingleValueOrDefault<long>(queryTag.Tag, expectedVR: queryTag.VR);
 
             if (longVal.HasValue)
             {
@@ -123,7 +123,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
 
         private static void AddStringRow(DicomDataset instance, List<InsertStringExtendedQueryTagTableTypeV1Row> stringRows, QueryTag queryTag)
         {
-            string stringVal = instance.GetSingleValueOrDefault<string>(queryTag.Tag);
+            string stringVal = instance.GetSingleValueOrDefault<string>(queryTag.Tag, expectedVR: queryTag.VR);
             if (stringVal != null)
             {
                 stringRows.Add(new InsertStringExtendedQueryTagTableTypeV1Row(queryTag.ExtendedQueryTagStoreEntry.Key, stringVal, (byte)queryTag.Level));


### PR DESCRIPTION
## Description
When element has different VR than expected, skip both validation and store.

## Related issues
Addresses [AB#81009](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/81009)

## Testing
* All automated tests pass.
* Manually verified bug not repro.
