### PR TITLE
Resolve Schema Version in Foreground as Necessary

### DIFF
--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Delete/DeleteServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Delete/DeleteServiceTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Delete
             _transactionScope = Substitute.For<ITransactionScope>();
             transactionHandler.BeginTransaction().Returns(_transactionScope);
 
-            _indexDataStoreFactory.GetInstance().Returns(_indexDataStore);
+            _indexDataStoreFactory.GetInstanceAsync().Returns(_indexDataStore);
             _deleteService = new DeleteService(_indexDataStoreFactory, _metadataStore, _fileDataStore, deletedInstanceCleanupConfigurationOptions, transactionHandler, NullLogger<DeleteService>.Instance);
         }
 

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Delete/DeleteServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Delete/DeleteServiceTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Delete
             _transactionScope = Substitute.For<ITransactionScope>();
             transactionHandler.BeginTransaction().Returns(_transactionScope);
 
-            _indexDataStoreFactory.GetInstanceAsync().Returns(_indexDataStore);
+            _indexDataStoreFactory.GetInstanceAsync(CancellationToken.None).Returns(_indexDataStore);
             _deleteService = new DeleteService(_indexDataStoreFactory, _metadataStore, _fileDataStore, deletedInstanceCleanupConfigurationOptions, transactionHandler, NullLogger<DeleteService>.Instance);
         }
 

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/AddExtendedQueryTagServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/AddExtendedQueryTagServiceTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.ChangeFeed
             _extendedQueryTagEntryValidator = Substitute.For<IExtendedQueryTagEntryValidator>();
             _extendedQueryTagStore = Substitute.For<IExtendedQueryTagStore>();
             var storeFactory = Substitute.For<IStoreFactory<IExtendedQueryTagStore>>();
-            storeFactory.GetInstance().Returns(_extendedQueryTagStore);
+            storeFactory.GetInstanceAsync().Returns(_extendedQueryTagStore);
             var config = new Configs.ExtendedQueryTagConfiguration();
             _extendedQueryTagService = new AddExtendedQueryTagService(storeFactory, _extendedQueryTagEntryValidator, Options.Create(config));
         }

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/AddExtendedQueryTagServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/AddExtendedQueryTagServiceTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.ChangeFeed
             _extendedQueryTagEntryValidator = Substitute.For<IExtendedQueryTagEntryValidator>();
             _extendedQueryTagStore = Substitute.For<IExtendedQueryTagStore>();
             var storeFactory = Substitute.For<IStoreFactory<IExtendedQueryTagStore>>();
-            storeFactory.GetInstanceAsync().Returns(_extendedQueryTagStore);
+            storeFactory.GetInstanceAsync(default).Returns(_extendedQueryTagStore);
             var config = new Configs.ExtendedQueryTagConfiguration();
             _extendedQueryTagService = new AddExtendedQueryTagService(storeFactory, _extendedQueryTagEntryValidator, Options.Create(config));
         }

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/DeleteExtendedQueryTagServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/DeleteExtendedQueryTagServiceTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.ChangeFeed
         {
             _extendedQueryTagStore = Substitute.For<IExtendedQueryTagStore>();
             var factory = Substitute.For<IStoreFactory<IExtendedQueryTagStore>>();
-            factory.GetInstance().Returns(_extendedQueryTagStore);
+            factory.GetInstanceAsync().Returns(_extendedQueryTagStore);
             _extendedQueryTagService = new DeleteExtendedQueryTagService(factory, new DicomTagParser());
         }
 

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/DeleteExtendedQueryTagServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/DeleteExtendedQueryTagServiceTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.ChangeFeed
         {
             _extendedQueryTagStore = Substitute.For<IExtendedQueryTagStore>();
             var factory = Substitute.For<IStoreFactory<IExtendedQueryTagStore>>();
-            factory.GetInstanceAsync().Returns(_extendedQueryTagStore);
+            factory.GetInstanceAsync(default).Returns(_extendedQueryTagStore);
             _extendedQueryTagService = new DeleteExtendedQueryTagService(factory, new DicomTagParser());
         }
 

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/GetExtendedQueryTagsServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/GetExtendedQueryTagsServiceTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.ExtendedQueryTag
             _extendedQueryTagStore = Substitute.For<IExtendedQueryTagStore>();
             _dicomTagParser = Substitute.For<IDicomTagParser>();
             var factory = Substitute.For<IStoreFactory<IExtendedQueryTagStore>>();
