### PR TITLE
AddDicomBackgroundWorkers to extended on IDicomServerBuilder 

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
@@ -42,11 +42,14 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// Add services for DICOM background workers.
         /// </summary>
-        /// <param name="services">The services collection.</param>
-        public static void AddDicomBackgroundWorkers(this IServiceCollection services)
+        /// <param name="serverBuilder">The DICOM server builder instance.</param>
+        /// <returns>The DICOM server builder instance.</returns>
+        public static IDicomServerBuilder AddBackgroundWorkers(this IDicomServerBuilder serverBuilder)
         {
-            services.AddScoped<DeletedInstanceCleanupWorker>();
-            services.AddHostedService<DeletedInstanceCleanupBackgroundService>();
+            EnsureArg.IsNotNull(serverBuilder, nameof(serverBuilder));
+            serverBuilder.Services.AddScoped<DeletedInstanceCleanupWorker>();
+            serverBuilder.Services.AddHostedService<DeletedInstanceCleanupBackgroundService>();
+            return serverBuilder;
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Dicom.Web/Startup.cs
+++ b/src/Microsoft.Health.Dicom.Web/Startup.cs
@@ -33,13 +33,12 @@ namespace Microsoft.Health.Dicom.Web
             services.AddDicomServer(Configuration)
                 .AddBlobStorageDataStore(Configuration)
                 .AddMetadataStorageDataStore(Configuration)
-                .AddSqlServer(Configuration);
-
-            /*
-               The execution of IHostedServices depends on the order they are added to the dependency injection container, so we
-               need to ensure that the schema is initialized before the background workers are started.
-           */
-            services.AddDicomBackgroundWorkers();
+                .AddSqlServer(Configuration)
+                /*
+                    The execution of IHostedServices depends on the order they are added to the dependency injection container, so we
+                    need to ensure that the schema is initialized before the background workers are started.
+                */
+                .AddBackgroundWorkers();
 
             AddApplicationInsightsTelemetry(services);
         }


### PR DESCRIPTION
## Description
AddDicomBackgroundWorkers to extended on IDicomServerBuilder  instead of IServiceCollection

## Related issues
Addresses [AB#80433](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/80433)

## Testing
All automated test passed

## Notes
The extension method AddDicomBackgroundWorkers(this IServiceCollection services) should probably extend IDicomServerBuilder instead of IServiceCollection. This could make startUp code more clear.
