### PR TITLE
Allow multipart/related media type for retrieved instance transaction

### DIFF
--- a/src/Microsoft.Health.Dicom.Client/DicomWebClient.cs
+++ b/src/Microsoft.Health.Dicom.Client/DicomWebClient.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Health.Dicom.Client
 
             request.Headers.TryAddWithoutValidation(
                 "Accept",
-                CreateAcceptHeader(DicomWebConstants.MediaTypeApplicationDicom, dicomTransferSyntax));
+                CreateAcceptHeader(CreateMultipartMediaTypeHeader(DicomWebConstants.ApplicationDicomMediaType), dicomTransferSyntax));
 
             HttpResponseMessage response = await HttpClient.SendAsync(request, cancellationToken)
                 .ConfigureAwait(false);

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveTransferSyntaxHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveTransferSyntaxHandler.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Retrieve
            {
                 { ResourceType.Study, DescriptorsForGetNonFrameResource(PayloadTypes.MultipartRelated) },
                 { ResourceType.Series, DescriptorsForGetNonFrameResource(PayloadTypes.MultipartRelated) },
-                { ResourceType.Instance, DescriptorsForGetNonFrameResource(PayloadTypes.SinglePart) },
+                { ResourceType.Instance, DescriptorsForGetNonFrameResource(PayloadTypes.SinglePartOrMultipartRelated) },
                 { ResourceType.Frames, DescriptorsForGetFrame() },
            };
 

--- a/src/Microsoft.Health.Dicom.Tests.Common/AcceptHeaderHelpers.cs
+++ b/src/Microsoft.Health.Dicom.Tests.Common/AcceptHeaderHelpers.cs
@@ -29,11 +29,11 @@ namespace Microsoft.Health.Dicom.Tests.Common
                quality: quality);
         }
 
-        public static AcceptHeader CreateAcceptHeaderForGetInstance(string transferSyntax = "*", string mediaType = KnownContentTypes.ApplicationDicom, double? quality = null)
+        public static AcceptHeader CreateAcceptHeaderForGetInstance(string transferSyntax = "*", string mediaType = KnownContentTypes.ApplicationDicom, double? quality = null, PayloadTypes payloadTypes = PayloadTypes.SinglePart)
         {
             return CreateAcceptHeader(
                transferSyntax: transferSyntax,
-               payloadType: PayloadTypes.SinglePart,
+               payloadType: payloadTypes,
                mediaType: mediaType,
                quality: quality);
         }

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Instance.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Instance.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Dicom;
 using Microsoft.Health.Dicom.Client;
@@ -37,7 +38,14 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
 
             using DicomWebResponse<DicomFile> response = await _client.RetrieveInstanceAsync(instanceId.StudyInstanceUid, instanceId.SeriesInstanceUid, instanceId.SopInstanceUid, transferSyntax);
 
-            Assert.Equal(DicomWebConstants.ApplicationDicomMediaType, response.ContentHeaders.ContentType.MediaType);
+            Assert.Equal(DicomWebConstants.MultipartRelatedMediaType, response.ContentHeaders.ContentType.MediaType);
+            foreach (NameValueHeaderValue param in response.ContentHeaders.ContentType.Parameters)
+            {
+                if (param.Name == "type")
+                {
+                    Assert.Equal($"\"{DicomWebConstants.ApplicationDicomMediaType}\"", param.Value);
+                }
+            }
 
             var actual = await response.GetValueAsync();
             var expected = DicomFile.Open(transcoderTestData.ExpectedOutputDicomFile);


### PR DESCRIPTION
## Description
Support `multipart/related; type="application/dicom";` media type for retrieve instance transaction

## Related issues
Addresses [issue #444, AB#80402].

## Testing
- Added new unit test and e2e test to test both media types
