### PR TITLE
Add ManageExtendedQueryTags data access role for administrate extended query tags

### DIFF
--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/AddExtendedQueryTagHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/AddExtendedQueryTagHandler.cs
@@ -30,9 +30,9 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         {
             EnsureArg.IsNotNull(request, nameof(request));
 
-            if (await AuthorizationService.CheckAccess(DataActions.Write, cancellationToken) != DataActions.Write)
+            if (await AuthorizationService.CheckAccess(DataActions.Admin, cancellationToken) != DataActions.Admin)
             {
-                throw new UnauthorizedDicomActionException(DataActions.Write);
+                throw new UnauthorizedDicomActionException(DataActions.Admin);
             }
 
             return await _addExtendedQueryTagService.AddExtendedQueryTagAsync(request.ExtendedQueryTags, cancellationToken);

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/AddExtendedQueryTagHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/AddExtendedQueryTagHandler.cs
@@ -30,9 +30,9 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         {
             EnsureArg.IsNotNull(request, nameof(request));
 
-            if (await AuthorizationService.CheckAccess(DataActions.ExtendedQueryTag, cancellationToken) != DataActions.ExtendedQueryTag)
+            if (await AuthorizationService.CheckAccess(DataActions.ManageExtendedQueryTag, cancellationToken) != DataActions.ManageExtendedQueryTag)
             {
-                throw new UnauthorizedDicomActionException(DataActions.ExtendedQueryTag);
+                throw new UnauthorizedDicomActionException(DataActions.ManageExtendedQueryTag);
             }
 
             return await _addExtendedQueryTagService.AddExtendedQueryTagAsync(request.ExtendedQueryTags, cancellationToken);

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/AddExtendedQueryTagHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/AddExtendedQueryTagHandler.cs
@@ -30,9 +30,9 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         {
             EnsureArg.IsNotNull(request, nameof(request));
 
-            if (await AuthorizationService.CheckAccess(DataActions.ManageExtendedQueryTag, cancellationToken) != DataActions.ManageExtendedQueryTag)
+            if (await AuthorizationService.CheckAccess(DataActions.ManageExtendedQueryTags, cancellationToken) != DataActions.ManageExtendedQueryTags)
             {
-                throw new UnauthorizedDicomActionException(DataActions.ManageExtendedQueryTag);
+                throw new UnauthorizedDicomActionException(DataActions.ManageExtendedQueryTags);
             }
 
             return await _addExtendedQueryTagService.AddExtendedQueryTagAsync(request.ExtendedQueryTags, cancellationToken);

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/AddExtendedQueryTagHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/AddExtendedQueryTagHandler.cs
@@ -30,9 +30,9 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         {
             EnsureArg.IsNotNull(request, nameof(request));
 
-            if (await AuthorizationService.CheckAccess(DataActions.Admin, cancellationToken) != DataActions.Admin)
+            if (await AuthorizationService.CheckAccess(DataActions.ExtendedQueryTag, cancellationToken) != DataActions.ExtendedQueryTag)
             {
-                throw new UnauthorizedDicomActionException(DataActions.Admin);
+                throw new UnauthorizedDicomActionException(DataActions.ExtendedQueryTag);
             }
 
             return await _addExtendedQueryTagService.AddExtendedQueryTagAsync(request.ExtendedQueryTags, cancellationToken);

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/DeleteExtendedQueryTagHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/DeleteExtendedQueryTagHandler.cs
@@ -30,9 +30,9 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         {
             EnsureArg.IsNotNull(request, nameof(request));
 
-            if (await AuthorizationService.CheckAccess(DataActions.ExtendedQueryTag, cancellationToken) != DataActions.ExtendedQueryTag)
+            if (await AuthorizationService.CheckAccess(DataActions.ManageExtendedQueryTag, cancellationToken) != DataActions.ManageExtendedQueryTag)
             {
-                throw new UnauthorizedDicomActionException(DataActions.ExtendedQueryTag);
+                throw new UnauthorizedDicomActionException(DataActions.ManageExtendedQueryTag);
             }
 
             await _deleteExtendedQueryTagService.DeleteExtendedQueryTagAsync(request.TagPath, cancellationToken);

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/DeleteExtendedQueryTagHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/DeleteExtendedQueryTagHandler.cs
@@ -30,9 +30,9 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         {
             EnsureArg.IsNotNull(request, nameof(request));
 
-            if (await AuthorizationService.CheckAccess(DataActions.ManageExtendedQueryTag, cancellationToken) != DataActions.ManageExtendedQueryTag)
+            if (await AuthorizationService.CheckAccess(DataActions.ManageExtendedQueryTags, cancellationToken) != DataActions.ManageExtendedQueryTags)
             {
-                throw new UnauthorizedDicomActionException(DataActions.ManageExtendedQueryTag);
+                throw new UnauthorizedDicomActionException(DataActions.ManageExtendedQueryTags);
             }
 
             await _deleteExtendedQueryTagService.DeleteExtendedQueryTagAsync(request.TagPath, cancellationToken);

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/DeleteExtendedQueryTagHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/DeleteExtendedQueryTagHandler.cs
@@ -30,9 +30,9 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         {
             EnsureArg.IsNotNull(request, nameof(request));
 
-            if (await AuthorizationService.CheckAccess(DataActions.Delete, cancellationToken) != DataActions.Delete)
+            if (await AuthorizationService.CheckAccess(DataActions.Admin, cancellationToken) != DataActions.Admin)
             {
-                throw new UnauthorizedDicomActionException(DataActions.Delete);
+                throw new UnauthorizedDicomActionException(DataActions.Admin);
             }
 
             await _deleteExtendedQueryTagService.DeleteExtendedQueryTagAsync(request.TagPath, cancellationToken);

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/DeleteExtendedQueryTagHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/DeleteExtendedQueryTagHandler.cs
@@ -30,9 +30,9 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         {
             EnsureArg.IsNotNull(request, nameof(request));
 
-            if (await AuthorizationService.CheckAccess(DataActions.Admin, cancellationToken) != DataActions.Admin)
+            if (await AuthorizationService.CheckAccess(DataActions.ExtendedQueryTag, cancellationToken) != DataActions.ExtendedQueryTag)
             {
-                throw new UnauthorizedDicomActionException(DataActions.Admin);
+                throw new UnauthorizedDicomActionException(DataActions.ExtendedQueryTag);
             }
 
             await _deleteExtendedQueryTagService.DeleteExtendedQueryTagAsync(request.TagPath, cancellationToken);

--- a/src/Microsoft.Health.Dicom.Core/Features/Security/DataActions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Security/DataActions.cs
@@ -25,7 +25,10 @@ namespace Microsoft.Health.Dicom.Core.Features.Security
         [EnumMember(Value = "delete")]
         Delete = 1 << 2,
 
+        [EnumMember(Value = "admin")]
+        Admin = 1 << 3,
+
         [EnumMember(Value = "*")]
-        All = (Delete << 1) - 1,
+        All = (Admin << 1) - 1,
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Security/DataActions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Security/DataActions.cs
@@ -25,10 +25,10 @@ namespace Microsoft.Health.Dicom.Core.Features.Security
         [EnumMember(Value = "delete")]
         Delete = 1 << 2,
 
-        [EnumMember(Value = "admin")]
-        Admin = 1 << 3,
+        [EnumMember(Value = "extendedQueryTag")]
+        ExtendedQueryTag = 1 << 3,    // Allow to administrate extended query tags.
 
         [EnumMember(Value = "*")]
-        All = (Admin << 1) - 1,
+        All = (ExtendedQueryTag << 1) - 1,
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Security/DataActions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Security/DataActions.cs
@@ -25,10 +25,10 @@ namespace Microsoft.Health.Dicom.Core.Features.Security
         [EnumMember(Value = "delete")]
         Delete = 1 << 2,
 
-        [EnumMember(Value = "extendedQueryTag")]
-        ExtendedQueryTag = 1 << 3,    // Allow to administrate extended query tags.
+        [EnumMember(Value = "manageExtendedQueryTag")]
+        ManageExtendedQueryTag = 1 << 3,    // Allow to manage extended query tags.
 
         [EnumMember(Value = "*")]
-        All = (ExtendedQueryTag << 1) - 1,
+        All = (ManageExtendedQueryTag << 1) - 1,
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Security/DataActions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Security/DataActions.cs
@@ -25,10 +25,10 @@ namespace Microsoft.Health.Dicom.Core.Features.Security
         [EnumMember(Value = "delete")]
         Delete = 1 << 2,
 
-        [EnumMember(Value = "manageExtendedQueryTag")]
-        ManageExtendedQueryTag = 1 << 3,    // Allow to manage extended query tags.
+        [EnumMember(Value = "manageExtendedQueryTags")]
+        ManageExtendedQueryTags = 1 << 3,    // Allow to manage extended query tags.
 
         [EnumMember(Value = "*")]
-        All = (ManageExtendedQueryTag << 1) - 1,
+        All = (ManageExtendedQueryTags << 1) - 1,
     }
 }


### PR DESCRIPTION
## Description
Add ManageExtendedQueryTags data access role for administrate extended query tags
## Related issues

Addresses [AB#81520](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/81520)
