### PR TITLE
Remove DicomValidation.AutomationValidation from test code

### DIFF
--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Extensions/DicomDatasetExtensionsTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Extensions/DicomDatasetExtensionsTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Extensions
 {
     public class DicomDatasetExtensionsTests
     {
-        private readonly DicomDataset _dicomDataset = new DicomDataset();
+        private readonly DicomDataset _dicomDataset = new DicomDataset().NotValidated();
 
         [Fact]
         public void GivenDicomTagWithDifferentVR_WhenGetSingleOrDefaultIsCalled_ThenShouldReturnNull()
@@ -67,15 +67,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Extensions
         [Fact]
         public void GivenAnInvalidDicomDateValue_WhenGetStringDateAsDateTimeIsCalled_ThenNullShouldBeReturned()
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            DicomValidation.AutoValidation = false;
-#pragma warning restore CS0618 // Type or member is obsolete
-
             _dicomDataset.Add(DicomTag.StudyDate, "2010");
-
-#pragma warning disable CS0618 // Type or member is obsolete
-            DicomValidation.AutoValidation = true;
-#pragma warning restore CS0618 // Type or member is obsolete
 
             Assert.Null(_dicomDataset.GetStringDateAsDate(DicomTag.StudyDate));
         }

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/DicomDatasetValidatorTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/DicomDatasetValidatorTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Store
 
         private IDicomDatasetValidator _dicomDatasetValidator;
 
-        private readonly DicomDataset _dicomDataset = Samples.CreateRandomInstanceDataset();
+        private readonly DicomDataset _dicomDataset = Samples.CreateRandomInstanceDataset().NotValidated();
         private readonly IQueryTagService _queryTagService;
         private readonly List<QueryTag> _queryTags;
 
@@ -152,16 +152,8 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Store
 
             _dicomDatasetValidator = new DicomDatasetValidator(featureConfiguration, minValidator, _queryTagService);
 
-#pragma warning disable CS0618 // Type or member is obsolete
-            DicomValidation.AutoValidation = false;
-#pragma warning restore CS0618 // Type or member is obsolete
-
             // LO VR, invalid characters
             _dicomDataset.Add(DicomTag.SeriesDescription, "CT1 abdomen\u0000");
-
-#pragma warning disable CS0618 // Type or member is obsolete
-            DicomValidation.AutoValidation = true;
-#pragma warning restore CS0618 // Type or member is obsolete
 
             await ExecuteAndValidateException<DatasetValidationException>(ValidationFailedFailureCode);
         }
@@ -169,17 +161,8 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Store
         [Fact]
         public async Task GivenDatasetWithInvalidIndexedTagValue_WhenValidating_ThenValidationExceptionShouldBeThrown()
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            DicomValidation.AutoValidation = false;
-#pragma warning restore CS0618 // Type or member is obsolete
-
             // CS VR, > 16 characters is not allowed
             _dicomDataset.Add(DicomTag.Modality, "01234567890123456789");
-
-#pragma warning disable CS0618 // Type or member is obsolete
-            DicomValidation.AutoValidation = true;
-#pragma warning restore CS0618 // Type or member is obsolete
-
             await ExecuteAndValidateException<DicomElementValidationException>(ValidationFailedFailureCode);
         }
 
