### PR TITLE
feat(observation): create dose summary observations

### DIFF
--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Fhir/IFhirService.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Fhir/IFhirService.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Hl7.Fhir.Model;
@@ -38,6 +39,14 @@ namespace Microsoft.Health.DicomCast.Core.Features.Fhir
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A task representing the retrieving operation.</returns>
         Task<Endpoint> RetrieveEndpointAsync(string queryParameter, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Asynchronously retrieve all Observations which have contain the provided `Identifier` as an Observation.Identifier.
+        /// </summary>
+        /// <param name="identifier">the identifier to search by</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A list of Observations</returns>
+        Task<IEnumerable<Observation>> RetrieveObservationsAsync(Identifier identifier, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Validates that FHIR server is right version and supports transactions.

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/ChangeFeedProcessor.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/ChangeFeedProcessor.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker
                         if (!(changeFeedEntry.Action == ChangeFeedAction.Create && changeFeedEntry.State == ChangeFeedState.Deleted))
                         {
                             await _fhirTransactionPipeline.ProcessAsync(changeFeedEntry, cancellationToken);
-                            _logger.LogInformation("Succesfully process DICOM event with SequenceID: {sequenceId}", changeFeedEntry.Sequence);
+                            _logger.LogInformation("Successfully process DICOM event with SequenceID: {sequenceId}", changeFeedEntry.Sequence);
                         }
                         else
                         {

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/FhirTransactionRequest.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/FhirTransactionRequest.cs
@@ -18,5 +18,8 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
 
         /// <inheritdoc/>
         public FhirTransactionRequestEntry ImagingStudy { get; set; }
+        
+        /// <inheritdoc/>
+        public FhirTransactionRequestEntry Observation { get; set; }
     }
 }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/FhirTransactionResponse.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/FhirTransactionResponse.cs
@@ -18,5 +18,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
 
         /// <inheritdoc/>
         public FhirTransactionResponseEntry ImagingStudy { get; set; }
+
+        public FhirTransactionResponseEntry Observation { get; set; }
     }
 }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/IFhirTransactionRequestResponse.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/IFhirTransactionRequestResponse.cs
@@ -25,5 +25,10 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
         /// Gets or sets the imaging study.
         /// </summary>
         T ImagingStudy { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Observation
+        /// </summary>
+        T Observation { get; set; }
     }
 }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationDeleteHandler.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationDeleteHandler.cs
