### PR TITLE
Make Sql schema migration idempotent

### DIFF
--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/2.diff.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/2.diff.sql
@@ -6,24 +6,31 @@
     TagLevel can be 0, 1 or 2 to represent Instance, Series or Study level
     TagStatus can be 0, 1 or 2 to represent Adding, Ready or Deleting
 **************************************************************/
-CREATE TABLE dbo.ExtendedQueryTag (
-    TagKey                  INT                  NOT NULL, --PK
-    TagPath                 VARCHAR(64)          NOT NULL,
-    TagVR                   VARCHAR(2)           NOT NULL,
-    TagPrivateCreator       NVARCHAR(64)         NULL, 
-    TagLevel                TINYINT              NOT NULL,
-    TagStatus               TINYINT              NOT NULL
-)
+IF NOT EXISTS (
+    SELECT * 
+    FROM sys.tables
+    WHERE name = 'ExtendedQueryTag')
+BEGIN
+    CREATE TABLE dbo.ExtendedQueryTag (
+        TagKey                  INT                  NOT NULL, --PK
+        TagPath                 VARCHAR(64)          NOT NULL,
+        TagVR                   VARCHAR(2)           NOT NULL,
+        TagPrivateCreator       NVARCHAR(64)         NULL, 
+        TagLevel                TINYINT              NOT NULL,
+        TagStatus               TINYINT              NOT NULL
+    )
 
-CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTag ON dbo.ExtendedQueryTag
-(
-    TagKey
-)
+    CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTag ON dbo.ExtendedQueryTag
+    (
+        TagKey
+    )
 
-CREATE UNIQUE NONCLUSTERED INDEX IX_ExtendedQueryTag_TagPath ON dbo.ExtendedQueryTag
-(
-    TagPath
-)
+    CREATE UNIQUE NONCLUSTERED INDEX IX_ExtendedQueryTag_TagPath ON dbo.ExtendedQueryTag
+    (
+        TagPath
+    )
+END
+GO
 
 /*************************************************************
     Extended Query Tag Data Table for VR Types mapping to String
@@ -32,23 +39,30 @@ CREATE UNIQUE NONCLUSTERED INDEX IX_ExtendedQueryTag_TagPath ON dbo.ExtendedQuer
           the Watermark is used to ensure that if there are different values between instances,
           the value on the instance with the highest watermark wins.
 **************************************************************/
-CREATE TABLE dbo.ExtendedQueryTagString (
+IF NOT EXISTS (
+    SELECT * 
+    FROM sys.tables
+    WHERE name = 'ExtendedQueryTagString')
+BEGIN
+    CREATE TABLE dbo.ExtendedQueryTagString (
     TagKey                  INT                  NOT NULL, --PK
     TagValue                NVARCHAR(64)         NOT NULL,
     StudyKey                BIGINT               NOT NULL, --FK
     SeriesKey               BIGINT               NULL,     --FK
     InstanceKey             BIGINT               NULL,     --FK
     Watermark               BIGINT               NOT NULL
-) WITH (DATA_COMPRESSION = PAGE)
+    ) WITH (DATA_COMPRESSION = PAGE)
 
-CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagString ON dbo.ExtendedQueryTagString
-(
-    TagKey,
-    TagValue,
-    StudyKey,
-    SeriesKey,
-    InstanceKey
-)
+    CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagString ON dbo.ExtendedQueryTagString
+    (
+        TagKey,
+        TagValue,
+        StudyKey,
+        SeriesKey,
+        InstanceKey
+    )
+END
+GO
 
 /*************************************************************
     Extended Query Tag Data Table for VR Types mapping to Long
@@ -57,23 +71,30 @@ CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagString ON dbo.ExtendedQueryTag
           the Watermark is used to ensure that if there are different values between instances,
           the value on the instance with the highest watermark wins.
 **************************************************************/
-CREATE TABLE dbo.ExtendedQueryTagLong (
-    TagKey                  INT                  NOT NULL, --PK
-    TagValue                BIGINT               NOT NULL,
-    StudyKey                BIGINT               NOT NULL, --FK
-    SeriesKey               BIGINT               NULL,     --FK
-    InstanceKey             BIGINT               NULL,     --FK
-    Watermark               BIGINT               NOT NULL
-) WITH (DATA_COMPRESSION = PAGE)
+IF NOT EXISTS (
+    SELECT * 
+    FROM sys.tables
+    WHERE name = 'ExtendedQueryTagLong')
+BEGIN
+    CREATE TABLE dbo.ExtendedQueryTagLong (
+        TagKey                  INT                  NOT NULL, --PK
+        TagValue                BIGINT               NOT NULL,
+        StudyKey                BIGINT               NOT NULL, --FK
+        SeriesKey               BIGINT               NULL,     --FK
+        InstanceKey             BIGINT               NULL,     --FK
+        Watermark               BIGINT               NOT NULL
+    ) WITH (DATA_COMPRESSION = PAGE)
 
-CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagLong ON dbo.ExtendedQueryTagLong
-(
-    TagKey,
-    TagValue,
-    StudyKey,
-    SeriesKey,
-    InstanceKey
-)
+    CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagLong ON dbo.ExtendedQueryTagLong
+    (
+        TagKey,
+        TagValue,
+        StudyKey,
+        SeriesKey,
+        InstanceKey
+    )
+END
+GO
 
 /*************************************************************
     Extended Query Tag Data Table for VR Types mapping to Double
@@ -82,23 +103,30 @@ CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagLong ON dbo.ExtendedQueryTagLo
           the Watermark is used to ensure that if there are different values between instances,
           the value on the instance with the highest watermark wins.
 **************************************************************/
-CREATE TABLE dbo.ExtendedQueryTagDouble (
-    TagKey                  INT                  NOT NULL, --PK
-    TagValue                FLOAT(53)            NOT NULL,
-    StudyKey                BIGINT               NOT NULL, --FK
-    SeriesKey               BIGINT               NULL,     --FK
-    InstanceKey             BIGINT               NULL,     --FK
-    Watermark               BIGINT               NOT NULL
-) WITH (DATA_COMPRESSION = PAGE)
+IF NOT EXISTS (
+    SELECT * 
+    FROM sys.tables
+    WHERE name = 'ExtendedQueryTagDouble')
+BEGIN
+    CREATE TABLE dbo.ExtendedQueryTagDouble (
+        TagKey                  INT                  NOT NULL, --PK
+        TagValue                FLOAT(53)            NOT NULL,
+        StudyKey                BIGINT               NOT NULL, --FK
+        SeriesKey               BIGINT               NULL,     --FK
+        InstanceKey             BIGINT               NULL,     --FK
+        Watermark               BIGINT               NOT NULL
+    ) WITH (DATA_COMPRESSION = PAGE)
 
-CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagDouble ON dbo.ExtendedQueryTagDouble
-(
-    TagKey,
-    TagValue,
-    StudyKey,
-    SeriesKey,
-    InstanceKey
-)
+    CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagDouble ON dbo.ExtendedQueryTagDouble
+    (
+        TagKey,
+        TagValue,
+        StudyKey,
+        SeriesKey,
+        InstanceKey
+    )
+END
+GO
 
 /*************************************************************
     Extended Query Tag Data Table for VR Types mapping to DateTime
@@ -107,23 +135,30 @@ CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagDouble ON dbo.ExtendedQueryTag
           the Watermark is used to ensure that if there are different values between instances,
           the value on the instance with the highest watermark wins.
 **************************************************************/
-CREATE TABLE dbo.ExtendedQueryTagDateTime (
-    TagKey                  INT                  NOT NULL, --PK
-    TagValue                DATETIME2(7)         NOT NULL,
-    StudyKey                BIGINT               NOT NULL, --FK
-    SeriesKey               BIGINT               NULL,     --FK
-    InstanceKey             BIGINT               NULL,     --FK
-    Watermark               BIGINT               NOT NULL
-) WITH (DATA_COMPRESSION = PAGE)
+IF NOT EXISTS (
+    SELECT * 
+    FROM sys.tables
+    WHERE name = 'ExtendedQueryTagDateTime')
+BEGIN
+    CREATE TABLE dbo.ExtendedQueryTagDateTime (
+        TagKey                  INT                  NOT NULL, --PK
+        TagValue                DATETIME2(7)         NOT NULL,
+        StudyKey                BIGINT               NOT NULL, --FK
+        SeriesKey               BIGINT               NULL,     --FK
+        InstanceKey             BIGINT               NULL,     --FK
+        Watermark               BIGINT               NOT NULL
+    ) WITH (DATA_COMPRESSION = PAGE)
 
-CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagDateTime ON dbo.ExtendedQueryTagDateTime
-(
-    TagKey,
-    TagValue,
-    StudyKey,
-    SeriesKey,
-    InstanceKey
-)
+    CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagDateTime ON dbo.ExtendedQueryTagDateTime
+    (
+        TagKey,
+        TagValue,
+        StudyKey,
+        SeriesKey,
+        InstanceKey
+    )
+END
+GO
 
 /*************************************************************
     Extended Query Tag Data Table for VR Types mapping to PersonName
@@ -133,113 +168,143 @@ CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagDateTime ON dbo.ExtendedQueryT
           the value on the instance with the highest watermark wins.
     Note: The primary key is designed on the assumption that tags only occur once in an instance.
 **************************************************************/
-CREATE TABLE dbo.ExtendedQueryTagPersonName (
-    TagKey                  INT                  NOT NULL, --FK
-    TagValue                NVARCHAR(200)        COLLATE SQL_Latin1_General_CP1_CI_AI NOT NULL,
-    StudyKey                BIGINT               NOT NULL, --FK
-    SeriesKey               BIGINT               NULL,     --FK
-    InstanceKey             BIGINT               NULL,     --FK
-    Watermark               BIGINT               NOT NULL,
-    WatermarkAndTagKey      AS CONCAT(TagKey, '.', Watermark), --PK
-    TagValueWords           AS REPLACE(REPLACE(TagValue, '^', ' '), '=', ' ') PERSISTED,
-) WITH (DATA_COMPRESSION = PAGE)
+IF NOT EXISTS (
+    SELECT * 
+    FROM sys.tables
+    WHERE name = 'ExtendedQueryTagPersonName')
+BEGIN
+    CREATE TABLE dbo.ExtendedQueryTagPersonName (
+        TagKey                  INT                  NOT NULL, --FK
+        TagValue                NVARCHAR(200)        COLLATE SQL_Latin1_General_CP1_CI_AI NOT NULL,
+        StudyKey                BIGINT               NOT NULL, --FK
+        SeriesKey               BIGINT               NULL,     --FK
+        InstanceKey             BIGINT               NULL,     --FK
+        Watermark               BIGINT               NOT NULL,
+        WatermarkAndTagKey      AS CONCAT(TagKey, '.', Watermark), --PK
+        TagValueWords           AS REPLACE(REPLACE(TagValue, '^', ' '), '=', ' ') PERSISTED,
+    ) WITH (DATA_COMPRESSION = PAGE)
 
-CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagPersonName ON dbo.ExtendedQueryTagPersonName
-(
-    TagKey,
-    TagValue,
-    StudyKey,
-    SeriesKey,
-    InstanceKey
-)
+    CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagPersonName ON dbo.ExtendedQueryTagPersonName
+    (
+        TagKey,
+        TagValue,
+        StudyKey,
+        SeriesKey,
+        InstanceKey
+    )
 
-CREATE UNIQUE NONCLUSTERED INDEX IXC_ExtendedQueryTagPersonName_WatermarkAndTagKey ON dbo.ExtendedQueryTagPersonName
-(
-    WatermarkAndTagKey
-)
+    CREATE UNIQUE NONCLUSTERED INDEX IXC_ExtendedQueryTagPersonName_WatermarkAndTagKey ON dbo.ExtendedQueryTagPersonName
+    (
+        WatermarkAndTagKey
+    )
 
-CREATE FULLTEXT INDEX ON ExtendedQueryTagPersonName(TagValueWords LANGUAGE 1033)
-KEY INDEX IXC_ExtendedQueryTagPersonName_WatermarkAndTagKey
-WITH STOPLIST = OFF;
+    CREATE FULLTEXT INDEX ON ExtendedQueryTagPersonName(TagValueWords LANGUAGE 1033)
+    KEY INDEX IXC_ExtendedQueryTagPersonName_WatermarkAndTagKey
+    WITH STOPLIST = OFF;
+END
+GO
 
 /*************************************************************
     The user defined type for AddExtendedQueryTagsInput
 *************************************************************/