-            factory.GetInstance().Returns(_extendedQueryTagStore);
+            factory.GetInstanceAsync().Returns(_extendedQueryTagStore);
             _getExtendedQueryTagsService = new GetExtendedQueryTagsService(factory, _dicomTagParser);
         }
 

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/GetExtendedQueryTagsServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/GetExtendedQueryTagsServiceTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.ExtendedQueryTag
             _extendedQueryTagStore = Substitute.For<IExtendedQueryTagStore>();
             _dicomTagParser = Substitute.For<IDicomTagParser>();
             var factory = Substitute.For<IStoreFactory<IExtendedQueryTagStore>>();
-            factory.GetInstanceAsync().Returns(_extendedQueryTagStore);
+            factory.GetInstanceAsync(default).Returns(_extendedQueryTagStore);
             _getExtendedQueryTagsService = new GetExtendedQueryTagsService(factory, _dicomTagParser);
         }
 

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/QueryTagServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/QueryTagServiceTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.ExtendedQueryTag
             _extendedQueryTagStore = Substitute.For<IExtendedQueryTagStore>();
             _featureConfiguration = new FeatureConfiguration() { EnableExtendedQueryTags = true };
             _extendedQueryTagStoreFactory = Substitute.For<IStoreFactory<IExtendedQueryTagStore>>();
-            _extendedQueryTagStoreFactory.GetInstance().Returns(_extendedQueryTagStore);
+            _extendedQueryTagStoreFactory.GetInstanceAsync().Returns(_extendedQueryTagStore);
             _queryTagService = new QueryTagService(_extendedQueryTagStoreFactory, Options.Create(_featureConfiguration));
         }
 

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/QueryTagServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/QueryTagServiceTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.ExtendedQueryTag
             _extendedQueryTagStore = Substitute.For<IExtendedQueryTagStore>();
             _featureConfiguration = new FeatureConfiguration() { EnableExtendedQueryTags = true };
             _extendedQueryTagStoreFactory = Substitute.For<IStoreFactory<IExtendedQueryTagStore>>();
-            _extendedQueryTagStoreFactory.GetInstanceAsync().Returns(_extendedQueryTagStore);
+            _extendedQueryTagStoreFactory.GetInstanceAsync(CancellationToken.None).Returns(_extendedQueryTagStore);
             _queryTagService = new QueryTagService(_extendedQueryTagStoreFactory, Options.Create(_featureConfiguration));
         }
 

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/StoreOrchestratorTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/StoreOrchestratorTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Store
             _dicomInstanceEntry.GetDicomDatasetAsync(DefaultCancellationToken).Returns(_dicomDataset);
             _dicomInstanceEntry.GetStreamAsync(DefaultCancellationToken).Returns(_stream);
 
-            _indexDataStoreFactory.GetInstanceAsync().Returns(_indexDataStore);
+            _indexDataStoreFactory.GetInstanceAsync(DefaultCancellationToken).Returns(_indexDataStore);
 
             _indexDataStore.CreateInstanceIndexAsync(_dicomDataset, DefaultCancellationToken).Returns(DefaultVersion);
             _queryTagService.GetQueryTagsAsync(Arg.Any<CancellationToken>())

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/StoreOrchestratorTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/StoreOrchestratorTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Store
             _dicomInstanceEntry.GetDicomDatasetAsync(DefaultCancellationToken).Returns(_dicomDataset);
             _dicomInstanceEntry.GetStreamAsync(DefaultCancellationToken).Returns(_stream);
 
