### PR TITLE
Correlation ID / Request ID for Requests.

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Features/Context/DicomRequestContextMiddleware.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Context/DicomRequestContextMiddleware.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Health.Dicom.Api.Features.Context
                 method: request.Method,
                 uri,
                 baseUri,
+                correlationId: System.Diagnostics.Activity.Current?.RootId,
                 context.Request.Headers,
                 context.Response.Headers);
 

--- a/src/Microsoft.Health.Dicom.Core/Features/Context/DicomRequestContext.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Context/DicomRequestContext.cs
@@ -20,15 +20,17 @@ namespace Microsoft.Health.Dicom.Core.Features.Context
             string method,
             string uriString,
             string baseUriString,
+            string correlationId,
             IDictionary<string, StringValues> requestHeaders,
             IDictionary<string, StringValues> responseHeaders)
-            : this(method, new Uri(uriString), new Uri(baseUriString), requestHeaders, responseHeaders)
+            : this(method, new Uri(uriString), new Uri(baseUriString), correlationId, requestHeaders, responseHeaders)
         { }
 
         public DicomRequestContext(
             string method,
             Uri uri,
             Uri baseUri,
+            string correlationId,
             IDictionary<string, StringValues> requestHeaders,
             IDictionary<string, StringValues> responseHeaders)
         {
@@ -40,6 +42,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Context
             Method = method;
             Uri = uri;
             BaseUri = baseUri;
+            CorrelationId = correlationId;
             RequestHeaders = requestHeaders;
             ResponseHeaders = responseHeaders;
         }


### PR DESCRIPTION
## Description
Currently, correlation id or request id is empty. Hence, there is no way to look at the logs and know about what request the customer is exactly complaining about. This user story should fix that issue.

Following is the pipeline that could be followed. Once the user's request fails, user will look into the logs exposed to them. The logs will have a correlation id or a request id. Customer would tell us the request id that failed. We will look at either `LinuxRequestTelemetry` table or `LinuxExceptionTelemetry` table to get more details about the request. There should be a column called operation id which should correlate to this correlation id or request id field.

## Related issues
[AB#82312](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/82312).