### PR TITLE
Fix flaky end to end tests

### DIFF
--- a/src/Microsoft.Health.Dicom.Tests.Common/Comparers/DicomFileEqualityComparer.cs
+++ b/src/Microsoft.Health.Dicom.Tests.Common/Comparers/DicomFileEqualityComparer.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using Dicom;
 using EnsureThat;
@@ -11,39 +12,45 @@ namespace Microsoft.Health.Dicom.Tests.Common.Comparers
 {
     public class DicomFileEqualityComparer : IEqualityComparer<DicomFile>
     {
+        private static DicomFileEqualityComparer _default = new DicomFileEqualityComparer();
+
+        public static DicomFileEqualityComparer Default => _default;
+
+        private readonly DicomItemCollectionEqualityComparer _metadataComparer;
+        private readonly DicomDatasetEqualityComparer _datasetComparer;
+        private readonly IEnumerable<DicomTag> _ignoredTags;
+
         public DicomFileEqualityComparer()
-           : this(new DicomTag[0])
+           : this(Array.Empty<DicomTag>())
         {
         }
 
         public DicomFileEqualityComparer(IEnumerable<DicomTag> ignoredTags)
         {
             EnsureArg.IsNotNull(ignoredTags, nameof(ignoredTags));
-            IgnoredTags = ignoredTags;
+            _ignoredTags = ignoredTags;
+            _metadataComparer = new DicomItemCollectionEqualityComparer(_ignoredTags);
+            _datasetComparer = new DicomDatasetEqualityComparer(_ignoredTags);
         }
 
-        bool IEqualityComparer<DicomFile>.Equals(DicomFile x, DicomFile y)
+        public bool Equals(DicomFile x, DicomFile y)
         {
             if (x == null || y == null)
             {
                 return object.ReferenceEquals(x, y);
             }
 
-            IEqualityComparer<IEnumerable<DicomItem>> metadataComparer = new DicomItemCollectionEqualityComparer(IgnoredTags);
-            if (!metadataComparer.Equals(x.FileMetaInfo, y.FileMetaInfo))
+            if (!_metadataComparer.Equals(x.FileMetaInfo, y.FileMetaInfo))
             {
                 return false;
             }
 
-            IEqualityComparer<DicomDataset> dataSetComparer = new DicomDatasetEqualityComparer(IgnoredTags);
-            return dataSetComparer.Equals(x.Dataset, y.Dataset);
+            return _datasetComparer.Equals(x.Dataset, y.Dataset);
         }
 
-        int IEqualityComparer<DicomFile>.GetHashCode(DicomFile obj)
+        public int GetHashCode(DicomFile obj)
         {
             return obj.GetHashCode();
         }
-
-        public IEnumerable<DicomTag> IgnoredTags { get; }
     }
 }

