### PR TITLE
Replace blob.DownloadToAsync with blob.OpenReadAsync

### DIFF
--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/DataStoreTestsFixture.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/DataStoreTestsFixture.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             var jsonSerializer = new JsonSerializer();
             jsonSerializer.Converters.Add(new JsonDicomConverter());
 
-            FileStore = new BlobFileStore(_blobClient, optionsMonitor, RecyclableMemoryStreamManager, Substitute.For<BlobDataStoreConfiguration>());
+            FileStore = new BlobFileStore(_blobClient, optionsMonitor, Substitute.For<BlobDataStoreConfiguration>());
             MetadataStore = new BlobMetadataStore(_blobClient, jsonSerializer, optionsMonitor, RecyclableMemoryStreamManager);
         }
 

--- a/tools/dicom-web-electron/main.js
+++ b/tools/dicom-web-electron/main.js
@@ -81,6 +81,7 @@ async function createWindow() {
                     'Authorization': authorizationHeader
                 },
                 maxContentLength: maxSizeBytes,
+                maxBodyLength: maxSizeBytes,
                 httpsAgent: httpsAgent
             })
             .then(function(response) {


### PR DESCRIPTION
## Description
This PR replaces our calls on getting file from `blob.DownloadToAsync` to `blob.OpenReadAsync`. The behavior difference is that the `OpenReadAsync` returns a lazy `Stream` which only starts to download when it is actually being read. Previously, when using `DownloadToAsync` we realize the entire stream in memory. 

The result of this is that our single file read allocations go down significantly, but we we will face more garbage collection as we're not using the `RecyclableMemoryStreamManager` any longer.

In the long term I believe we can strike a balance between which method to use based on file size if we record the dicom file size during the ingestion. 

## Related issues
Addresses [AB#81741](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/81741).

## Testing
Existing tests continue to pass. 