@@ -193,18 +176,10 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Store
         [Fact]
         public async Task GivenExtendedQueryTags_WhenValidating_ThenExtendedQueryTagsShouldBeValidated()
         {
-            DicomTag standardTag = DicomTag.DestinationAE;
-
-#pragma warning disable CS0618 // Type or member is obsolete
-            DicomValidation.AutoValidation = false;
-#pragma warning restore CS0618 // Type or member is obsolete
+            DicomTag standardTag = DicomTag.DestinationAE; 
 
             // AE > 16 characters is not allowed
             _dicomDataset.Add(standardTag, "01234567890123456");
-
-#pragma warning disable CS0618 // Type or member is obsolete
-            DicomValidation.AutoValidation = true;
-#pragma warning restore CS0618 // Type or member is obsolete
 
             QueryTag indextag = new QueryTag(standardTag.BuildExtendedQueryTagStoreEntry());
             _queryTags.Add(indextag);
@@ -218,16 +193,8 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Store
 
             DicomIntegerString element = new DicomIntegerString(tag, "0123456789123"); // exceed max length 12
 
-#pragma warning disable CS0618 // Type or member is obsolete
-            DicomValidation.AutoValidation = false;
-#pragma warning restore CS0618 // Type or member is obsolete
-
             // AE > 16 characters is not allowed
             _dicomDataset.Add(element);
-
-#pragma warning disable CS0618 // Type or member is obsolete
-            DicomValidation.AutoValidation = true;
-#pragma warning restore CS0618 // Type or member is obsolete
 
             QueryTag indextag = new QueryTag(tag.BuildExtendedQueryTagStoreEntry(vr: element.ValueRepresentation.Code));
             _queryTags.Clear();

--- a/src/Microsoft.Health.Dicom.Tests.Common/Samples.cs
+++ b/src/Microsoft.Health.Dicom.Tests.Common/Samples.cs
@@ -155,9 +155,10 @@ namespace Microsoft.Health.Dicom.Tests.Common
         public static DicomFile CreateRandomDicomFile(
                     string studyInstanceUid = null,
                     string seriesInstanceUid = null,
-                    string sopInstanceUid = null)
+                    string sopInstanceUid = null,
+                    bool validateItems = true)
         {
-            return new DicomFile(CreateRandomInstanceDataset(studyInstanceUid, seriesInstanceUid, sopInstanceUid));
+            return new DicomFile(CreateRandomInstanceDataset(studyInstanceUid, seriesInstanceUid, sopInstanceUid, validateItems: validateItems));
         }
 
         public static DicomFile CreateRandomDicomFileWithInvalidVr(
@@ -165,7 +166,7 @@ namespace Microsoft.Health.Dicom.Tests.Common
                    string seriesInstanceUid = null,
                    string sopInstanceUid = null)
         {
-            DicomFile file = new DicomFile(CreateRandomInstanceDataset(studyInstanceUid, seriesInstanceUid, sopInstanceUid).NotValidated()); 
+            DicomFile file = new DicomFile(CreateRandomInstanceDataset(studyInstanceUid, seriesInstanceUid, sopInstanceUid, validateItems: false));
             file.Dataset.Add(GenerateNewDataSetWithInvalidVr());
             return file;
         }
@@ -184,19 +185,23 @@ namespace Microsoft.Health.Dicom.Tests.Common
             string studyInstanceUid = null,
             string seriesInstanceUid = null,
             string sopInstanceUid = null,
-            string sopClassUid = null)
+            string sopClassUid = null,
+            bool validateItems = true)
         {
-            var ds = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian)
-            {
-                { DicomTag.StudyInstanceUID, studyInstanceUid ?? TestUidGenerator.Generate() },
-                { DicomTag.SeriesInstanceUID, seriesInstanceUid ?? TestUidGenerator.Generate() },
-                { DicomTag.SOPInstanceUID, sopInstanceUid ?? TestUidGenerator.Generate() },
-                { DicomTag.SOPClassUID, sopClassUid ?? TestUidGenerator.Generate() },
-                { DicomTag.BitsAllocated, (ushort)8 },
-                { DicomTag.PhotometricInterpretation, PhotometricInterpretation.Monochrome2.Value },
-                { DicomTag.PatientID, TestUidGenerator.Generate() },
-            };
+            var ds = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian);
 
