### PR TITLE
Throw ExtendedQueryTagNotFoundException when tag doesn't exist

### DIFF
--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/DeleteExtendedQueryTagServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/DeleteExtendedQueryTagServiceTests.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Dicom;
@@ -37,8 +36,8 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.ChangeFeed
         [Fact]
         public async Task GivenNotExistingTagPath_WhenDeleteExtendedQueryTagIsInvoked_ThenShouldThrowException()
         {
-            _extendedQueryTagStore.GetExtendedQueryTagsAsync(default, default).ReturnsForAnyArgs(new Func<NSubstitute.Core.CallInfo, IReadOnlyList<ExtendedQueryTagStoreEntry>>((x) => { throw new Exception(); }));
-            await Assert.ThrowsAsync<Exception>(() => _extendedQueryTagService.DeleteExtendedQueryTagAsync(DicomTag.DeviceSerialNumber.GetPath()));
+            _extendedQueryTagStore.GetExtendedQueryTagsAsync(default, default).ReturnsForAnyArgs(new List<ExtendedQueryTagStoreEntry>());
+            await Assert.ThrowsAsync<ExtendedQueryTagNotFoundException>(() => _extendedQueryTagService.DeleteExtendedQueryTagAsync(DicomTag.DeviceSerialNumber.GetPath()));
         }
 
         [Fact]

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/DeleteExtendedQueryTagService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/DeleteExtendedQueryTagService.cs
@@ -46,6 +46,10 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
             {
                 await _extendedQueryTagStore.DeleteExtendedQueryTagAsync(normalizedPath, extendedQueryTagEntries[0].VR, cancellationToken);
             }
+            else
+            {
+                throw new ExtendedQueryTagNotFoundException(string.Format(DicomCoreResource.ExtendedQueryTagNotFound, tagPath));
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
Throw ExtendedQueryTagNotFoundException when tag doesn't exist

## Related issues
Addresses [AB#81032](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/81032)