--- a/src/Microsoft.Health.Dicom.Tests.Common/Comparers/DicomItemEqualityComparer.cs
+++ b/src/Microsoft.Health.Dicom.Tests.Common/Comparers/DicomItemEqualityComparer.cs
@@ -17,6 +17,10 @@ namespace Microsoft.Health.Dicom.Tests.Common.Comparers
     /// </summary>
     public class DicomItemEqualityComparer : IEqualityComparer<DicomItem>
     {
+        private static DicomItemEqualityComparer _default = new DicomItemEqualityComparer();
+
+        public static DicomItemEqualityComparer Default => _default;
+
         public bool Equals([AllowNull] DicomItem x, [AllowNull] DicomItem y)
         {
             if (x == null || y == null)

--- a/src/Microsoft.Health.Dicom.Tests.Common/Comparers/DicomPixelDataEqualityComparer.cs
+++ b/src/Microsoft.Health.Dicom.Tests.Common/Comparers/DicomPixelDataEqualityComparer.cs
@@ -11,7 +11,11 @@ namespace Microsoft.Health.Dicom.Tests.Common.Comparers
 {
     public class DicomPixelDataEqualityComparer : IEqualityComparer<DicomPixelData>
     {
-        bool IEqualityComparer<DicomPixelData>.Equals(DicomPixelData x, DicomPixelData y)
+        private static DicomPixelDataEqualityComparer _default = new DicomPixelDataEqualityComparer();
+
+        public static DicomPixelDataEqualityComparer Default => _default;
+
+        public bool Equals(DicomPixelData x, DicomPixelData y)
         {
             if (x == null || y == null)
             {
@@ -59,7 +63,7 @@ namespace Microsoft.Health.Dicom.Tests.Common.Comparers
             return true;
         }
 
-        int IEqualityComparer<DicomPixelData>.GetHashCode(DicomPixelData obj)
+        public int GetHashCode(DicomPixelData obj)
         {
             return obj.GetHashCode();
         }

--- a/src/Microsoft.Health.Dicom.Tests.Common/Comparers/ExtendedQueryTagEntryEqualityComparer.cs
+++ b/src/Microsoft.Health.Dicom.Tests.Common/Comparers/ExtendedQueryTagEntryEqualityComparer.cs
@@ -12,7 +12,10 @@ namespace Microsoft.Health.Dicom.Tests.Common.Comparers
 {
     public class ExtendedQueryTagEntryEqualityComparer : IEqualityComparer<ExtendedQueryTagEntry>
     {
-        public static ExtendedQueryTagEntryEqualityComparer Default => new ExtendedQueryTagEntryEqualityComparer();
+        private static ExtendedQueryTagEntryEqualityComparer _default = new ExtendedQueryTagEntryEqualityComparer();
+
+        public static ExtendedQueryTagEntryEqualityComparer Default => _default;
+
 
         public bool Equals(ExtendedQueryTagEntry x, ExtendedQueryTagEntry y)
         {

--- a/src/Microsoft.Health.Dicom.Tests.Common/Comparers/ExtendedQueryTagStoreEntryEqualityComparer.cs
+++ b/src/Microsoft.Health.Dicom.Tests.Common/Comparers/ExtendedQueryTagStoreEntryEqualityComparer.cs
@@ -12,7 +12,9 @@ namespace Microsoft.Health.Dicom.Tests.Common.Comparers
 {
     public class ExtendedQueryTagStoreEntryEqualityComparer : IEqualityComparer<ExtendedQueryTagStoreEntry>
     {
-        public static ExtendedQueryTagStoreEntryEqualityComparer Default => new ExtendedQueryTagStoreEntryEqualityComparer();
+        private static ExtendedQueryTagStoreEntryEqualityComparer _default = new ExtendedQueryTagStoreEntryEqualityComparer();
+
+        public static ExtendedQueryTagStoreEntryEqualityComparer Default => _default;
 
         public bool Equals(ExtendedQueryTagStoreEntry x, ExtendedQueryTagStoreEntry y)
         {

--- a/src/Microsoft.Health.Dicom.Tests.Common/Comparers/QueryTagComparer.cs
+++ b/src/Microsoft.Health.Dicom.Tests.Common/Comparers/QueryTagComparer.cs
@@ -12,7 +12,9 @@ namespace Microsoft.Health.Dicom.Tests.Common.Comparers
 {
     public class QueryTagComparer : IEqualityComparer<QueryTag>
     {
-        public static QueryTagComparer Default => new QueryTagComparer();
+        private static QueryTagComparer _default = new QueryTagComparer();
+
+        public static QueryTagComparer Default => _default;
 
         public bool Equals(QueryTag x, QueryTag y)
         {

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Frame.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Frame.cs
@@ -60,7 +60,6 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
                 Assert.Equal(item.ToByteArray(), pixelData.GetFrame(frameIndex).Data);
                 frameIndex++;
             }
-
         }
 
         [Theory]

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Frame.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Frame.cs
@@ -36,10 +36,10 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
         public async Task GivenSupportedAcceptHeaders_WhenRetrieveFrame_ThenServerShouldReturnExpectedContent(string testDataFolder, string mediaType, string transferSyntax)
         {
             TranscoderTestData transcoderTestData = TranscoderTestDataHelper.GetTestData(testDataFolder);
-            DicomFile inputDicomFile = await DicomFile.OpenAsync(transcoderTestData.InputDicomFile);
-            await EnsureFileIsStoredAsync(inputDicomFile);
-            var instanceId = inputDicomFile.Dataset.ToInstanceIdentifier();
-            _studiesToClean.Add(instanceId.StudyInstanceUid);
+            DicomFile inputDicomFile = await DicomFile.OpenAsync(transcoderTestData.InputDicomFile);             
+            var instanceId = RandomizeInstanceIdentifier(inputDicomFile.Dataset);
+
+            await InternalStoreAsync(new[] { inputDicomFile });
 
             DicomFile outputDicomFile = DicomFile.Open(transcoderTestData.ExpectedOutputDicomFile);
             DicomPixelData pixelData = DicomPixelData.Create(outputDicomFile.Dataset);
@@ -60,6 +60,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
                 Assert.Equal(item.ToByteArray(), pixelData.GetFrame(frameIndex).Data);
                 frameIndex++;
             }
+
         }
 
         [Theory]

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Instance.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Instance.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
 
             Assert.Equal(DicomWebConstants.ApplicationDicomMediaType, response.ContentHeaders.ContentType.MediaType);
 
-            var actual = (await response.GetValueAsync());
+            var actual = await response.GetValueAsync();
             var expected = DicomFile.Open(transcoderTestData.ExpectedOutputDicomFile);
             Assert.Equal(expected, actual, new DicomFileEqualityComparer(
                 ignoredTags: new[]


### PR DESCRIPTION
## Description
Randomize instance identifier of test files, so that never get conflict error  when upload.

## Related issues
Addresses [AB#80262](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/80262)

## Testing
Locally passed.