+            if (!validateItems)
+            {
+                ds = ds.NotValidated();
+            }
+
+            ds.Add(DicomTag.StudyInstanceUID, studyInstanceUid ?? TestUidGenerator.Generate());
+            ds.Add(DicomTag.SeriesInstanceUID, seriesInstanceUid ?? TestUidGenerator.Generate());
+            ds.Add(DicomTag.SOPInstanceUID, sopInstanceUid ?? TestUidGenerator.Generate());
+            ds.Add(DicomTag.SOPClassUID, sopClassUid ?? TestUidGenerator.Generate());
+            ds.Add(DicomTag.BitsAllocated, (ushort)8);
+            ds.Add(DicomTag.PhotometricInterpretation, PhotometricInterpretation.Monochrome2.Value);
+            ds.Add(DicomTag.PatientID, TestUidGenerator.Generate());
             return ds;
         }
 

--- a/src/Microsoft.Health.Dicom.Tests.Common/Samples.cs
+++ b/src/Microsoft.Health.Dicom.Tests.Common/Samples.cs
@@ -165,18 +165,8 @@ namespace Microsoft.Health.Dicom.Tests.Common
                    string seriesInstanceUid = null,
                    string sopInstanceUid = null)
         {
-            DicomFile file = new DicomFile(CreateRandomInstanceDataset(studyInstanceUid, seriesInstanceUid, sopInstanceUid));
-
-#pragma warning disable CS0618 // Type or member is obsolete
-            DicomValidation.AutoValidation = false;
-#pragma warning restore CS0618 // Type or member is obsolete
-
+            DicomFile file = new DicomFile(CreateRandomInstanceDataset(studyInstanceUid, seriesInstanceUid, sopInstanceUid).NotValidated()); 
             file.Dataset.Add(GenerateNewDataSetWithInvalidVr());
-
-#pragma warning disable CS0618 // Type or member is obsolete
-            DicomValidation.AutoValidation = true;
-#pragma warning restore CS0618 // Type or member is obsolete
-
             return file;
         }
 

--- a/src/Microsoft.Health.Dicom.Tests.Common/Samples.cs
+++ b/src/Microsoft.Health.Dicom.Tests.Common/Samples.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Health.Dicom.Tests.Common
 
         private static DicomDataset GenerateNewDataSetWithInvalidVr()
         {
-            var dicomDataset = new DicomDataset();
+            var dicomDataset = new DicomDataset().NotValidated();
 
             // CS VR type, char length should be less than or equal to 16
             dicomDataset.Add(DicomTag.Modality, "123456789ABCDEFGHIJK");

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/StoreTransactionTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/StoreTransactionTests.cs
@@ -323,7 +323,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
         [InlineData("11|")]
         public async Task GivenDatasetWithInvalidUid_WhenStoring_TheServerShouldReturnConflict(string studyInstanceUID)
         {
-            DicomFile dicomFile1 = Samples.CreateRandomDicomFile(studyInstanceUID);
+            DicomFile dicomFile1 = Samples.CreateRandomDicomFile(studyInstanceUID, validateItems: false);
 
             DicomWebException exception = await Assert.ThrowsAsync<DicomWebException>(() => _client.StoreAsync(new[] { dicomFile1 }));
 

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/StoreTransactionTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/StoreTransactionTests.cs
@@ -323,15 +323,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
         [InlineData("11|")]
         public async Task GivenDatasetWithInvalidUid_WhenStoring_TheServerShouldReturnConflict(string studyInstanceUID)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            DicomValidation.AutoValidation = false;
-#pragma warning restore CS0618 // Type or member is obsolete
-
             DicomFile dicomFile1 = Samples.CreateRandomDicomFile(studyInstanceUID);
-
-#pragma warning disable CS0618 // Type or member is obsolete
-            DicomValidation.AutoValidation = true;
-#pragma warning restore CS0618 // Type or member is obsolete
 
             DicomWebException exception = await Assert.ThrowsAsync<DicomWebException>(() => _client.StoreAsync(new[] { dicomFile1 }));
 


### PR DESCRIPTION
## Description
use DicomDataset.NotValidated() instead.

## Related issues
Addresses [AB#81755](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/81755)

## Testing
Automation test passes locally
