### PR TITLE
Operation Id to KubernetesContainers

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Features/Context/DicomRequestContextMiddleware.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Context/DicomRequestContextMiddleware.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Health.Dicom.Api.Features.Context
 {
     public class DicomRequestContextMiddleware
     {
+        private const string OperationIdName = "operationId";
         private readonly RequestDelegate _next;
 
         public DicomRequestContextMiddleware(RequestDelegate next)
@@ -53,7 +54,7 @@ namespace Microsoft.Health.Dicom.Api.Features.Context
             dicomRequestContextAccessor.RequestContext = dicomRequestContext;
 
             // Adding operation id for this request thread to the log context.
-            using (LogContext.PushProperty("operationId", System.Diagnostics.Activity.Current?.RootId))
+            using (LogContext.PushProperty(OperationIdName, System.Diagnostics.Activity.Current?.RootId))
             {
                 // Call the next delegate/middleware in the pipeline
                 await _next(context);

--- a/src/Microsoft.Health.Dicom.Api/Features/Context/DicomRequestContextMiddleware.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Context/DicomRequestContextMiddleware.cs
@@ -9,6 +9,7 @@ using EnsureThat;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.Health.Dicom.Core.Features.Context;
+using Serilog.Context;
 
 namespace Microsoft.Health.Dicom.Api.Features.Context
 {
@@ -51,8 +52,12 @@ namespace Microsoft.Health.Dicom.Api.Features.Context
 
             dicomRequestContextAccessor.RequestContext = dicomRequestContext;
 
-            // Call the next delegate/middleware in the pipeline
-            await _next(context);
+            // Adding operation id for this request thread to the log context.
+            using (LogContext.PushProperty("operationId", System.Diagnostics.Activity.Current?.RootId))
+            {
+                // Call the next delegate/middleware in the pipeline
+                await _next(context);
+            }
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Api/Microsoft.Health.Dicom.Api.csproj
+++ b/src/Microsoft.Health.Dicom.Api/Microsoft.Health.Dicom.Api.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Scrutor" Version="3.3.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.11.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" PrivateAssets="All" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" PrivateAssets="All" />


### PR DESCRIPTION
## Description
Added operation id to logs pushed to KubernetesContainers. This will help correlating the logs in LinuxRequestTelemetry.

`operationId` field is added as a property so won't be available as a separate field. Hence, a workaround will be required to join data from LinuxRequestTelemetry table to KubernetesContainers. Following is a Kusto query snippet that can be used:


> LinuxRequestTelemetry
> | where PreciseTimeStamp >= ago(15m)
> | where resultCode != 200
> | join (
> KubernetesContainers
> | where PodName contains "ali0427"
> | where PreciseTimeStamp >= ago(15m)
> | extend operation_Id = extract(@'operationId":"([a-z0-9]*)"', 1, log)
> ) on operation_Id


## Related issues
[AB#82459](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/82459).