@@ -1,0 +1,78 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Utility;
+using Microsoft.Health.DicomCast.Core.Extensions;
+using Microsoft.Health.DicomCast.Core.Features.Fhir;
+
+namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
+{
+    public interface IObservationDeleteHandler
+    {
+        /// <summary>
+        /// Create a transaction request entry to delete an existing DoseSummary observation based on the StudyInstanceUID provided
+        /// in the transaction context.
+        /// </summary>
+        /// <remarks>
+        /// - This currently only supports single observation deletion.
+        /// - There _should_ only be a single observation per study instance -- but a users can technically create add
+        ///   more as there is no built in 1:1 mapping in FHIR.
+        /// - If multiple dose summaries are found mapping to the same study instance, we only delete the first one returned.
+        /// </remarks>
+        /// <param name="context">The transaction request context</param>
+        /// <param name="cancellationToken">the cancellation token</param>
+        /// <returns>a transaction request entry to delete a single Dose Summary if a matching one is found</returns>
+        Task<FhirTransactionRequestEntry> BuildAsync(FhirTransactionContext context, CancellationToken cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    class ObservationDeleteHandler : IObservationDeleteHandler
+    {
+        private readonly IFhirService _fhirService;
+
+        public ObservationDeleteHandler(IFhirService fhirService)
+        {
+            EnsureArg.IsNotNull(fhirService, nameof(fhirService));
+            _fhirService = fhirService;
+        }
+
+        public async Task<FhirTransactionRequestEntry> BuildAsync(FhirTransactionContext context, CancellationToken cancellationToken)
+        {
+            EnsureArg.IsNotNull(context, nameof(context));
+            EnsureArg.IsNotNull(context.ChangeFeedEntry, nameof(context.ChangeFeedEntry));
+
+            // operate on the pre-condition that their _should_ only be one DoseSummary per ImagingStudy.
+            // If multiple observations are found; just use the first one.
+            // TODO current codebase only supports single resource per FhirTransactionRequest. Will need to refactor to support multiple.
+            // TODO currently only supports deleting a single matched resource.
+            Identifier identifier = ImagingStudyIdentifierUtility.CreateIdentifier(context.ChangeFeedEntry.StudyInstanceUid);
+            IEnumerable<Observation> matchingObservationsAsync = await _fhirService.RetrieveObservationsAsync(identifier, cancellationToken);
+            var matchingObservations = matchingObservationsAsync.ToList();
+
+            // terminate early if no observation found
+            if (!matchingObservations.Any())
+                return null;
+
+            Observation observationToDelete = matchingObservations.First();
+            var request = new Bundle.RequestComponent()
+            {
+                Method = Bundle.HTTPVerb.DELETE,
+                Url = $"{ResourceType.Observation.GetLiteral()}/{observationToDelete.Id}"
+            };
+
+            return new FhirTransactionRequestEntry(
+                FhirTransactionRequestMode.Delete,
+                request,
+                observationToDelete.ToServerResourceId(),
+                observationToDelete);
+        }
+    }
+}

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationParser.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationParser.cs
@@ -1,0 +1,417 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Dicom;
+using Dicom.StructuredReport;
+using Hl7.Fhir.Model;
+using Microsoft.Health.DicomCast.Core.Features.Fhir;
+
+namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
+{
+    /// <summary>
+    /// Container for holding the parsed Observations from a DicomDataset
+    /// </summary>
+    public class ParsedObservation
+    {
+        public Collection<Observation> DoseSummaries { get; } = new();
+        public Collection<Observation> IrradiationEvents { get; } = new();
+    }
+
+    public static class ObservationParser
+    {
+        /// <summary>
+        /// Parses the DicomStructuredReports in a DicomDataset for the contained Observations.
+        /// </summary>
+        /// <remarks>
+        /// For observation profiles see: https://confluence.hl7.org/display/IMIN/Radiation+Dose+Summary+for+Diagnostic+Procedures+on+FHIR#RadiationDoseSummaryforDiagnosticProceduresonFHIR-DoseSummaryObservationProfile
+        /// </remarks>
+        /// <param name="dataset">The dataset to parse</param>
+        /// <param name="patientRef">Reference to an existing patient to link to</param>
+        /// <param name="imagingStudyRef">Reference to an existing ImagingStudy to link to</param>
+        /// <returns>An object containing the Observations found in the dataset</returns>
+        public static ParsedObservation CreateObservations(
+            DicomDataset dataset,
+            ResourceReference patientRef,
+            ResourceReference imagingStudyRef)
+        {
+            var parsedObservations = new ParsedObservation();
+
+            // Recursive loop to add all found Dose Summaries and Irradiation Events to the passed observation set
+            static void ObservationParseLoop(
+                DicomDataset dataset,
+                ResourceReference patientRef,
+                ResourceReference imagingStudyRef,
+                ParsedObservation observations
+            )
+            {
+                var report = new DicomStructuredReport(dataset);
+                // see if the current report code matches any of the observation container codes; if so, create the appropriate observation
+                try
+                {
+                    (string Value, string Scheme) lookupTuple = (report.Code.Value, report.Code.Scheme);
+                    if (DoseSummaryReportCodes.Contains(lookupTuple))
+                    {
+                        Observation doseSummary = CreateDoseSummary(
+                            dataset,
+                            imagingStudyRef,
+                            patientRef);
+                        observations.DoseSummaries.Add(doseSummary);
+                    }
+
+                    if (IrradiationEventCodes.Contains(lookupTuple))
+                    {
+                        Observation irradiationEvent = CreateIrradiationEvent(dataset, patientRef);
+                        observations.IrradiationEvents.Add(irradiationEvent);
+                    }
+                }
+                catch (MissingMemberException)
+                {
+                    // Occurs when a required attribute is unable to be extracted from a dataset.
+                    // Ignore and move onto the next one.
+                }
+                catch (Exception)
+                {
+                    // exception thrown if the report does not contain a Code. In which case we ignore it
+                    // and move onto the next reports
+                }
+
+                // Recursively iterate through every child in the document checking for nested observations.
+                // Return the final aggregated list of observations.
+                foreach (DicomContentItem childItem in report.Children())
+                    ObservationParseLoop(childItem.Dataset, patientRef, imagingStudyRef, observations);
+            }
+
+            // run the loop
+            ObservationParseLoop(dataset, patientRef, imagingStudyRef, parsedObservations);
+
+            // Set each observation status to Preliminary
+            foreach (Observation doseSummary in parsedObservations.DoseSummaries)
+                doseSummary.Status = ObservationStatus.Preliminary;
+            foreach (Observation irradiationEvent in parsedObservations.IrradiationEvents)
+                irradiationEvent.Status = ObservationStatus.Preliminary;
+
+            return parsedObservations;
+        }
+
+        /// <summary>
+        /// Creates an Observation "Dose Summary" profile based on the the spec outlined at:
+        /// https://confluence.hl7.org/display/IMIN/Radiation+Dose+Summary+for+Diagnostic+Procedures+on+FHIR#RadiationDoseSummaryforDiagnosticProceduresonFHIR-DoseSummaryObservationProfile
+        /// </summary>
+        /// <returns>A Dose Summary</returns>
+        private static Observation CreateDoseSummary(
+            DicomDataset dataset,
+            ResourceReference imagingStudyRef,
+            ResourceReference patientRef)
+        {
+            // Create the observation
+            var observation = new Observation
+            {
+                // Set the code.coding
+                Code = new CodeableConcept("http://loinc.org", "73569-6", "Radiation exposure and protection information"),
+                // Add Patient reference
+                Subject = patientRef
+            };
+            // Add ImagingStudy reference
+            observation.PartOf.Add(imagingStudyRef);
+
+            // Set identifiers
+            if (dataset.TryGetSingleValue(DicomTag.StudyInstanceUID, out string studyUid))
+            {
+                Identifier identifier = ImagingStudyIdentifierUtility.CreateIdentifier(studyUid);
+                observation.Identifier.Add(identifier);
+            }
+            else
+            {
+                throw new MissingMemberException($"Unable to {nameof(DicomTag.StudyInstanceUID)} from dose summary observation dataset");
+            }
+
+            if (dataset.TryGetSingleValue(DicomTag.AccessionNumber, out string accessionNumber))
+            {
+                // TODO system correct? seems like a foobar name
+                const string accessionSystem = "http://ginormoushospital.org/accession";
+                var identifier = new Identifier(accessionSystem, accessionNumber)
+                {
+                    Type = new CodeableConcept("http://terminology.hl7.org/CodeSystem/v2-0203", "ACSN")
+                };
+                observation.Identifier.Add(identifier);
+            }
+            else
+            {
+                throw new MissingMemberException($"Unable to {nameof(DicomTag.AccessionNumber)} from dose summary observation dataset");
+            }
+
+            // Add all structured report information
+            ApplyDicomTransforms(observation, dataset, new List<(string, string)>()
+            {
+                EntranceExposureAtRp,
+                AccumulatedAverageGlandularDose,
+                DoseAreaProductTotal,
+                FluoroDoseAreaProductTotal,
+                AcquisitionDoseAreaProductTotal,
+                TotalFluoroTime,
+                TotalNumberOfRadiographicFrames,
+                AdministeredActivity,
+                CtDoseLengthProductTotal,
+                TotalNumberOfIrradiationEvents,
+                MeanCtdIvol,
+                RadiopharmaceuticalAgent,
+                RadiopharmaceuticalVolume,
+                Radionuclide,
+                RouteOfAdministration,
+            });
+
+            return observation;
+        }
+
+        /// <summary>
+        /// Creates an Observation "Irradiation Event" based on the spec outlined at:
+        /// https://confluence.hl7.org/display/IMIN/Radiation+Dose+Summary+for+Diagnostic+Procedures+on+FHIR#RadiationDoseSummaryforDiagnosticProceduresonFHIR-DoseSummaryObservationProfile
+        /// </summary>
+        /// <param name="dataset">The dataset to parse</param>
+        /// <param name="patientRef">Patient which the Irradiation Event is a subject of</param>
+        private static Observation CreateIrradiationEvent(DicomDataset dataset, ResourceReference patientRef)
+        {
+            var report = new DicomStructuredReport(dataset);
+            // create the observation
+            var observation = new Observation
+            {
+                Code = new CodeableConcept("http://dicom.nema.org/resources/ontology/DCM", "113852", "Irradiation Event"),
+                Subject = patientRef
+            };
+
+            // try to extract the event UID
+            try
+            {
+                DicomContentItem irradiationEventItem = report.Children()
+                    .First(item => (item.Code.Value, item.Code.Scheme) == IrradiationEventUid);
+                DicomUID irradiationEventUidValue = irradiationEventItem.Get<DicomUID>();
+                // TODO is this the right "system"???
+                var system = irradiationEventItem.Code.Scheme == Dcm
+                    ? DcmSystem
+                    : SctSystem;
+                var identifier = new Identifier(irradiationEventUidValue.Name, irradiationEventUidValue.UID);
+                observation.Identifier.Add(identifier);
+            }
+            catch (Exception ex)
+            {
+                throw new MissingMemberException($"unable to extract {nameof(IrradiationEventUid)} from dataset: {ex.Message}");
+            }
+
+            // Extract the necessary information
+            ApplyDicomTransforms(observation, report.Dataset, new List<(string, string)>()
+            {
+                MeanCtdIvol,
+                Dlp,
+                CtdIwPhantomType
+            });
+
+            return observation;
+        }
+
+        /// <summary>
+        /// Mutates the given Observation by recursively parsing the given DicomDataset into
+        /// DicomStructuredReports and searching for tags provided.
+        /// </summary>
+        /// <param name="observation">Observation to mutate</param>
+        /// <param name="dataset">DicomDataset to parse for values</param>
+        /// <param name="onlyInclude">Dicom structured report codes to parse values from</param>
+        private static void ApplyDicomTransforms(Observation observation, DicomDataset dataset, ICollection<(string, string)> onlyInclude = null)
+        {
+            var report = new DicomStructuredReport(dataset);
+            (string Value, string Scheme) lookupTuple = (report.Code.Value, report.Code.Scheme);
+            if (onlyInclude == null || onlyInclude.Contains(lookupTuple))
+            {
+                if (DicomComponentMutators.TryGetValue(lookupTuple, out Action<Observation, DicomStructuredReport> mutator))
+                {
+                    mutator(observation, report);
+                }
+                else
+                {
+                    throw new InvalidProgramException($"no attribute applicator found for dicom code {lookupTuple.ToString()}");
+                }
+            }
+
+            foreach (DicomContentItem child in report.Children())
+                ApplyDicomTransforms(observation, child.Dataset, onlyInclude);
+        }
+
+        // https://www.hl7.org/fhir/terminologies-systems.html
+        private const string SctSystem = "http://snomed.info/sct";
+        private const string DcmSystem = "http://dicom.nema.org/resources/ontology/DCM";
+
+        private const string Dcm = "DCM";
+        private const string Sct = "Sct";
+
+        //------------------------------------------------------------
+        // Report codes
+        // - When you encounter this code in a structured report, it means to create a new "Does Summary" Observation
+        //------------------------------------------------------------
+        private static readonly (string, string) RadiopharmaceuticalRadiationDoseReport = ("113500", Dcm); // (113500,DCM,"Radiopharmaceutical Radiation Dose Report")
+        private static readonly (string, string) XRayRadiationDoseReport = ("113701", Dcm); // (113701,DCM,"X-Ray Radiation Dose Report")
+
+
+        //------------------------------------------------------------
+        // Irradiation Event Codes
+        // - When you encounter this code in a structured report, it means to create a new "Irradiation Event" Observation
+        //------------------------------------------------------------
+        private static readonly (string, string) IrradiationEventXRayData = ("113706", Dcm); // (113706,DCM,"Irradiation Event X-Ray Data")
+        private static readonly (string, string) CtAcquisition = ("113819", Dcm); // (113819,DCM,"CT Acquisition")
+        private static readonly (string, string) OrganDose = ("113518", "DCM"); // (113518,DCM,"Organ Dose")  => Radiopharmaceutical Radiation Dose Report
+
+
+        //------------------------------------------------------------
+        // Dicom Codes (attribute)
+        // - These are report values which map to non component observation attributes.
+        //------------------------------------------------------------
+        private static readonly (string, string) IrradiationEventUid = ("113769", Dcm); // (113769,DCM,"Irradiation Event UID")
+        // private static readonly (string, string) StudyInstanceUid = ("110180", Dcm); // (110180,DCM,"Study Instance UID") TODO maybe (0020,000D) ???
+        // private static readonly (string, string) AccessionNumber = ("121022", Dcm); // TODO no sample; maybe (0008,0050) ???
+        // private static readonly (string, string) StartOfXrayIrradiation = ("113809", Dcm); // (113809,DCM,"Start of X-ray Irradiation")
+        // private static readonly (string, string) IrradiationAuthorizing = ("113850", Dcm); // TODO no sample maybe (121406,DCM,"Reference Authority") ???
+        // private static readonly (string, string) PregnancyObservable = ("364320009", Sct); // TODO no sample maybe "(0010,21c0) US" ???
+
+        //------------------------------------------------------------
+        // Dicom codes (component)
+        // - These are report values which map to Observation.component values
+        //------------------------------------------------------------
+        // Dose Summary
+        // TODO cannot find "DoseSummary.component:effectiveDose" anywhere
+        private static readonly (string, string) EntranceExposureAtRp = ("111636", Dcm); // (111636,DCM,"Entrance Exposure at RP")
+        private static readonly (string, string) AccumulatedAverageGlandularDose = ("111637", Dcm); // (111637,DCM,"Accumulated Average Glandular Dose")
+        private static readonly (string, string) DoseAreaProductTotal = ("113722", Dcm); // (113722,DCM,"Dose Area Product Total")
+        private static readonly (string, string) FluoroDoseAreaProductTotal = ("113726", Dcm); // (113726,DCM,"Fluoro Dose Area Product Total")
+        private static readonly (string, string) AcquisitionDoseAreaProductTotal = ("113727", Dcm); // (113727,DCM,"Acquisition Dose Area Product Total")
+        private static readonly (string, string) TotalFluoroTime = ("113730", Dcm); // (113730,DCM,"Total Fluoro Time")
+        private static readonly (string, string) TotalNumberOfRadiographicFrames = ("113731", Dcm); // (113731,DCM,"Total Number of Radiographic Frames")
+        private static readonly (string, string) AdministeredActivity = ("113507", Dcm); // (113507,DCM,"Administered activity")
+        private static readonly (string, string) CtDoseLengthProductTotal = ("113813", Dcm); // (113813,DCM,"CT Dose Length Product Total") 
+        private static readonly (string, string) TotalNumberOfIrradiationEvents = ("113812", Dcm); // (113812,DCM,"Total Number of Irradiation Events")
+        private static readonly (string, string) MeanCtdIvol = ("113830", Dcm); // (113830,DCM,"Mean CTDIvol")
+        private static readonly (string, string) RadiopharmaceuticalAgent = ("349358000", Sct); // TODO no sample; maybe (F-61FDB,SRT,"Radiopharmaceutical agent") ???
+        private static readonly (string, string) RadiopharmaceuticalVolume = ("123005", Dcm); // TODO no sample; maybe (0018,1071) DS ???
+        private static readonly (string, string) Radionuclide = ("89457008", Sct); // TODO no sample; maybe (C-10072,SRT,"Radionuclide") ???
+        private static readonly (string, string) RouteOfAdministration = ("410675002", Sct); // TODO no sample; maybe (G-C340,SRT,"Route of administration") ???
+
+        // (Ir)radiation Event
+        // uses MeanCtdIvol as well
+        private static readonly (string, string) Dlp = ("113838", Dcm); // (113838,DCM,"DLP")
+        private static readonly (string, string) CtdIwPhantomType = ("113835", Dcm); // (113835,DCM,"CTDIw Phantom Type")
+
+        /// <summary>
+        /// DicomStructuredReport codes which mean the start of a Dose Summary
+        /// </summary>
+        private static List<(string, string)> DoseSummaryReportCodes = new()
+        {
+            RadiopharmaceuticalRadiationDoseReport,
+            XRayRadiationDoseReport,
+        };
+
+        /// <summary>
+        /// DicomStructuredReport codes which mean the start of an Irradiation Event
+        /// </summary>
+        private static List<(string, string)> IrradiationEventCodes = new()
+        {
+            IrradiationEventXRayData,
+            CtAcquisition,
+            OrganDose
+        };
+
+        /// <summary>
+        /// Lookup map of Dicom Report Codes `(code,string)` to Observation mutator
+        /// </summary>
+        private static readonly Dictionary<(string, string), Action<Observation, DicomStructuredReport>> DicomComponentMutators = new()
+        {
+            [IrradiationEventUid] = SetIrradiationEventUid,
+            [EntranceExposureAtRp] = AddComponentForDicomMeasuredValue,
+            [AccumulatedAverageGlandularDose] = AddComponentForDicomMeasuredValue,
+            [DoseAreaProductTotal] = AddComponentForDicomMeasuredValue,
+            [FluoroDoseAreaProductTotal] = AddComponentForDicomMeasuredValue,
+            [AcquisitionDoseAreaProductTotal] = AddComponentForDicomMeasuredValue,
+            [TotalFluoroTime] = AddComponentForDicomMeasuredValue,
+            [TotalNumberOfRadiographicFrames] = AddComponentForDicomIntegerValue,
+            [AdministeredActivity] = AddComponentForDicomMeasuredValue,
+            [CtDoseLengthProductTotal] = AddComponentForDicomMeasuredValue,
+            [TotalNumberOfIrradiationEvents] = AddComponentForDicomIntegerValue,
+            [MeanCtdIvol] = AddComponentForDicomMeasuredValue,
+            [RadiopharmaceuticalAgent] = AddComponentForDicomTextValue,
+            [RadiopharmaceuticalVolume] = AddComponentForDicomMeasuredValue,
+            [Radionuclide] = AddComponentForDicomTextValue,
+            [RouteOfAdministration] = AddComponentForDicomMeasuredValue,
+            [Dlp] = AddComponentForDicomMeasuredValue,
+            [CtdIwPhantomType] = AddComponentForDicomCodeValue,
+        };
+
+        private static void SetIrradiationEventUid(Observation observation, DicomStructuredReport report)
+        {
+            var system = GetSystem(report.Code.Scheme);
+            var value = report.Get<string>();
+            observation.Identifier.Add(new Identifier(system, value));
+        }
+
+        private static void AddComponentForDicomMeasuredValue(Observation observation, DicomStructuredReport report)
+        {
+            var system = GetSystem(report.Code.Scheme);
+            var component = new Observation.ComponentComponent
+            {
+                Code = new CodeableConcept(system, report.Code.Value, report.Code.Meaning),
+            };
+            DicomMeasuredValue measuredValue = report.Get<DicomMeasuredValue>();
+            component.Value = new Quantity(measuredValue.Value, measuredValue.Code.Value);
+            observation.Component.Add(component);
+        }
+
+        private static void AddComponentForDicomTextValue(Observation observation, DicomStructuredReport report)
+        {
+            var system = GetSystem(report.Code.Scheme);
+            var component = new Observation.ComponentComponent
+            {
+                Code = new CodeableConcept(system, report.Code.Value, report.Code.Meaning),
+            };
+            var value = report.Get<string>();
+            component.Value = new FhirString(value);
+            observation.Component.Add(component);
+        }
+
+
+        private static void AddComponentForDicomCodeValue(Observation observation, DicomStructuredReport report)
+        {
+            var system = GetSystem(report.Code.Scheme);
+            var component = new Observation.ComponentComponent
+            {
+                Code = new CodeableConcept(system, report.Code.Value, report.Code.Meaning),
+            };
+            DicomCodeItem codeItem = report.Get<DicomCodeItem>();
+            component.Value = new CodeableConcept(system, codeItem.Value, codeItem.Meaning);
+            observation.Component.Add(component);
+        }
+
+        private static void AddComponentForDicomIntegerValue(Observation observation, DicomStructuredReport report)
+        {
+            var system = GetSystem(report.Code.Scheme);
+            var component = new Observation.ComponentComponent
+            {
+                Code = new CodeableConcept(system, report.Code.Value, report.Code.Meaning),
+            };
+            var value = report.Get<int>();
+            component.Value = new Integer(value);
+            observation.Component.Add(component);
+        }
+
+        private static string GetSystem(string scheme)
+        {
+            return scheme switch
+            {
+                Dcm => DcmSystem,
+                Sct => SctSystem,
+                _ => throw new InvalidOperationException($"unsupported code system: {scheme}")
+            };
+        }
+    }
+}

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationPipelineStep.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationPipelineStep.cs
@@ -1,0 +1,65 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Globalization;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using Hl7.Fhir.Utility;
+using Microsoft.Health.Dicom.Client.Models;
+using Microsoft.Health.DicomCast.Core.Features.Fhir;
+
+namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
+{
+    public class ObservationPipelineStep : IFhirTransactionPipelineStep
+    {
+        private readonly IObservationUpsertHandler _observationUpsertHandler;
+        private readonly IObservationDeleteHandler _observationDeleteHandler;
+
+        public ObservationPipelineStep(
+            IObservationUpsertHandler observationUpsertHandler,
+            IObservationDeleteHandler observationDeleteHandler
+        )
+        {
+            EnsureArg.IsNotNull(observationUpsertHandler, nameof(observationUpsertHandler));
+            EnsureArg.IsNotNull(observationDeleteHandler, nameof(observationDeleteHandler));
+
+            _observationUpsertHandler = observationUpsertHandler;
+            _observationDeleteHandler = observationDeleteHandler;
+        }
+
+        /// <inheritdoc/>
+        public async Task PrepareRequestAsync(FhirTransactionContext context, CancellationToken cancellationToken)
+        {
+            EnsureArg.IsNotNull(context, nameof(context));
+
+            ChangeFeedEntry changeFeedEntry = context.ChangeFeedEntry;
+            context.Request.Observation = changeFeedEntry.Action switch
+            {
+                ChangeFeedAction.Create => await _observationUpsertHandler.BuildAsync(context, cancellationToken),
+                ChangeFeedAction.Delete => await _observationDeleteHandler.BuildAsync(context, cancellationToken),
+                _ => throw new NotSupportedException(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        DicomCastCoreResource.NotSupportedChangeFeedAction,
+                        changeFeedEntry.Action))
+            };
+        }
+
+        /// <inheritdoc/>
+        public void ProcessResponse(FhirTransactionContext context)
+        {
+            EnsureArg.IsNotNull(context, nameof(context));
+            if (context.Request?.Observation?.RequestMode != FhirTransactionRequestMode.Create)
+                return;
+
+            HttpStatusCode statusCode = context.Response.Observation.Response.Annotation<HttpStatusCode>();
+            if (statusCode == HttpStatusCode.OK)
+                throw new ResourceConflictException();
+        }
+    }
+}

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationUpsertHandler.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationUpsertHandler.cs
@@ -1,0 +1,120 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Utility;
+using Microsoft.Health.Dicom.Client.Models;
+using Microsoft.Health.DicomCast.Core.Extensions;
+using Microsoft.Health.DicomCast.Core.Features.Fhir;
+
+namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
+{
+    public interface IObservationUpsertHandler
+    {
+        /// <summary>
+        /// Creates a transaction request to either update or create a Dose Summary observation based on the information
+        /// found in the DicomDataset provided in the context.
+        /// </summary>
+        /// <param name="context">The transaction context</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>A transaction request entry containing either a PUT or POST request to create a Dose Summary observation</returns>
+        Task<FhirTransactionRequestEntry> BuildAsync(FhirTransactionContext context, CancellationToken cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    class ObservationUpsertHandler : IObservationUpsertHandler
+    {
+        private readonly IFhirService _fhirService;
+
+        public ObservationUpsertHandler(IFhirService fhirService)
+        {
+            EnsureArg.IsNotNull(fhirService, nameof(fhirService));
+            _fhirService = fhirService;
+        }
+
+        public async Task<FhirTransactionRequestEntry> BuildAsync(FhirTransactionContext context, CancellationToken cancellationToken)
+        {
+            EnsureArg.IsNotNull(context, nameof(context));
+            EnsureArg.IsNotNull(context.ChangeFeedEntry, nameof(context.ChangeFeedEntry));
+            EnsureArg.IsNotNull(context.Request, nameof(context.Request));
+
+            IResourceId patientId = context.Request.Patient.ResourceId;
+            IResourceId imagingStudyId = context.Request.ImagingStudy.ResourceId;
+            ChangeFeedEntry changeFeedEntry = context.ChangeFeedEntry;
+
+            // Parse all observations out of the dataset
+            ParsedObservation parsedObservations = ObservationParser.CreateObservations(
+                changeFeedEntry.Metadata,
+                patientId.ToResourceReference(),
+                imagingStudyId.ToResourceReference()
+            );
+            Collection<Observation> doseSummaries = parsedObservations.DoseSummaries;
+            Collection<Observation> irradiationEvents = parsedObservations.IrradiationEvents;
+
+            if (!doseSummaries.Any())
+                return null;
+
+            // operate on the pre-condition that their _should_ only be one DoseSummary per ImagingStudy.
+            // If multiple observations are found; just use the first one.
+            Observation doseSummary = doseSummaries[0];
+
+            // Filter out existing observations
+            Identifier imagingStudyIdentifier = imagingStudyId.ToResourceReference().Identifier;
+            IEnumerable<Observation> existingDoseSummariesAsync = imagingStudyIdentifier != null
+                ? await _fhirService
+                    .RetrieveObservationsAsync(
+                        imagingStudyId.ToResourceReference().Identifier,
+                        cancellationToken)
+                : new List<Observation>();
+
+            var existingDoseSummaries =
+                existingDoseSummariesAsync.ToList();
+            var isExisting = existingDoseSummaries.Any();
+
+            FhirTransactionRequestMode method = isExisting
+                ? FhirTransactionRequestMode.Create
+                : FhirTransactionRequestMode.Update;
+
+            Bundle.RequestComponent request = isExisting
+                ? new Bundle.RequestComponent()
+                {
+                    Method = Bundle.HTTPVerb.PUT,
+                    Url = $"{ResourceType.Observation.GetLiteral()}/{existingDoseSummaries[0].Id}"
+                }
+                : new Bundle.RequestComponent()
+                {
+                    Method = Bundle.HTTPVerb.POST,
+                    Url = ResourceType.Observation.GetLiteral()
+                };
+
+            FhirTransactionRequestMode transactionRequestMode = isExisting
+                ? FhirTransactionRequestMode.Update
+                : FhirTransactionRequestMode.Create;
+
+            IResourceId resourceId = isExisting
+                ? existingDoseSummaries[0].ToServerResourceId()
+                : new ClientResourceId();
+
+            var transactionRequestEntry = new FhirTransactionRequestEntry(
+                transactionRequestMode,
+                request,
+                resourceId,
+                doseSummary
+            );
+
+            // Even if there are multiple dose summary transactions, we only act on the first one.
+            // There can _technically_ be multiple dose summary within a single report. However, it
+            // goes against the dicom specification.
+            // TODO figure out how we can support creation of irradiation events -- which require be able to create more than one instance of resource at once.
+            return transactionRequestEntry;
+        }
+    }
+}

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Modules/FhirModule.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Modules/FhirModule.cs
@@ -67,6 +67,16 @@ namespace Microsoft.Health.DicomCast.Core.Modules
                 .Singleton()
                 .AsSelf()
                 .AsImplementedInterfaces();
+            
+            services.Add<ObservationUpsertHandler>()
+                .Singleton()
+                .AsSelf()
+                .AsImplementedInterfaces();
+
+            services.Add<ObservationDeleteHandler>()
+                .Singleton()
+                .AsSelf()
+                .AsImplementedInterfaces();
         }
     }
 }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Modules/WorkerModule.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Modules/WorkerModule.cs