-CREATE TYPE dbo.AddExtendedQueryTagsInputTableType_1 AS TABLE
-(
-    TagPath                    VARCHAR(64),  -- Extended Query Tag Path. Each extended query tag take 8 bytes, support upto 8 levels, no delimeter between each level.
-    TagVR                      VARCHAR(2),  -- Extended Query Tag VR.
-    TagPrivateCreator          NVARCHAR(64),  -- Extended Query Tag Private Creator, only valid for private tag.
-    TagLevel                   TINYINT  -- Extended Query Tag level. 0 -- Instance Level, 1 -- Series Level, 2 -- Study Level
-)
+IF TYPE_ID(N'AddExtendedQueryTagsInputTableType_1') IS NULL
+BEGIN
+    CREATE TYPE dbo.AddExtendedQueryTagsInputTableType_1 AS TABLE
+    (
+        TagPath                    VARCHAR(64),  -- Extended Query Tag Path. Each extended query tag take 8 bytes, support upto 8 levels, no delimeter between each level.
+        TagVR                      VARCHAR(2),  -- Extended Query Tag VR.
+        TagPrivateCreator          NVARCHAR(64),  -- Extended Query Tag Private Creator, only valid for private tag.
+        TagLevel                   TINYINT  -- Extended Query Tag level. 0 -- Instance Level, 1 -- Series Level, 2 -- Study Level
+    )
+END
 GO
 
 /*************************************************************
     Table valued parameter to insert into Extended Query Tag table for data type String
 *************************************************************/
-CREATE TYPE dbo.InsertStringExtendedQueryTagTableType_1 AS TABLE
-(
-    TagKey                     INT,
-    TagValue                   NVARCHAR(64),
-    TagLevel                   TINYINT
-)
+IF TYPE_ID(N'InsertStringExtendedQueryTagTableType_1') IS NULL
+BEGIN
+    CREATE TYPE dbo.InsertStringExtendedQueryTagTableType_1 AS TABLE
+    (
+        TagKey                     INT,
+        TagValue                   NVARCHAR(64),
+        TagLevel                   TINYINT
+    )
+END
 GO
 
 /*************************************************************
     Table valued parameter to insert into Extended Query Tag table for data type Double
 *************************************************************/
-CREATE TYPE dbo.InsertDoubleExtendedQueryTagTableType_1 AS TABLE
-(
-    TagKey                     INT,
-    TagValue                   FLOAT(53),
-    TagLevel                   TINYINT
-)
+IF TYPE_ID(N'InsertDoubleExtendedQueryTagTableType_1') IS NULL
+BEGIN
+    CREATE TYPE dbo.InsertDoubleExtendedQueryTagTableType_1 AS TABLE
+    (
+        TagKey                     INT,
+        TagValue                   FLOAT(53),
+        TagLevel                   TINYINT
+    )
+END
 GO
 
 /*************************************************************
     Table valued parameter to insert into Extended Query Tag table for data type Long
 *************************************************************/
-CREATE TYPE dbo.InsertLongExtendedQueryTagTableType_1 AS TABLE
-(
-    TagKey                     INT,
-    TagValue                   BIGINT,
-    TagLevel                   TINYINT
-)
+IF TYPE_ID(N'InsertLongExtendedQueryTagTableType_1') IS NULL
+BEGIN
+    CREATE TYPE dbo.InsertLongExtendedQueryTagTableType_1 AS TABLE
+    (
+        TagKey                     INT,
+        TagValue                   BIGINT,
+        TagLevel                   TINYINT
+    )
+END
 GO
 
 /*************************************************************
     Table valued parameter to insert into Extended Query Tag table for data type Date Time
 *************************************************************/
-CREATE TYPE dbo.InsertDateTimeExtendedQueryTagTableType_1 AS TABLE
-(
-    TagKey                     INT,
-    TagValue                   DATETIME2(7),
-    TagLevel                   TINYINT
-)
+IF TYPE_ID(N'InsertDateTimeExtendedQueryTagTableType_1') IS NULL
+BEGIN
+    CREATE TYPE dbo.InsertDateTimeExtendedQueryTagTableType_1 AS TABLE
+    (
+        TagKey                     INT,
+        TagValue                   DATETIME2(7),
+        TagLevel                   TINYINT
+    )
+END
 GO
 
 /*************************************************************
     Table valued parameter to insert into Extended Query Tag table for data type Person Name
 *************************************************************/
-CREATE TYPE dbo.InsertPersonNameExtendedQueryTagTableType_1 AS TABLE
-(
-    TagKey                     INT,
-    TagValue                   NVARCHAR(200)        COLLATE SQL_Latin1_General_CP1_CI_AI,
-    TagLevel                   TINYINT
-)
+IF TYPE_ID(N'InsertPersonNameExtendedQueryTagTableType_1') IS NULL
+BEGIN
+    CREATE TYPE dbo.InsertPersonNameExtendedQueryTagTableType_1 AS TABLE
+    (
+        TagKey                     INT,
+        TagValue                   NVARCHAR(200)        COLLATE SQL_Latin1_General_CP1_CI_AI,
+        TagLevel                   TINYINT
+    )
+END
 GO
 
 /*************************************************************
     Sequence for generating sequential unique ids
 **************************************************************/
