### PR TITLE
Throttling when adding extended query tag.

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
@@ -76,6 +76,7 @@ namespace Microsoft.AspNetCore.Builder
             services.AddSingleton(Options.Create(dicomServerConfiguration.Features));
             services.AddSingleton(Options.Create(dicomServerConfiguration.Services.DeletedInstanceCleanup));
             services.AddSingleton(Options.Create(dicomServerConfiguration.Services.StoreServiceSettings));
+            services.AddSingleton(Options.Create(dicomServerConfiguration.Services.ExtendedQueryTag));
             services.AddSingleton(Options.Create(dicomServerConfiguration.Audit));
 
             services.RegisterAssemblyModules(Assembly.GetExecutingAssembly(), dicomServerConfiguration);

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/ExtendedQueryTagEntryValidatorTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/ExtendedQueryTagEntryValidatorTests.cs
@@ -3,7 +3,9 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Linq;
 using Dicom;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.Dicom.Core.Exceptions;
 using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Core.Features.Common;
@@ -19,7 +21,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.ChangeFeed
 
         public ExtendedQueryTagEntryValidatorTests()
         {
-            _extendedQueryTagEntryValidator = new ExtendedQueryTagEntryValidator(new DicomTagParser());
+            _extendedQueryTagEntryValidator = new ExtendedQueryTagEntryValidator(new DicomTagParser(), Options.Create(new Configs.ExtendedQueryTagConfiguration()));
         }
 
         [Fact]
@@ -160,6 +162,14 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.ChangeFeed
             DicomTag dicomTag = new DicomTag(0x2201, 0x0010);
             ExtendedQueryTagEntry entry = CreateExtendedQueryTagEntry(dicomTag.GetPath(), DicomVR.AE.Code);
             Assert.Throws<ExtendedQueryTagEntryValidationException>(() => _extendedQueryTagEntryValidator.ValidateExtendedQueryTags(new ExtendedQueryTagEntry[] { entry }));
+        }
+
+        [Fact]
+        public void GivenTooManyTags_WhenValidating_ThenShouldThrowException()
+        {
+            DicomTag dicomTag = new DicomTag(0x2201, 0x0010);
+            ExtendedQueryTagEntry entry = CreateExtendedQueryTagEntry(dicomTag.GetPath(), DicomVR.AE.Code);
+            Assert.Throws<ExtendedQueryTagEntryValidationException>(() => _extendedQueryTagEntryValidator.ValidateExtendedQueryTags(Enumerable.Repeat(entry, 129)));
         }
 
 

--- a/src/Microsoft.Health.Dicom.Core/Configs/ExtendedQueryTagConfiguration.cs
+++ b/src/Microsoft.Health.Dicom.Core/Configs/ExtendedQueryTagConfiguration.cs
@@ -5,12 +5,14 @@
 
 namespace Microsoft.Health.Dicom.Core.Configs
 {
-    public class ServicesConfiguration
+    /// <summary>
+    /// Configuration for extended query tag feature.
+    /// </summary>
+    public class ExtendedQueryTagConfiguration
     {
-        public DeletedInstanceCleanupConfiguration DeletedInstanceCleanup { get; } = new DeletedInstanceCleanupConfiguration();
-
-        public StoreConfiguration StoreServiceSettings { get; } = new StoreConfiguration();
-
-        public ExtendedQueryTagConfiguration ExtendedQueryTag { get; } = new ExtendedQueryTagConfiguration();
+        /// <summary>
+        /// Maximum allowed number of tags when adding.
+        /// </summary>
+        public int MaxBulkAddSize { get; set; } = 128;
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Dicom.Core {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class DicomCoreResource {
@@ -545,6 +545,15 @@ namespace Microsoft.Health.Dicom.Core {
         internal static string StudyNotFound {
             get {
                 return ResourceManager.GetString("StudyNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Adding too many tags. Up to {0} tags are allowed with one call..
+        /// </summary>
+        internal static string TooManyTagsToAdd {
+            get {
+                return ResourceManager.GetString("TooManyTagsToAdd", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -357,5 +357,9 @@ The first part date {1} should be lesser than or equal to the second part date {
   </data>
   <data name="ExtendedQueryTagFeatureDisabled" xml:space="preserve">
     <value>Extended Query Tag feature is disabled.</value>
+  </data>
+  <data name="TooManyTagsToAdd" xml:space="preserve">
+    <value>Adding too many tags. Up to {0} tags are allowed with one call.</value>
+    <comment>{0} max allowed tags.</comment>
   </data>
 </root>

--- a/src/Microsoft.Health.Dicom.Web/appsettings.json
+++ b/src/Microsoft.Health.Dicom.Web/appsettings.json
@@ -23,6 +23,9 @@
             },
             "StoreServiceSettings": {
                 "MaxAllowedDicomFileSize": 2147483647
+            },
+            "ExtendedQueryTag": {
+                "MaxBulkAddSize": 128
             }
         },
         "Audit": {
@@ -61,7 +64,7 @@
             "ExponentialRetryMaxAttempts": 6,
             "ServerTimeoutInMinutes": 2,
             "DownloadMaximumConcurrency": 5,
-            "UploadMaximumConcurrency":  5
+            "UploadMaximumConcurrency": 5
         }
     },
     "SqlServer": {


### PR DESCRIPTION
## Description
Allow up to 128 tags with one call.

## Related issues
Addresses [AB#79598](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/79598)