@@ -116,14 +116,14 @@ namespace Microsoft.Health.DicomCast.Core.Modules
                 .AsImplementedInterfaces();
 
             services.Add<ImagingStudySeriesPropertySynchronizer>()
-               .Singleton()
-               .AsSelf()
-               .AsImplementedInterfaces();
+                .Singleton()
+                .AsSelf()
+                .AsImplementedInterfaces();
 
             services.Add<ImagingStudyInstancePropertySynchronizer>()
-               .Singleton()
-               .AsSelf()
-               .AsImplementedInterfaces();
+                .Singleton()
+                .AsSelf()
+                .AsImplementedInterfaces();
 
             services.Add<FhirTransactionRequestResponsePropertyAccessors>()
                 .Singleton()
@@ -145,6 +145,11 @@ namespace Microsoft.Health.DicomCast.Core.Modules
                 .AsImplementedInterfaces();
 
             services.Add<ImagingStudyPipelineStep>()
+                .Singleton()
+                .AsSelf()
+                .AsImplementedInterfaces();
+
+            services.Add<ObservationPipelineStep>()
                 .Singleton()
                 .AsSelf()
                 .AsImplementedInterfaces();


### PR DESCRIPTION
## Description

- Adds an observation pipeline step to the transaction pipeline to create
  DoseSummary observations based on the specification at [Radiation Dose Summary
  for Diagnostic Procedures on FHIR spec][1].
- Currently parses DicomStructuredReports for both DoseSummary and
  IrradiationEvent observations but only DoseSummary is currently created as the
  transaction request pipeline will require a larger refactor to support
  creating multiple resources within a single request.

Status Log:

- [x] Dose Summary Observation support
  - [x] Able to parse
  - [x] Able to create/update/delete
- [ ] Irradiation Event Observation support
  - [x] Able to parse
  - [ ] Able to create/update/delete
- [ ] Indication Observation support
  - [ ] Able to parse
  - [ ] Able to create/update/delete
- [ ] Pregnancy Status Profile support
  - [ ] Able to parse
  - [ ] Able to create/update/delete

[1]:
  https://confluence.hl7.org/display/IMIN/Radiation+Dose+Summary+for+Diagnostic+Procedures+on+FHIR#RadiationDoseSummaryforDiagnosticProceduresonFHIR-DoseSummaryObservationProfile

## Related issues

N/A

## Testing

- [x] Manual E2E testing completed using test DICOM files provided by
      @moiradillon12
  - Refer to
    https://confluence.hl7.org/pages/viewpage.action?pageId=97464644#RadiationDoseSummaryforDiagnosticProceduresonFHIR-Usageexamples
    for sample FHIR queries.
- [ ] Unit tests