-CREATE SEQUENCE dbo.TagKeySequence
-    AS INT
-    START WITH 1
-    INCREMENT BY 1
-    MINVALUE 1
-    NO CYCLE
-    CACHE 10000
-
+IF NOT EXISTS (
+    SELECT * 
+    FROM sys.sequences
+    WHERE name = 'TagKeySequence')
+BEGIN
+    CREATE SEQUENCE dbo.TagKeySequence
+        AS INT
+        START WITH 1
+        INCREMENT BY 1
+        MINVALUE 1
+        NO CYCLE
+        CACHE 10000
+END
 GO
 
 /***************************************************************************************/
@@ -441,7 +506,7 @@ GO
 --     @extendedQueryTags
 --         * The extended query tag list
 /***************************************************************************************/
-CREATE PROCEDURE dbo.AddExtendedQueryTags (
+CREATE OR ALTER PROCEDURE dbo.AddExtendedQueryTags (
     @extendedQueryTags dbo.AddExtendedQueryTagsInputTableType_1 READONLY
 )
 AS
@@ -479,7 +544,7 @@ GO
 --     @tagPath
 --         * The TagPath for the extended query tag to retrieve.
 /***************************************************************************************/
-CREATE PROCEDURE dbo.GetExtendedQueryTag (
+CREATE OR ALTER PROCEDURE dbo.GetExtendedQueryTag (
     @tagPath  VARCHAR(64) = NULL
 )
 AS
@@ -511,7 +576,7 @@ GO
 --     @dataType
 --         * the data type of extended query tag. 0 -- String, 1 -- Long, 2 -- Double, 3 -- DateTime, 4 -- PersonName
 /***************************************************************************************/
-CREATE PROCEDURE dbo.DeleteExtendedQueryTag (
+CREATE OR ALTER PROCEDURE dbo.DeleteExtendedQueryTag (
     @tagPath VARCHAR(64),
     @dataType TINYINT
 )

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/2.diff.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/2.diff.sql
@@ -149,15 +149,6 @@ BEGIN
         InstanceKey             BIGINT               NULL,     --FK
         Watermark               BIGINT               NOT NULL
     ) WITH (DATA_COMPRESSION = PAGE)
-
-    CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagDouble ON dbo.ExtendedQueryTagDouble
-    (
-        TagKey,
-        TagValue,
-        StudyKey,
-        SeriesKey,
-        InstanceKey
-    )
 END
 
 IF NOT EXISTS (

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/2.diff.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/2.diff.sql
@@ -19,12 +19,24 @@ BEGIN
         TagLevel                TINYINT              NOT NULL,
         TagStatus               TINYINT              NOT NULL
     )
+END
 
-    CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTag ON dbo.ExtendedQueryTag
+IF NOT EXISTS (
+    SELECT * 
+	FROM sys.indexes 
+	WHERE name='IXC_ExtendedQueryTag' AND object_id = OBJECT_ID('dbo.ExtendedQueryTag'))
+BEGIN
+	CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTag ON dbo.ExtendedQueryTag
     (
         TagKey
     )
+END
 
+IF NOT EXISTS (
+    SELECT * 
+	FROM sys.indexes 
+	WHERE name='IX_ExtendedQueryTag_TagPath' AND object_id = OBJECT_ID('dbo.ExtendedQueryTag'))
+BEGIN
     CREATE UNIQUE NONCLUSTERED INDEX IX_ExtendedQueryTag_TagPath ON dbo.ExtendedQueryTag
     (
         TagPath
@@ -52,8 +64,14 @@ BEGIN
     InstanceKey             BIGINT               NULL,     --FK
     Watermark               BIGINT               NOT NULL
     ) WITH (DATA_COMPRESSION = PAGE)
+END
 
-    CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagString ON dbo.ExtendedQueryTagString
+IF NOT EXISTS (
+    SELECT * 
+	FROM sys.indexes 
+	WHERE name='IXC_ExtendedQueryTagString' AND object_id = OBJECT_ID('dbo.ExtendedQueryTagString'))
+BEGIN
+	CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagString ON dbo.ExtendedQueryTagString
     (
         TagKey,
         TagValue,
@@ -84,8 +102,14 @@ BEGIN
         InstanceKey             BIGINT               NULL,     --FK
         Watermark               BIGINT               NOT NULL
     ) WITH (DATA_COMPRESSION = PAGE)
+END
 
-    CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagLong ON dbo.ExtendedQueryTagLong
+IF NOT EXISTS (
+    SELECT * 
+	FROM sys.indexes 
+	WHERE name='IXC_ExtendedQueryTagLong' AND object_id = OBJECT_ID('dbo.ExtendedQueryTagLong'))
+BEGIN
+	CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagLong ON dbo.ExtendedQueryTagLong
     (
         TagKey,
         TagValue,
@@ -126,6 +150,21 @@ BEGIN
         InstanceKey
     )
 END
+
+IF NOT EXISTS (
+    SELECT * 
+	FROM sys.indexes 
+	WHERE name='IXC_ExtendedQueryTagDouble' AND object_id = OBJECT_ID('dbo.ExtendedQueryTagDouble'))
+BEGIN
+	CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagDouble ON dbo.ExtendedQueryTagDouble
+    (
+        TagKey,
+        TagValue,
+        StudyKey,
+        SeriesKey,
+        InstanceKey
+    )
+END
 GO
 
 /*************************************************************
@@ -148,8 +187,14 @@ BEGIN
         InstanceKey             BIGINT               NULL,     --FK
         Watermark               BIGINT               NOT NULL
     ) WITH (DATA_COMPRESSION = PAGE)
+END
 
-    CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagDateTime ON dbo.ExtendedQueryTagDateTime
+IF NOT EXISTS (
+    SELECT * 
+	FROM sys.indexes 
+	WHERE name='IXC_ExtendedQueryTagDateTime' AND object_id = OBJECT_ID('dbo.ExtendedQueryTagDateTime'))
+BEGIN
+	CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagDateTime ON dbo.ExtendedQueryTagDateTime
     (
         TagKey,
         TagValue,
@@ -183,8 +228,14 @@ BEGIN
         WatermarkAndTagKey      AS CONCAT(TagKey, '.', Watermark), --PK
         TagValueWords           AS REPLACE(REPLACE(TagValue, '^', ' '), '=', ' ') PERSISTED,
     ) WITH (DATA_COMPRESSION = PAGE)
+END
 
-    CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagPersonName ON dbo.ExtendedQueryTagPersonName
+IF NOT EXISTS (
+    SELECT * 
+	FROM sys.indexes 
+	WHERE name='IXC_ExtendedQueryTagPersonName' AND object_id = OBJECT_ID('dbo.ExtendedQueryTagPersonName'))
+BEGIN
+	CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagPersonName ON dbo.ExtendedQueryTagPersonName
     (
         TagKey,
         TagValue,
@@ -192,12 +243,24 @@ BEGIN
         SeriesKey,
         InstanceKey
     )
+END
 
+IF NOT EXISTS (
+    SELECT * 
+	FROM sys.indexes 
+	WHERE name='IXC_ExtendedQueryTagPersonName_WatermarkAndTagKey' AND object_id = OBJECT_ID('dbo.ExtendedQueryTagPersonName'))
+BEGIN
     CREATE UNIQUE NONCLUSTERED INDEX IXC_ExtendedQueryTagPersonName_WatermarkAndTagKey ON dbo.ExtendedQueryTagPersonName
     (
         WatermarkAndTagKey
     )
+END
 
+IF NOT EXISTS (
+    SELECT * 
+	FROM sys.fulltext_indexes 
+	where object_id = object_id('dbo.ExtendedQueryTagPersonName'))
+BEGIN
     CREATE FULLTEXT INDEX ON ExtendedQueryTagPersonName(TagValueWords LANGUAGE 1033)
     KEY INDEX IXC_ExtendedQueryTagPersonName_WatermarkAndTagKey
     WITH STOPLIST = OFF;

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlDataStoreTestsFixture.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlDataStoreTestsFixture.cs
@@ -68,11 +68,11 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
 
             var schemaManagerDataStore = new SchemaManagerDataStore(sqlConnectionFactory);
 
-            var schemaUpgradeRunner = new SchemaUpgradeRunner(scriptProvider, baseScriptProvider, NullLogger<SchemaUpgradeRunner>.Instance, sqlConnectionFactory, schemaManagerDataStore);
+            SchemaUpgradeRunner = new SchemaUpgradeRunner(scriptProvider, baseScriptProvider, NullLogger<SchemaUpgradeRunner>.Instance, sqlConnectionFactory, schemaManagerDataStore);
 
             var schemaInformation = new SchemaInformation(SchemaVersionConstants.Min, SchemaVersionConstants.Max);
 
-            _schemaInitializer = new SchemaInitializer(config, schemaUpgradeRunner, schemaInformation, sqlConnectionFactory, sqlConnectionStringProvider, mediator, NullLogger<SchemaInitializer>.Instance);
+            _schemaInitializer = new SchemaInitializer(config, SchemaUpgradeRunner, schemaInformation, sqlConnectionFactory, sqlConnectionStringProvider, mediator, NullLogger<SchemaInitializer>.Instance);
 
             SqlTransactionHandler = new SqlTransactionHandler();
 
@@ -99,6 +99,8 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
         public SqlConnectionWrapperFactory SqlConnectionWrapperFactory { get; }
 
         public IIndexDataStoreFactory SqlIndexDataStoreFactory { get; }
+
+        public SchemaUpgradeRunner SchemaUpgradeRunner { get; }
 
         public string TestConnectionString { get; }
 

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlDataStoreTestsFixture.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlDataStoreTestsFixture.cs
@@ -70,21 +70,21 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
 
             SchemaUpgradeRunner = new SchemaUpgradeRunner(scriptProvider, baseScriptProvider, NullLogger<SchemaUpgradeRunner>.Instance, sqlConnectionFactory, schemaManagerDataStore);
 
-            var schemaInformation = new SchemaInformation(SchemaVersionConstants.Min, SchemaVersionConstants.Max);
+            SchemaInformation = new SchemaInformation(SchemaVersionConstants.Min, SchemaVersionConstants.Max);
 
-            _schemaInitializer = new SchemaInitializer(config, SchemaUpgradeRunner, schemaInformation, sqlConnectionFactory, sqlConnectionStringProvider, mediator, NullLogger<SchemaInitializer>.Instance);
+            _schemaInitializer = new SchemaInitializer(config, SchemaUpgradeRunner, SchemaInformation, sqlConnectionFactory, sqlConnectionStringProvider, mediator, NullLogger<SchemaInitializer>.Instance);
 
             SqlTransactionHandler = new SqlTransactionHandler();
 
             SqlConnectionWrapperFactory = new SqlConnectionWrapperFactory(SqlTransactionHandler, new SqlCommandWrapperFactory(), sqlConnectionFactory);
 
             SqlIndexDataStoreFactory = new SqlIndexDataStoreFactory(
-                schemaInformation,
+                SchemaInformation,
                 new[] { new SqlIndexDataStoreV1(SqlConnectionWrapperFactory), new SqlIndexDataStoreV2(SqlConnectionWrapperFactory) });
 
             InstanceStore = new SqlInstanceStore(SqlConnectionWrapperFactory);
 
-            ExtendedQueryTagStore = new SqlExtendedQueryTagStore(SqlConnectionWrapperFactory, schemaInformation, NullLogger<SqlExtendedQueryTagStore>.Instance);
+            ExtendedQueryTagStore = new SqlExtendedQueryTagStore(SqlConnectionWrapperFactory, SchemaInformation, NullLogger<SqlExtendedQueryTagStore>.Instance);
 
             TestHelper = new SqlIndexDataStoreTestHelper(TestConnectionString);
         }
@@ -111,6 +111,8 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
         public IExtendedQueryTagStore ExtendedQueryTagStore { get; }
 
         public SqlIndexDataStoreTestHelper TestHelper { get; }
+
+        public SchemaInformation SchemaInformation { get; set; }
 
         public static string GenerateDatabaseName(string prefix = "DICOMINTEGRATIONTEST_")
         {

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Health.Dicom.SqlServer.Features.Schema;
@@ -39,8 +41,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
         }
 
         [Theory]
-        [InlineData(SchemaVersionConstants.Max)]
-        // we can keep adding previous schema version explicitly whenever SchemaVersionConstants.Max is updated.
+        [MemberData(nameof(SchemaDiffVersions))]
         public async Task GivenASchemaVersion_WhenApplyingDiffTwice_ShouldSucceed(int schemaVersion)
         {
             SqlDataStoreTestsFixture snapshotFixture = new SqlDataStoreTestsFixture(SqlDataStoreTestsFixture.GenerateDatabaseName("SNAPSHOT"));
@@ -54,5 +55,6 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             await snapshotFixture.DisposeAsync();
         }
 
+        public static IEnumerable<object[]> SchemaDiffVersions = new List<object[]>(Enumerable.Range(SchemaVersionConstants.Min + 1, SchemaVersionConstants.Max - 1).Select(x => new object[] { x }));
     }
 }

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
@@ -49,6 +49,9 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             await snapshotFixture.InitializeAsync(forceIncrementalSchemaUpgrade: false);
             await snapshotFixture.SchemaUpgradeRunner.ApplySchemaAsync(schemaVersion, applyFullSchemaSnapshot: false, CancellationToken.None);
             await snapshotFixture.SchemaUpgradeRunner.ApplySchemaAsync(schemaVersion, applyFullSchemaSnapshot: false, CancellationToken.None);
+
+            // cleanup if succeeds
+            await snapshotFixture.DisposeAsync();
         }
 
     }

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
@@ -55,6 +55,6 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             await snapshotFixture.DisposeAsync();
         }
 
-        public static IEnumerable<object[]> SchemaDiffVersions = new List<object[]>(Enumerable.Range(SchemaVersionConstants.Min + 1, SchemaVersionConstants.Max - 1).Select(x => new object[] { x }));
+        public static IEnumerable<object[]> SchemaDiffVersions = new List<object[]>(Enumerable.Range(start: SchemaVersionConstants.Min + 1, count: SchemaVersionConstants.Max - SchemaVersionConstants.Min).Select(x => new object[] { x }));
     }
 }

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
@@ -6,6 +6,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Health.Dicom.SqlServer.Features.Schema;
+using Microsoft.Health.SqlServer.Features.Schema;
 using Microsoft.SqlServer.Dac.Compare;
 using Xunit;
 
@@ -37,12 +38,18 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             await diffFixture.DisposeAsync();
         }
 
-        [Fact]
-        public async Task GivenASchemaVersion_WhenApplyingDiffTwice_ShouldSucceed()
+        [Theory]
+        [InlineData(SchemaVersionConstants.Max)]
+        // we can keep adding previous schema version explicitly whenever SchemaVersionConstants.Max is updated.
+        public async Task GivenASchemaVersion_WhenApplyingDiffTwice_ShouldSucceed(int schemaVersion)
         {
             SqlDataStoreTestsFixture snapshotFixture = new SqlDataStoreTestsFixture(SqlDataStoreTestsFixture.GenerateDatabaseName("SNAPSHOT"));
+            snapshotFixture.SchemaInformation = new SchemaInformation(SchemaVersionConstants.Min, schemaVersion - 1);
+
             await snapshotFixture.InitializeAsync(forceIncrementalSchemaUpgrade: false);
-            await snapshotFixture.SchemaUpgradeRunner.ApplySchemaAsync(SchemaVersionConstants.Max, applyFullSchemaSnapshot: false, CancellationToken.None);
+            await snapshotFixture.SchemaUpgradeRunner.ApplySchemaAsync(schemaVersion, applyFullSchemaSnapshot: false, CancellationToken.None);
+            await snapshotFixture.SchemaUpgradeRunner.ApplySchemaAsync(schemaVersion, applyFullSchemaSnapshot: false, CancellationToken.None);
         }
+
     }
 }

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
@@ -3,7 +3,9 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Health.Dicom.SqlServer.Features.Schema;
 using Microsoft.SqlServer.Dac.Compare;
 using Xunit;
 
@@ -33,6 +35,14 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             // cleanup if succeeds
             await snapshotFixture.DisposeAsync();
             await diffFixture.DisposeAsync();
+        }
+
+        [Fact]
+        public async Task GivenASchemaVersion_WhenApplyingDiffTwice_ShouldSucceed()
+        {
+            SqlDataStoreTestsFixture snapshotFixture = new SqlDataStoreTestsFixture(SqlDataStoreTestsFixture.GenerateDatabaseName("SNAPSHOT"));
+            await snapshotFixture.InitializeAsync(forceIncrementalSchemaUpgrade: false);
+            await snapshotFixture.SchemaUpgradeRunner.ApplySchemaAsync(SchemaVersionConstants.Max, applyFullSchemaSnapshot: false, CancellationToken.None);
         }
     }
 }


### PR DESCRIPTION
## Description
This PR updates latest schema migration script(2.diff.sql) for schema migration idempotency.
Currently schema-manager tool runs schema initialization scripts(x.sql) in transaction but runs the migration scripts(x.diff.sql) without wrapping in transaction so this PR ensures that our migration scripts(x.diff.sql) is idempotent.

## Related issues
Addresses [#AB81400](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Resolute/Stories/?workitem=81400)

## Testing
Integration test is added
