### PR TITLE
Personal/smithasa/cifix

### DIFF
--- a/release/scripts/PowerShell/DicomServerRelease/Public/Set-DicomServerClientAppRoleAssignments.ps1
+++ b/release/scripts/PowerShell/DicomServerRelease/Public/Set-DicomServerClientAppRoleAssignments.ps1
@@ -42,6 +42,9 @@ function Set-DicomServerClientAppRoleAssignments {
     $aadClientServicePrincipal = Get-AzureAdServicePrincipal -Filter "appId eq '$AppId'"
     $ObjectId = $aadClientServicePrincipal.ObjectId
 
+    Write-Host "API app: $apiApplication"
+    Write-Host "Client app: $aadClientServicePrincipal"
+
     $existingRoleAssignments = Get-AzureADServiceAppRoleAssignment -ObjectId $apiApplication.ObjectId | Where-Object {$_.PrincipalId -eq $ObjectId} 
 
     $expectedRoles = New-Object System.Collections.ArrayList

--- a/release/scripts/PowerShell/DicomServerRelease/Public/Set-DicomServerClientAppRoleAssignments.ps1
+++ b/release/scripts/PowerShell/DicomServerRelease/Public/Set-DicomServerClientAppRoleAssignments.ps1
@@ -63,6 +63,9 @@ function Set-DicomServerClientAppRoleAssignments {
         }
     }
 
+    Write-Host "The following roles will be added: $rolesToAdd"
+    Write-Host "The following roles will be removed: $rolesToRemove"
+
     foreach ($role in $rolesToAdd) {
         # This is known to report failure in certain scenarios, but will actually apply the permissions
         try {

--- a/release/scripts/PowerShell/DicomServerRelease/Public/Set-DicomServerClientAppRoleAssignments.ps1
+++ b/release/scripts/PowerShell/DicomServerRelease/Public/Set-DicomServerClientAppRoleAssignments.ps1
@@ -45,7 +45,7 @@ function Set-DicomServerClientAppRoleAssignments {
     Write-Host "API app: $apiApplication"
     Write-Host "Client app: $aadClientServicePrincipal"
 
-    $existingRoleAssignments = Get-AzureADServiceAppRoleAssignment -ObjectId $apiApplication.ObjectId | Where-Object {$_.PrincipalId -eq $ObjectId} 
+    $existingRoleAssignments = Get-AzureADServiceAppRoleAssignedTo -ObjectId $ObjectId | Where-Object {$_.ResourceId -eq $apiApplication.ObjectId} 
 
     $expectedRoles = New-Object System.Collections.ArrayList
     $rolesToAdd = New-Object System.Collections.ArrayList
@@ -76,7 +76,7 @@ function Set-DicomServerClientAppRoleAssignments {
         }
         catch {
             #The role may have been assigned. Check:
-            $roleAssigned = Get-AzureADServiceAppRoleAssignment -ObjectId $apiApplication.ObjectId | Where-Object {$_.PrincipalId -eq $ObjectId -and $_.Id -eq $role}
+            $roleAssigned = Get-AzureADServiceAppRoleAssignedTo -ObjectId $ObjectId | Where-Object {$_.ResourceId -eq $apiApplication.ObjectId -and $_.Id -eq $role}
             if (!$roleAssigned) {
                 throw "Failure adding app role assignment for service principal."
             }


### PR DESCRIPTION
## Description
Regressions in AAD PS scripts around getting the assigned role permissions

Get-AzureADServiceAppRoleAssignment returns nothing for CI, even though the roles are already assigned.

so it is replaced by

Get-AzureADServiceAppRoleAssignedTo which returns the correct role assignments


## Related issues
[AB#83049](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/83049)

## Testing
https://microsofthealthoss.visualstudio.com/DicomServer/_build/results?buildId=12126&view=results
