### PR TITLE
Change the Test setup Identity admin consent to use supported graph API

### DIFF
--- a/release/scripts/PowerShell/DicomServerRelease/Private/Grant-ClientAppAdminConsent.ps1
+++ b/release/scripts/PowerShell/DicomServerRelease/Private/Grant-ClientAppAdminConsent.ps1
@@ -42,8 +42,7 @@ function Grant-ClientAppAdminConsent {
         client_id  = "1950a258-227b-4e31-a9cf-717495945fc2" # Microsoft Azure PowerShell
     }
     
-    $tokenResponse = Invoke-RestMethod (Get-
-    ) -Method POST -Body $body -ContentType 'application/x-www-form-urlencoded'
+    $tokenResponse = Invoke-RestMethod (Get-AzureADTokenEndpoint) -Method POST -Body $body -ContentType 'application/x-www-form-urlencoded'
     
     $header = @{
         'Authorization'          = 'Bearer ' + $tokenResponse.access_token

--- a/release/scripts/PowerShell/DicomServerRelease/Private/Grant-ClientAppAdminConsent.ps1
+++ b/release/scripts/PowerShell/DicomServerRelease/Private/Grant-ClientAppAdminConsent.ps1
@@ -27,7 +27,7 @@ function Grant-ClientAppAdminConsent {
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNull()]
-        [pscredential]$RoleId
+        [string]$RoleId
     )
 
     Set-StrictMode -Version Latest

