### PR TITLE
Add back background service health check

### DIFF
--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -53,7 +53,7 @@ Postman only supports uploading DICOM files using the single part payload define
    - Content-Type: `application/dicom`
 - Click `Send`, a successful post will result in a 200 OK
 
-![Postman headers](/docs/images/postman-singlepart-headers.png)
+![Postman headers](/docs/images/postman-singlepart-headers.PNG)
 
 ## Postman for Get
 - Example QIDO to get all studies

--- a/src/Microsoft.Health.Dicom.Api/Microsoft.Health.Dicom.Api.csproj
+++ b/src/Microsoft.Health.Dicom.Api/Microsoft.Health.Dicom.Api.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="fo-dicom" Version="4.0.7" />
     <PackageReference Include="fo-dicom.Json" Version="4.0.7" NoWarn="NU1701" />
     <PackageReference Include="MediatR" Version="9.0.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.17.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Health.Abstractions" Version="$(HealthcareSharedPackageVersion)" />
     <PackageReference Include="Microsoft.Health.Api" Version="$(HealthcareSharedPackageVersion)" />

--- a/src/Microsoft.Health.Dicom.Api/Microsoft.Health.Dicom.Api.csproj
+++ b/src/Microsoft.Health.Dicom.Api/Microsoft.Health.Dicom.Api.csproj
@@ -25,6 +25,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Scrutor" Version="3.3.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.11.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" PrivateAssets="All" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
@@ -80,6 +80,7 @@ namespace Microsoft.AspNetCore.Builder
 
             services.RegisterAssemblyModules(Assembly.GetExecutingAssembly(), dicomServerConfiguration);
             services.RegisterAssemblyModules(typeof(InitializationModule).Assembly, dicomServerConfiguration);
+            services.AddApplicationInsightsTelemetry();
 
             services.AddOptions();
 

--- a/src/Microsoft.Health.Dicom.Core/Modules/ServiceModule.cs
+++ b/src/Microsoft.Health.Dicom.Core/Modules/ServiceModule.cs
@@ -10,6 +10,7 @@ using Microsoft.Health.Dicom.Core.Features.ChangeFeed;
 using Microsoft.Health.Dicom.Core.Features.Common;
 using Microsoft.Health.Dicom.Core.Features.Delete;
 using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
+using Microsoft.Health.Dicom.Core.Features.HealthCheck;
 using Microsoft.Health.Dicom.Core.Features.Query;
 using Microsoft.Health.Dicom.Core.Features.Retrieve;
 using Microsoft.Health.Dicom.Core.Features.Store;
@@ -141,6 +142,10 @@ namespace Microsoft.Health.Dicom.Core.Modules
                    .Scoped()
                    .AsSelf()
                    .AsImplementedInterfaces();
+
+            services.AddSingleton<BackgroundServiceHealthCheckCache>();
+
+            services.AddHealthChecks().AddCheck<BackgroundServiceHealthCheck>(name: "BackgroundServiceHealthCheck");
 
             if (_featureConfiguration.EnableExtendedQueryTags)
             {


### PR DESCRIPTION
## Description
Adds back health check for background service but move application insights telemetry adding from core to api.

Also fixed a typo in a doc (apparently png and PNG are treated the same in visual studio code but not on github)