-            _indexDataStoreFactory.GetInstance().Returns(_indexDataStore);
+            _indexDataStoreFactory.GetInstanceAsync().Returns(_indexDataStore);
 
             _indexDataStore.CreateInstanceIndexAsync(_dicomDataset, DefaultCancellationToken).Returns(DefaultVersion);
             _queryTagService.GetQueryTagsAsync(Arg.Any<CancellationToken>())

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/AddExtendedQueryTagService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/AddExtendedQueryTagService.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
 {
     public class AddExtendedQueryTagService : IAddExtendedQueryTagService
     {
-        private readonly IExtendedQueryTagStore _extendedQueryTagStore;
+        private readonly IStoreFactory<IExtendedQueryTagStore> _extendedQueryTagStoreFactory;
         private readonly IExtendedQueryTagEntryValidator _extendedQueryTagEntryValidator;
         private readonly int _maxAllowedCount;
 
@@ -30,7 +30,7 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
             EnsureArg.IsNotNull(extendedQueryTagEntryValidator, nameof(extendedQueryTagEntryValidator));
             EnsureArg.IsNotNull(extendedQueryTagConfiguration?.Value, nameof(extendedQueryTagConfiguration));
 
-            _extendedQueryTagStore = extendedQueryTagStoreFactory.GetInstance();
+            _extendedQueryTagStoreFactory = extendedQueryTagStoreFactory;
             _extendedQueryTagEntryValidator = extendedQueryTagEntryValidator;
             _maxAllowedCount = extendedQueryTagConfiguration.Value.MaxAllowedCount;
         }
@@ -41,7 +41,8 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
 
             IEnumerable<AddExtendedQueryTagEntry> result = extendedQueryTags.Select(item => item.Normalize());
 
-            await _extendedQueryTagStore.AddExtendedQueryTagsAsync(result, _maxAllowedCount, cancellationToken);
+            IExtendedQueryTagStore extendedQueryTagStore = await _extendedQueryTagStoreFactory.GetInstanceAsync(cancellationToken);
+            await extendedQueryTagStore.AddExtendedQueryTagsAsync(result, _maxAllowedCount, cancellationToken);
 
             // Current solution is synchronous, no job uri is generated, so always return blank response.
             return new AddExtendedQueryTagResponse();

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/QueryTagService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/QueryTagService.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
 {
     public class QueryTagService : IQueryTagService
     {
-        private readonly IExtendedQueryTagStore _extendedQueryTagStore;
+        private readonly IStoreFactory<IExtendedQueryTagStore> _extendedQueryTagStoreFactory;
         private readonly bool _enableExtendedQueryTags;
         public static readonly IReadOnlyList<QueryTag> CoreQueryTags = GetCoreQueryTags();
         private List<QueryTag> _allQueryTags;
@@ -28,7 +28,7 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         {
             EnsureArg.IsNotNull(extendedQueryTagStoreFactory, nameof(extendedQueryTagStoreFactory));
             EnsureArg.IsNotNull(featureConfiguration?.Value, nameof(featureConfiguration));
-            _extendedQueryTagStore = extendedQueryTagStoreFactory.GetInstance();
+            _extendedQueryTagStoreFactory = extendedQueryTagStoreFactory;
             _enableExtendedQueryTags = featureConfiguration.Value.EnableExtendedQueryTags;
         }
 
@@ -40,7 +40,8 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
                 {
                     _allQueryTags = new List<QueryTag>(CoreQueryTags);
 
-                    IReadOnlyList<ExtendedQueryTagStoreEntry> extendedQueryTagEntries = await _extendedQueryTagStore.GetExtendedQueryTagsAsync(cancellationToken: cancellationToken);
+                    IExtendedQueryTagStore extendedQueryTagStore = await _extendedQueryTagStoreFactory.GetInstanceAsync(cancellationToken);
+                    IReadOnlyList<ExtendedQueryTagStoreEntry> extendedQueryTagEntries = await extendedQueryTagStore.GetExtendedQueryTagsAsync(cancellationToken: cancellationToken);
                     _allQueryTags.AddRange(extendedQueryTagEntries.Select(entry => new QueryTag(entry)));
 
                     _allQueryTagsCompletionSource.SetResult(true);

--- a/src/Microsoft.Health.Dicom.SqlServer.UnitTests/Features/Common/SqlDbConnectionFactoryTests.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer.UnitTests/Features/Common/SqlDbConnectionFactoryTests.cs
@@ -1,0 +1,38 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using Microsoft.Health.Dicom.SqlServer.Features.Common;
+using Microsoft.Health.SqlServer;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Dicom.SqlServer.UnitTests.Features.Common
+{
+    public class SqlDbConnectionFactoryTests
+    {
+        [Fact]
+        public void GivenNullArgument_WhenConstructing_ThenThrowArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SqlDbConnectionFactory(null));
+        }
+
+        [Fact]
+        public async Task GivenAnyInvocation_WhenGettingConnection_ThenReturnUnderlyingResult()
+        {
+            ISqlConnectionFactory sqlConnectionFactory = Substitute.For<ISqlConnectionFactory>();
+            var factory = new SqlDbConnectionFactory(sqlConnectionFactory);
+
+            var expected = new SqlConnection();
+            using var tokenSource = new CancellationTokenSource();
+            sqlConnectionFactory.GetSqlConnectionAsync(null, tokenSource.Token).Returns(expected);
+
+            Assert.Same(expected, await factory.GetConnectionAsync(tokenSource.Token));
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.SqlServer.UnitTests/Features/Schema/BackgroundSchemaVersionResolverTests.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer.UnitTests/Features/Schema/BackgroundSchemaVersionResolverTests.cs
@@ -1,0 +1,29 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Health.Dicom.SqlServer.Features.Schema;
+using Microsoft.Health.SqlServer.Features.Schema;
+using Xunit;
+
+namespace Microsoft.Health.Dicom.SqlServer.UnitTests.Features.Schema
+{
+    public class BackgroundSchemaVersionResolverTests
+    {
+        [Fact]
+        public void GivenNullArgument_WhenConstructing_ThenThrowArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new BackgroundSchemaVersionResolver(null));
+        }
+
+        [Fact]
+        public async Task GivenAnyInvocation_WhenGettingCurrentVersion_ThenReturnCurrentVersion()
+        {
+            var resolver = new BackgroundSchemaVersionResolver(new SchemaInformation(1, 3) { Current = 2 });
+            Assert.Equal(SchemaVersion.V2, await resolver.GetCurrentVersionAsync(default));
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.SqlServer.UnitTests/Features/Schema/SqlSchemaVersionResolverTests.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer.UnitTests/Features/Schema/SqlSchemaVersionResolverTests.cs
@@ -1,0 +1,117 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Data.Common;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using Microsoft.Health.Dicom.SqlServer.Features.Common;
+using Microsoft.Health.Dicom.SqlServer.Features.Schema;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Dicom.SqlServer.UnitTests.Features.Schema
+{
+    public class SqlSchemaVersionResolverTests
+    {
+        [Fact]
+        public void GivenNullArgument_WhenConstructing_ThenThrowArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SqlSchemaVersionResolver(null));
+        }
+
+        [Theory]
+        [InlineData(null, SchemaVersion.Unknown)]
+        [InlineData(1, SchemaVersion.V1)]
+        [InlineData(2, SchemaVersion.V2)]
+        [InlineData(123, (SchemaVersion)123)]
+        public async Task GivenSuccessfulQuery_WhenGettingCurrentVersion_ThenReturnCurrentVersion(int? version, SchemaVersion expected)
+        {
+            IDbConnectionFactory dbConnectionFactory = Substitute.For<IDbConnectionFactory>();
+            var resolver = new SqlSchemaVersionResolver(dbConnectionFactory);
+
+            using var tokenSource = new CancellationTokenSource();
+            await using (SqlCommandValidation.ForVersion(dbConnectionFactory, tokenSource.Token, version))
+            {
+                Assert.Equal(expected, await resolver.GetCurrentVersionAsync(tokenSource.Token));
+            }
+        }
+
+        [Fact]
+        public async Task GivenUnknownError_WhenGettingCurrentVersion_ThenThrowException()
+        {
+            IDbConnectionFactory dbConnectionFactory = Substitute.For<IDbConnectionFactory>();
+            var resolver = new SqlSchemaVersionResolver(dbConnectionFactory);
+
+            using var tokenSource = new CancellationTokenSource();
+            await using (SqlCommandValidation.ForException(dbConnectionFactory, tokenSource.Token, new IOException()))
+            {
+                await Assert.ThrowsAsync<IOException>(() => resolver.GetCurrentVersionAsync(tokenSource.Token));
+            }
+        }
+
+        private sealed class SqlCommandValidation : IAsyncDisposable
+        {
+            private readonly IDbConnectionFactory _dbConnectionFactory;
+            private readonly DbConnection _dbConnection;
+            private readonly DbCommand _dbCommand;
+            private readonly CancellationToken _cancellationToken;
+
+            private SqlCommandValidation(
+                IDbConnectionFactory dbConnectionFactory,
+                CancellationToken cancellationToken,
+                int? response = null,
+                Exception exception = null)
+            {
+                _dbConnectionFactory = EnsureArg.IsNotNull(dbConnectionFactory, nameof(dbConnectionFactory));
+                _dbConnection = Substitute.For<DbConnection>();
+                _dbCommand = Substitute.For<DbCommand>();
+                _cancellationToken = cancellationToken;
+
+                _dbConnectionFactory.GetConnectionAsync(cancellationToken).Returns(_dbConnection);
+                _dbConnection.CreateCommand().Returns(_dbCommand);
+
+                if (exception == null)
+                {
+                    _dbCommand.ExecuteScalarAsync(cancellationToken).Returns(Task.FromResult<object>(response));
+                }
+                else
+                {
+                    _dbCommand.ExecuteScalarAsync(cancellationToken).Returns(Task.FromException<object>(exception));
+                }
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                Assert.Equal("SELECT MAX(Version) FROM dbo.SchemaVersion WHERE Status = 'complete' OR Status = 'completed'", _dbCommand.CommandText);
+                await _dbConnectionFactory.Received(1).GetConnectionAsync(_cancellationToken);
+                await _dbConnection.Received(1).OpenAsync(_cancellationToken);
+                _dbConnection.Received(1).CreateCommand();
+                await _dbCommand.Received(1).ExecuteScalarAsync(_cancellationToken);
+
+                _dbCommand.Dispose();
+                _dbConnection.Dispose();
+            }
+
+            public static SqlCommandValidation ForVersion(
+                IDbConnectionFactory dbConnectionFactory,
+                CancellationToken cancellationToken,
+                int? response)
+            {
+                return new SqlCommandValidation(dbConnectionFactory, cancellationToken, response: response);
+            }
+
+            public static SqlCommandValidation ForException(
+                IDbConnectionFactory dbConnectionFactory,
+                CancellationToken cancellationToken,
+                Exception exception)
+            {
+                return new SqlCommandValidation(dbConnectionFactory, cancellationToken, exception: exception);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.SqlServer/DicomSqlServerResource.Designer.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/DicomSqlServerResource.Designer.cs
@@ -86,5 +86,23 @@ namespace Microsoft.Health.Dicom.SqlServer {
                 return ResourceManager.GetString("SchemaVersionNeedsToBeUpgraded", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot process SQL schema version {0}..
+        /// </summary>
+        internal static string SchemaVersionOutOfRange {
+            get {
+                return ResourceManager.GetString("SchemaVersionOutOfRange", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Current SQL schema version could not be resolved..
+        /// </summary>
+        internal static string UnknownSchemaVersion {
+            get {
+                return ResourceManager.GetString("UnknownSchemaVersion", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Microsoft.Health.Dicom.SqlServer/DicomSqlServerResource.resx
+++ b/src/Microsoft.Health.Dicom.SqlServer/DicomSqlServerResource.resx
@@ -128,4 +128,11 @@
   <data name="SchemaVersionNeedsToBeUpgraded" xml:space="preserve">
     <value>Cannot carry out the SQL datastore operation because the SQL schema needs to be upgraded.</value>
   </data>
+  <data name="SchemaVersionOutOfRange" xml:space="preserve">
+    <value>Cannot process SQL schema version {0}.</value>
+    <comment>{0} current version</comment>
+  </data>
+  <data name="UnknownSchemaVersion" xml:space="preserve">
+    <value>Current SQL schema version could not be resolved.</value>
+  </data>
 </root>

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Common/IDbConnectionFactory.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Common/IDbConnectionFactory.cs
@@ -1,0 +1,32 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Health.Dicom.SqlServer.Features.Common
+{
+    /// <summary>
+    /// Represents a factory for creating connections for a database, like SQL.
+    /// </summary>
+    // TODO: Move to shared componenets
+    public interface IDbConnectionFactory
+    {
+        /// <summary>
+        /// Asynchronously retrieves a connection.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.
+        /// </param>
+        /// <returns>
+        /// A task representing the asychronous operation. The value of its <see cref="Task{TResult}.Result"/>
+        /// property contains the <see cref="DbConnection"/>.
+        /// </returns>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        Task<DbConnection> GetConnectionAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Common/SqlDbConnectionFactory.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Common/SqlDbConnectionFactory.cs
@@ -1,0 +1,30 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using Microsoft.Health.SqlServer;
+
+namespace Microsoft.Health.Dicom.SqlServer.Features.Common
+{
+    public class SqlDbConnectionFactory : IDbConnectionFactory
+    {
+        private readonly ISqlConnectionFactory _sqlConnectionFactory;
+
+        public SqlDbConnectionFactory(ISqlConnectionFactory sqlConnectionFactory)
+        {
+            EnsureArg.IsNotNull(sqlConnectionFactory, nameof(sqlConnectionFactory));
+            _sqlConnectionFactory = sqlConnectionFactory;
+        }
+
+        public async Task<DbConnection> GetConnectionAsync(CancellationToken cancellationToken = default)
+        {
+            // Note: Async/Await required for polymorphism
+            return await _sqlConnectionFactory.GetSqlConnectionAsync(cancellationToken: cancellationToken);
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Common/SqlStoreFactory.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Common/SqlStoreFactory.cs
@@ -5,10 +5,12 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Health.Dicom.Core.Features.Common;
 using Microsoft.Health.Dicom.SqlServer.Feature.Common;
-using Microsoft.Health.SqlServer.Features.Schema;
+using Microsoft.Health.Dicom.SqlServer.Features.Schema;
 
 namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
 {
@@ -20,20 +22,20 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
     internal class SqlStoreFactory<TVersionedStore, TStore> : IStoreFactory<TStore>
         where TVersionedStore : IVersioned, TStore
     {
-        private readonly SchemaInformation _schemaInformation;
-        private readonly IEnumerable<TVersionedStore> _versionedStores;
+        private readonly ISchemaVersionResolver _schemaResolver;
+        private readonly Dictionary<SchemaVersion, TVersionedStore> _versionedStores;
 
-        public SqlStoreFactory(SchemaInformation schemaInformation, IEnumerable<TVersionedStore> versionedStores)
+        public SqlStoreFactory(ISchemaVersionResolver schemaResolver, IEnumerable<TVersionedStore> versionedStores)
         {
-            EnsureArg.IsNotNull(schemaInformation, nameof(schemaInformation));
+            EnsureArg.IsNotNull(schemaResolver, nameof(schemaResolver));
             EnsureArg.IsNotNull(versionedStores, nameof(versionedStores));
-            _schemaInformation = schemaInformation;
-            _versionedStores = versionedStores;
+            _schemaResolver = schemaResolver;
+            _versionedStores = versionedStores.ToDictionary(x => x.Version);
         }
 
-        public TStore GetInstance()
+        public async Task<TStore> GetInstanceAsync(CancellationToken cancellationToken = default)
         {
-            return _versionedStores.First(store => (int)store.Version == _schemaInformation.Current.Value);
+            return _versionedStores[await _schemaResolver.GetCurrentVersionAsync(cancellationToken)];
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Common/SqlStoreFactory.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Common/SqlStoreFactory.cs
@@ -35,7 +35,17 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
 
         public async Task<TStore> GetInstanceAsync(CancellationToken cancellationToken = default)
         {
-            return _versionedStores[await _schemaResolver.GetCurrentVersionAsync(cancellationToken)];
+            SchemaVersion currentVersion = await _schemaResolver.GetCurrentVersionAsync(cancellationToken);
+            if (!_versionedStores.TryGetValue(currentVersion, out TVersionedStore value))
+            {
+                string msg = currentVersion == SchemaVersion.Unknown
+                    ? DicomSqlServerResource.UnknownSchemaVersion
+                    : DicomSqlServerResource.SchemaVersionOutOfRange;
+
+                throw new KeyNotFoundException(msg);
+            }
+
+            return value;
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/BackgroundSchemaVersionResolver.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/BackgroundSchemaVersionResolver.cs
@@ -14,18 +14,18 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.Schema
     /// <summary>
     /// Represents an <see cref="ISchemaVersionResolver"/> that relies on a background service to resolve the version.
     /// </summary>
-    public class PassthroughSchemaVersionResolver : ISchemaVersionResolver
+    public class BackgroundSchemaVersionResolver : ISchemaVersionResolver
     {
         private readonly SchemaInformation _schemaInformation;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PassthroughSchemaVersionResolver"/> class.
+        /// Initializes a new instance of the <see cref="BackgroundSchemaVersionResolver"/> class.
         /// </summary>
         /// <param name="schemaInformation">The information updated in the background.</param>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="schemaInformation"/> is <see langword="null"/>.
         /// </exception>
-        public PassthroughSchemaVersionResolver(SchemaInformation schemaInformation)
+        public BackgroundSchemaVersionResolver(SchemaInformation schemaInformation)
         {
             EnsureArg.IsNotNull(schemaInformation, nameof(schemaInformation));
             _schemaInformation = schemaInformation;

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/ISchemaVersionResolver.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/ISchemaVersionResolver.cs
@@ -7,24 +7,24 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.Health.Dicom.Core.Features.Common
+namespace Microsoft.Health.Dicom.SqlServer.Features.Schema
 {
     /// <summary>
-    /// Represents a factory that returns store implementations.
+    /// An abstraction for retrieving the version of the underlying versioned store.
     /// </summary>
-    public interface IStoreFactory<T>
+    public interface ISchemaVersionResolver
     {
         /// <summary>
-        /// Asynchronously fetches the store.
+        /// Asynchronously fetches the current version from the store.
         /// </summary>
         /// <param name="cancellationToken">
         /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.
         /// </param>
         /// <returns>
         /// A task representing the asychronous operation. The value of its <see cref="Task{TResult}.Result"/>
-        /// property contains the desired store instance.
+        /// property contains the current version.
         /// </returns>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        Task<T> GetInstanceAsync(CancellationToken cancellationToken = default);
+        Task<SchemaVersion> GetCurrentVersionAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/PassthroughSchemaVersionResolver.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/PassthroughSchemaVersionResolver.cs
@@ -1,0 +1,40 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using Microsoft.Health.SqlServer.Features.Schema;
+
+namespace Microsoft.Health.Dicom.SqlServer.Features.Schema
+{
+    /// <summary>
+    /// Represents an <see cref="ISchemaVersionResolver"/> that relies on a background service to resolve the version.
+    /// </summary>
+    public class PassthroughSchemaVersionResolver : ISchemaVersionResolver
+    {
+        private readonly SchemaInformation _schemaInformation;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PassthroughSchemaVersionResolver"/> class.
+        /// </summary>
+        /// <param name="schemaInformation">The information updated in the background.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="schemaInformation"/> is <see langword="null"/>.
+        /// </exception>
+        public PassthroughSchemaVersionResolver(SchemaInformation schemaInformation)
+        {
+            EnsureArg.IsNotNull(schemaInformation, nameof(schemaInformation));
+            _schemaInformation = schemaInformation;
+        }
+
+        /// <inheritdoc/>
+        public Task<SchemaVersion> GetCurrentVersionAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult((SchemaVersion)_schemaInformation.Current.GetValueOrDefault());
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/SqlSchemaVersionResolver.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/SqlSchemaVersionResolver.cs
@@ -1,0 +1,74 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using Microsoft.Health.SqlServer;
+
+namespace Microsoft.Health.Dicom.SqlServer.Features.Schema
+{
+    /// <summary>
+    /// Represents an <see cref="ISchemaVersionResolver"/> that determines the version present in a SQL server.
+    /// </summary>
+    public class SqlSchemaVersionResolver : ISchemaVersionResolver
+    {
+        private readonly ISqlConnectionFactory _sqlConnectionFactory;
+        private readonly ILogger<SqlSchemaVersionResolver> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqlSchemaVersionResolver"/> class.
+        /// </summary>
+        /// <param name="sqlConnectionFactory">A factory for creating SQL connections.</param>
+        /// <param name="logger">A typed logger for diagnostic information.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="sqlConnectionFactory"/> or <paramref name="logger"/> is <see langword="null"/>.
+        /// </exception>
+        public SqlSchemaVersionResolver(ISqlConnectionFactory sqlConnectionFactory, ILogger<SqlSchemaVersionResolver> logger)
+        {
+            EnsureArg.IsNotNull(sqlConnectionFactory, nameof(sqlConnectionFactory));
+            EnsureArg.IsNotNull(logger, nameof(logger));
+
+            _sqlConnectionFactory = sqlConnectionFactory;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Asynchronously fetches the current version from the SQL database.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.
+        /// </param>
+        /// <returns>
+        /// A task representing the asychronous operation. The value of its <see cref="Task{TResult}.Result"/>
+        /// property contains the current version in the SQL database.
+        /// </returns>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        public async Task<SchemaVersion> GetCurrentVersionAsync(CancellationToken cancellationToken = default)
+        {
+            const string tableName = "dbo.SchemaVersion";
+
+            using SqlConnection connection = await _sqlConnectionFactory.GetSqlConnectionAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            using SqlCommand selectCommand = connection.CreateCommand();
+            selectCommand.CommandText = "SELECT MAX(Version) FROM " + tableName + " WHERE Status = 'complete' OR Status = 'completed'";
+
+            try
+            {
+                var version = await selectCommand.ExecuteScalarAsync(cancellationToken) as int?;
+                return (SchemaVersion)version.GetValueOrDefault();
+            }
+            catch (SqlException e) when (e.Message is "Invalid object name 'dbo.SchemaVersion'.")
+            {
+                _logger.LogWarning("The table {TableName} does not exists. It must be new database", tableName);
+                return SchemaVersion.Unknown;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.SqlServer/Registration/DicomServerBuilderSqlServerRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Registration/DicomServerBuilderSqlServerRegistrationExtensions.cs
@@ -52,6 +52,10 @@ namespace Microsoft.Extensions.DependencyInjection
                 .Singleton()
                 .AsSelf();
 
+            services.Add<PassthroughSchemaVersionResolver>()
+                .Singleton()
+                .AsImplementedInterfaces();
+
             services.Add<SqlIndexDataStoreV1>()
                 .Scoped()
                 .AsImplementedInterfaces();

--- a/src/Microsoft.Health.Dicom.SqlServer/Registration/DicomServerBuilderSqlServerRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Registration/DicomServerBuilderSqlServerRegistrationExtensions.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .Singleton()
                 .AsSelf();
 
-            services.Add<PassthroughSchemaVersionResolver>()
+            services.Add<BackgroundSchemaVersionResolver>()
                 .Singleton()
                 .AsImplementedInterfaces();
 

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/ChangeFeedTestsFixture.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/ChangeFeedTestsFixture.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Threading.Tasks;
+using Microsoft.Health.Dicom.Core.Features.Common;
 using Microsoft.Health.Dicom.Core.Features.Store;
 using Xunit;
 
@@ -18,7 +19,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             _sqlDataStoreTestsFixture = new SqlDataStoreTestsFixture();
         }
 
-        public IIndexDataStore DicomIndexDataStore => _sqlDataStoreTestsFixture.IndexDataStore;
+        public IStoreFactory<IIndexDataStore> DicomIndexDataStoreFactory => _sqlDataStoreTestsFixture.IndexDataStoreFactory;
 
         public IIndexDataStoreTestHelper DicomIndexDataStoreTestHelper => _sqlDataStoreTestsFixture.TestHelper;
 

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/DeleteServiceTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/DeleteServiceTests.cs
@@ -11,6 +11,7 @@ using Dicom;
 using Microsoft.Health.Dicom.Core.Exceptions;
 using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Core.Features.Model;
+using Microsoft.Health.Dicom.Core.Features.Store;
 using Microsoft.Health.Dicom.Tests.Common;
 using Microsoft.Health.Dicom.Tests.Common.Extensions;
 using Xunit;
@@ -52,7 +53,8 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
         {
             var newDataSet = CreateValidMetadataDataset();
 
-            var version = await _fixture.IndexDataStore.CreateInstanceIndexAsync(newDataSet);
+            IIndexDataStore indexDataStore = await _fixture.IndexDataStoreFactory.GetInstanceAsync();
+            var version = await indexDataStore.CreateInstanceIndexAsync(newDataSet);
             var versionedDicomInstanceIdentifier = newDataSet.ToVersionedInstanceIdentifier(version);
 
             if (persistMetadata)

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/DeleteServiceTestsFixture.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/DeleteServiceTestsFixture.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
 
         public RecyclableMemoryStreamManager RecyclableMemoryStreamManager { get; }
 
-        public IIndexDataStore IndexDataStore => _sqlDataStoreTestsFixture.IndexDataStore;
+        public IStoreFactory<IIndexDataStore> IndexDataStoreFactory => _sqlDataStoreTestsFixture.IndexDataStoreFactory;
 
         public IIndexDataStoreTestHelper IndexDataStoreTestHelper => _sqlDataStoreTestsFixture.TestHelper;
 

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlDataStoreTestsFixture.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlDataStoreTestsFixture.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
 
             SqlConnectionWrapperFactory = new SqlConnectionWrapperFactory(SqlTransactionHandler, new SqlCommandWrapperFactory(), sqlConnectionFactory);
 
-            var schemaResolver = new PassthroughSchemaVersionResolver(schemaInformation);
+            var schemaResolver = new BackgroundSchemaVersionResolver(schemaInformation);
 
             IndexDataStoreFactory = new SqlStoreFactory<ISqlIndexDataStore, IIndexDataStore>(
                 schemaResolver,

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlDataStoreTestsFixture.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlDataStoreTestsFixture.cs
@@ -79,8 +79,10 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
 
             SqlConnectionWrapperFactory = new SqlConnectionWrapperFactory(SqlTransactionHandler, new SqlCommandWrapperFactory(), sqlConnectionFactory);
 
+            var schemaResolver = new PassthroughSchemaVersionResolver(schemaInformation);
+
             IndexDataStoreFactory = new SqlStoreFactory<ISqlIndexDataStore, IIndexDataStore>(
-                schemaInformation,
+                schemaResolver,
                 new[]
                 {
                     new SqlIndexDataStoreV1(SqlConnectionWrapperFactory),
@@ -91,7 +93,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             InstanceStore = new SqlInstanceStore(SqlConnectionWrapperFactory);
 
             ExtendedQueryTagStoreFactory = new SqlStoreFactory<ISqlExtendedQueryTagStore, IExtendedQueryTagStore>(
-                schemaInformation,
+                schemaResolver,
                 new[]
                 {
                     new SqlExtendedQueryTagStoreV1(),
@@ -112,17 +114,13 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
 
         public SqlConnectionWrapperFactory SqlConnectionWrapperFactory { get; }
 
-        internal IStoreFactory<IIndexDataStore> IndexDataStoreFactory { get; }
+        public IStoreFactory<IIndexDataStore> IndexDataStoreFactory { get; }
 
         public string TestConnectionString { get; }
-
-        public IIndexDataStore IndexDataStore { get => IndexDataStoreFactory.GetInstance(); }
 
         public IInstanceStore InstanceStore { get; }
 
         public IStoreFactory<IExtendedQueryTagStore> ExtendedQueryTagStoreFactory { get; }
-
-        public IExtendedQueryTagStore ExtendedQueryTagStore { get => ExtendedQueryTagStoreFactory.GetInstance(); }
 
         public SqlIndexDataStoreTestHelper TestHelper { get; }
 


### PR DESCRIPTION
## Description
- Create a new abstraction called `ISchemaVersionResolver` which can be used to fetch the current `SchemaVersion` for the underlying data store.
    - Unlike `SchemaInformation`, `ISchemaVersionResolver` allows the caller to lazily retrieve this information when fulfilling an asynchronous request
    - Add new `PassthroughSchemaVersionResolver` which simply returns the version referenced by `SchemaInformation`
- Refactor `IStoreFactory<T>` to be asynchronous to allow for the store to be resolved lazily within the request pipeline using `ISchemaVersionResolver`
- Add `PassthroughSchemaVersionResolver` to service container automatically with other SQL services
- Encapsulate `ISqlConnectionFactory` in new `IDbConnectionFactory` to enable unit testing
- Update tests to use the new APIs

## Related issues
[#83001](https://microsofthealth.visualstudio.com/Health/_workitems/edit/83001)

## Testing
Tests pass locally and in CI