--- a/release/scripts/PowerShell/DicomServerRelease/Private/Grant-ClientAppAdminConsent.ps1
+++ b/release/scripts/PowerShell/DicomServerRelease/Private/Grant-ClientAppAdminConsent.ps1
@@ -4,11 +4,11 @@ function Grant-ClientAppAdminConsent {
     Grants admin consent to a client app, so that users of the app are 
     not required to consent to the app calling the Dicom apli app on their behalf.
     .PARAMETER AppId
-    The client application service principal object ID.
+    The client application ID.
     .PARAMETER TenantAdminCredential
     Credentials for a tenant admin user
     .PARAMETER ApiAppId
-    Server Application service principal object ID
+    Server Application service ID
     #>
     param(
         [Parameter(Mandatory = $true)]

--- a/release/scripts/PowerShell/DicomServerRelease/Private/Grant-ClientAppAdminConsent.ps1
+++ b/release/scripts/PowerShell/DicomServerRelease/Private/Grant-ClientAppAdminConsent.ps1
@@ -15,15 +15,15 @@ function Grant-ClientAppAdminConsent {
     param(
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [string]$ClientAppServicePrincipalObjectId
+        [string]$ClientAppServicePrincipalObjectId,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNull()]
-        [pscredential]$TenantAdminCredential
+        [pscredential]$TenantAdminCredential,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [string]$ApiAppServicePrincipalObjectId
+        [string]$ApiAppServicePrincipalObjectId,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNull()]

--- a/release/scripts/PowerShell/DicomServerRelease/Private/Grant-ClientAppAdminConsent.ps1
+++ b/release/scripts/PowerShell/DicomServerRelease/Private/Grant-ClientAppAdminConsent.ps1
@@ -15,7 +15,7 @@ function Grant-ClientAppAdminConsent {
     param(
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [string]$ClientAppServicePrincipalObjectId,
+        [string]$ClientAppServicePrincipalObjectId
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNull()]
@@ -32,7 +32,7 @@ function Grant-ClientAppAdminConsent {
 
     Set-StrictMode -Version Latest
 
-    Write-Host "Granting admin consent for app: $ClientAppServicePrincipalObjectId, for role $RoleId"
+    Write-Host "Granting admin consent for app: $ClientAppServicePrincipalObjectId and role: $RoleId"
 
     # There currently is no documented or supported way of programatically
     # granting admin consent. So for now we resort to a hack. 
@@ -57,8 +57,8 @@ function Grant-ClientAppAdminConsent {
     $url = "https://graph.microsoft.com/v1.0/servicePrincipals/$ApiAppServicePrincipalObjectId/appRoleAssignedTo"
     
     $consentbody = @{
-        principalId = $ClientAppServicePrincipalObjectId,
-        resourceId  = $ApiAppServicePrincipalObjectId,
+        principalId = $ClientAppServicePrincipalObjectId
+        resourceId  = $ApiAppServicePrincipalObjectId
         appRoleId   = $RoleId
     }
 

--- a/release/scripts/PowerShell/DicomServerRelease/Private/Grant-ClientAppAdminConsent.ps1
+++ b/release/scripts/PowerShell/DicomServerRelease/Private/Grant-ClientAppAdminConsent.ps1
@@ -38,11 +38,12 @@ function Grant-ClientAppAdminConsent {
         grant_type = "password"
         username   = $TenantAdminCredential.GetNetworkCredential().UserName
         password   = $TenantAdminCredential.GetNetworkCredential().Password
-        resource   = "74658136-14ec-4630-ad9b-26e160ff0fc6" 
+        resource   = "a3efc889-f1b7-4532-9e01-91e32d1039f4" # MS graph service principle
         client_id  = "1950a258-227b-4e31-a9cf-717495945fc2" # Microsoft Azure PowerShell
     }
     
-    $tokenResponse = Invoke-RestMethod (Get-AzureADTokenEndpoint) -Method POST -Body $body -ContentType 'application/x-www-form-urlencoded'
+    $tokenResponse = Invoke-RestMethod (Get-
+    ) -Method POST -Body $body -ContentType 'application/x-www-form-urlencoded'
     
     $header = @{
         'Authorization'          = 'Bearer ' + $tokenResponse.access_token

--- a/release/scripts/PowerShell/DicomServerRelease/Private/Grant-ClientAppAdminConsent.ps1
+++ b/release/scripts/PowerShell/DicomServerRelease/Private/Grant-ClientAppAdminConsent.ps1
@@ -49,7 +49,7 @@ function Grant-ClientAppAdminConsent {
         'x-ms-client-request-id' = [guid]::NewGuid()
     }
 
-    $url = "https://graph.microsoft.com/v1.0/servicePrincipals/$appServicePrincipalObjectId/appRoleAssignedTo"
+    $url = "https://graph.microsoft.com/v1.0/servicePrincipals/$apiAppServicePrincipalObjectId/appRoleAssignedTo"
     
     $consentbody = @{
         principalId = $appServicePrincipalObjectId

--- a/release/scripts/PowerShell/DicomServerRelease/Public/Add-AadTestAuthEnvironment.ps1
+++ b/release/scripts/PowerShell/DicomServerRelease/Public/Add-AadTestAuthEnvironment.ps1
@@ -137,6 +137,9 @@ function Add-AadTestAuthEnvironment {
             $secretSecureString = ConvertTo-SecureString $newPassword.Value -AsPlainText -Force
         }
 
+        Write-Host "calling grant consent"
+        Grant-ClientAppAdminConsent -AppId $aadClientApplication.AppId -TenantAdminCredential $TenantAdminCredential -ApiAppId $application.AppId
+ 
         $environmentClientApplications += @{
             id          = $clientApp.Id
             displayName = $displayName
@@ -147,7 +150,7 @@ function Add-AadTestAuthEnvironment {
         Set-AzKeyVaultSecret -VaultName $KeyVaultName -Name "app--$($clientApp.Id)--id" -SecretValue $appIdSecureString | Out-Null
         Set-AzKeyVaultSecret -VaultName $KeyVaultName -Name "app--$($clientApp.Id)--secret" -SecretValue $secretSecureString | Out-Null
         
-        Set-DicomServerClientAppRoleAssignments -ApiAppId $application.AppId -AppId $aadClientApplication.AppId -AppRoles $clientApp.roles -TenantAdminCredential $TenantAdminCredential | Out-Null
+        Set-DicomServerClientAppRoleAssignments -ApiAppId $application.AppId -AppId $aadClientApplication.AppId -AppRoles $clientApp.roles | Out-Null
     }
 
     Write-Host "Set token and auth url in key vault"

--- a/release/scripts/PowerShell/DicomServerRelease/Public/Add-AadTestAuthEnvironment.ps1
+++ b/release/scripts/PowerShell/DicomServerRelease/Public/Add-AadTestAuthEnvironment.ps1
@@ -147,7 +147,7 @@ function Add-AadTestAuthEnvironment {
         Set-AzKeyVaultSecret -VaultName $KeyVaultName -Name "app--$($clientApp.Id)--id" -SecretValue $appIdSecureString | Out-Null
         Set-AzKeyVaultSecret -VaultName $KeyVaultName -Name "app--$($clientApp.Id)--secret" -SecretValue $secretSecureString | Out-Null
         
-        Set-DicomServerClientAppRoleAssignments -ApiAppId $application.AppId -AppId $aadClientApplication.AppId -AppRoles $clientApp.roles | Out-Null
+        Set-DicomServerClientAppRoleAssignments -ApiAppId $application.AppId -AppId $aadClientApplication.AppId -AppRoles $clientApp.roles -TenantAdminCredential $TenantAdminCredential | Out-Null
     }
 
     Write-Host "Set token and auth url in key vault"

--- a/release/scripts/PowerShell/DicomServerRelease/Public/Add-AadTestAuthEnvironment.ps1
+++ b/release/scripts/PowerShell/DicomServerRelease/Public/Add-AadTestAuthEnvironment.ps1
@@ -137,9 +137,6 @@ function Add-AadTestAuthEnvironment {
             $secretSecureString = ConvertTo-SecureString $newPassword.Value -AsPlainText -Force
         }
 
-        # Workaround to bug#83049
-        #Grant-ClientAppAdminConsent -AppId $aadClientApplication.AppId -TenantAdminCredential $TenantAdminCredential
-
         $environmentClientApplications += @{
             id          = $clientApp.Id
             displayName = $displayName

--- a/release/scripts/PowerShell/DicomServerRelease/Public/Set-DicomServerClientAppRoleAssignments.ps1
+++ b/release/scripts/PowerShell/DicomServerRelease/Public/Set-DicomServerClientAppRoleAssignments.ps1
@@ -12,6 +12,8 @@ function Set-DicomServerClientAppRoleAssignments {
     The objectId of the API application that has roles that need to be assigned
     .PARAMETER AppRoles
     The collection of roles from the testauthenvironment.json for the client application
+    .PARAMETER TenantAdminCredential
+    The tenant admin credential
     #>
     param(
         [Parameter(Mandatory = $true )]
@@ -24,7 +26,11 @@ function Set-DicomServerClientAppRoleAssignments {
 
         [Parameter(Mandatory = $true )]
         [AllowEmptyCollection()]
-        [string[]]$AppRoles
+        [string[]]$AppRoles,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [pscredential]$TenantAdminCredential
     )
 
     Set-StrictMode -Version Latest
@@ -81,10 +87,10 @@ function Set-DicomServerClientAppRoleAssignments {
                 throw "Failure adding app role assignment for service principal."
             }
         }
+        Write-Host "calling consent"
         Grant-ClientAppAdminConsent -ClientAppServicePrincipalObjectId $ObjectId -TenantAdminCredential $TenantAdminCredential -ApiAppServicePrincipalObjectId $apiApplication.ObjectId -RoleId $role
-
     }
-
+    
     foreach ($role in $rolesToRemove) {
         Remove-AzureADServiceAppRoleAssignment -ObjectId $ObjectId -AppRoleAssignmentId ($existingRoleAssignments | Where-Object { $_.Id -eq $role }).ObjectId | Out-Null
     }

--- a/release/scripts/PowerShell/DicomServerRelease/Public/Set-DicomServerClientAppRoleAssignments.ps1
+++ b/release/scripts/PowerShell/DicomServerRelease/Public/Set-DicomServerClientAppRoleAssignments.ps1
@@ -12,8 +12,6 @@ function Set-DicomServerClientAppRoleAssignments {
     The objectId of the API application that has roles that need to be assigned
     .PARAMETER AppRoles
     The collection of roles from the testauthenvironment.json for the client application
-    .PARAMETER TenantAdminCredential
-    The tenant admin credential
     #>
     param(
         [Parameter(Mandatory = $true )]
@@ -26,11 +24,7 @@ function Set-DicomServerClientAppRoleAssignments {
 
         [Parameter(Mandatory = $true )]
         [AllowEmptyCollection()]
-        [string[]]$AppRoles,
-
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNull()]
-        [pscredential]$TenantAdminCredential
+        [string[]]$AppRoles
     )
 
     Set-StrictMode -Version Latest
@@ -87,10 +81,8 @@ function Set-DicomServerClientAppRoleAssignments {
                 throw "Failure adding app role assignment for service principal."
             }
         }
-        Write-Host "calling consent"
-        Grant-ClientAppAdminConsent -ClientAppServicePrincipalObjectId $ObjectId -TenantAdminCredential $TenantAdminCredential -ApiAppServicePrincipalObjectId $apiApplication.ObjectId -RoleId $role
     }
-    
+
     foreach ($role in $rolesToRemove) {
         Remove-AzureADServiceAppRoleAssignment -ObjectId $ObjectId -AppRoleAssignmentId ($existingRoleAssignments | Where-Object { $_.Id -eq $role }).ObjectId | Out-Null
     }

--- a/release/scripts/PowerShell/DicomServerRelease/Public/Set-DicomServerClientAppRoleAssignments.ps1
+++ b/release/scripts/PowerShell/DicomServerRelease/Public/Set-DicomServerClientAppRoleAssignments.ps1
@@ -81,6 +81,8 @@ function Set-DicomServerClientAppRoleAssignments {
                 throw "Failure adding app role assignment for service principal."
             }
         }
+        Grant-ClientAppAdminConsent -ClientAppServicePrincipalObjectId $ObjectId -TenantAdminCredential $TenantAdminCredential -ApiAppServicePrincipalObjectId $apiApplication.ObjectId -RoleId $role
+
     }
 
     foreach ($role in $rolesToRemove) {

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/AuthorizationTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/AuthorizationTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             _fixture = fixture;
         }
 
-        [Fact(Skip = "Setup AAD admin consent issue, Bug 83049: DICOM OSS CI is broken")]
+        [Fact]
         public async Task GivenPostDicomRequest_WithAReadOnlyToken_ReturnUnauthorized()
         {
             if (AuthenticationSettings.SecurityEnabled)


### PR DESCRIPTION
## Description
During the test AAD setup for PR and CI, we use a internal API to grant admin consent.
This is broken and returns 404.
Moving the implementation to consent per role to a supported graph API, as recommended here
#12137 (comment)

## Related issues
[AB#83049](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/83049)

## Testing
E2E Auth test enabled and passing