### PR TITLE
Fix Docker-Compose File Extension for CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,6 @@
 **/.classpath
 **/.dockerignore
 **/.env
-**/.git
-**/.gitignore
 **/.project
 **/.settings
 **/.toolstarget
@@ -21,5 +19,10 @@
 **/obj
 **/secrets.dev.yaml
 **/values.dev.yaml
+**/build
+**/docs
+**/samples
+test
+tools
+*.md
 LICENSE
-README.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
 **/.classpath
 **/.dockerignore
 **/.env
+**/.git
+**/.gitignore
 **/.project
 **/.settings
 **/.toolstarget
@@ -26,3 +28,8 @@ test
 tools
 *.md
 LICENSE
+
+# SourceLink
+!.git/HEAD
+!.git/config
+!.git/refs/heads

--- a/build/ci-variables.yml
+++ b/build/ci-variables.yml
@@ -11,6 +11,6 @@ variables:
   buildConfiguration: 'Release'
   imageTag: '$(build.BuildNumber)'
   azureContainerRegistry: 'dicomoss.azurecr.io'
-  dicomServerComposeLocation: 'docker/docker-compose.yaml'
+  dicomServerComposeLocation: 'docker/docker-compose.yml'
   dicomCastComposeLocation: 'converter/dicom-cast/build/docker/docker-compose.yaml'
   skipNugetSecurityAnalysis: 'true' # NuGet config contains multiple feeds but meets exception criteria

--- a/build/docker-build-push.yml
+++ b/build/docker-build-push.yml
@@ -15,6 +15,7 @@ steps:
       dockerComposeFile: $(dicomServerComposeLocation)
       projectName: linux
       additionalImageTags: ${{parameters.tag}}
+      arguments: '--build-arg CONTINUOUS_INTEGRATION_BUILD=true'
 
   - task: DockerCompose@0
     displayName: 'Push Dicom Server Image'
@@ -35,7 +36,7 @@ steps:
       dockerComposeFile: $(dicomCastComposeLocation)
       projectName: linux
       additionalImageTags: ${{parameters.tag}}
-    
+
   - task: DockerCompose@0
     displayName: 'Push Dicom cast Server Image'
     inputs:

--- a/src/Microsoft.Health.Dicom.Web/Dockerfile
+++ b/src/Microsoft.Health.Dicom.Web/Dockerfile
@@ -15,10 +15,11 @@ USER nonroot
 # Copy the DICOM Server project and build it
 FROM mcr.microsoft.com/dotnet/sdk:5.0.300-alpine3.12@sha256:cd03cb780dc61a1ef6e450a9e7025aa34c15a2c03e8a62a5dcfe7f490f7d2905 AS build
 ARG BUILD_CONFIGURATION=Release
+ARG CONTINUOUS_INTEGRATION_BUILD=false
 WORKDIR /dicom-server
 COPY . .
 WORKDIR /dicom-server/src/Microsoft.Health.Dicom.Web
-RUN dotnet build "Microsoft.Health.Dicom.Web.csproj" -c $BUILD_CONFIGURATION -warnaserror
+RUN dotnet build "Microsoft.Health.Dicom.Web.csproj" -c $BUILD_CONFIGURATION -p:ContinuousIntegrationBuild=$CONTINUOUS_INTEGRATION_BUILD -warnaserror
 
 # Publish the DICOM Server from the build
 FROM build as publish

--- a/src/Microsoft.Health.Dicom.Web/Startup.cs
+++ b/src/Microsoft.Health.Dicom.Web/Startup.cs
@@ -30,14 +30,12 @@ namespace Microsoft.Health.Dicom.Web
             });
             services.AddDevelopmentIdentityProvider<DataActions>(Configuration, "DicomServer");
 
+            // The execution of IHostedServices depends on the order they are added to the dependency injection container, so we
+            // need to ensure that the schema is initialized before the background workers are started.
             services.AddDicomServer(Configuration)
                 .AddBlobStorageDataStore(Configuration)
                 .AddMetadataStorageDataStore(Configuration)
                 .AddSqlServer(Configuration)
-                /*
-                    The execution of IHostedServices depends on the order they are added to the dependency injection container, so we
-                    need to ensure that the schema is initialized before the background workers are started.
-                */
                 .AddBackgroundWorkers();
 
             AddApplicationInsightsTelemetry(services);


### PR DESCRIPTION
## Description
- Fix Docker Compose file extension for CI pipeline
- Correctly use .dockerignore file for faster builds
- Fix minor style error
- Set ContinuousIntegrationBuild flag for CI Docker builds

## Related issues
[AB#82320](https://microsofthealth.visualstudio.com/Health/_workitems/edit/82320)

## Testing
Locally test build and double-check CI name
