### PR TITLE
Add consent call back and enable the Authorization test

### DIFF
--- a/release/scripts/PowerShell/DicomServerRelease/Public/Add-AadTestAuthEnvironment.ps1
+++ b/release/scripts/PowerShell/DicomServerRelease/Public/Add-AadTestAuthEnvironment.ps1
@@ -137,8 +137,7 @@ function Add-AadTestAuthEnvironment {
             $secretSecureString = ConvertTo-SecureString $newPassword.Value -AsPlainText -Force
         }
 
-        # Workaround to bug#83049
-        #Grant-ClientAppAdminConsent -AppId $aadClientApplication.AppId -TenantAdminCredential $TenantAdminCredential
+        Grant-ClientAppAdminConsent -AppId $aadClientApplication.AppId -TenantAdminCredential $TenantAdminCredential
 
         $environmentClientApplications += @{
             id          = $clientApp.Id

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/AuthorizationTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/AuthorizationTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             _fixture = fixture;
         }
 
-        [Fact(Skip = "Setup AAD admin consent issue, Bug 83049: DICOM OSS CI is broken")]
+        [Fact]
         public async Task GivenPostDicomRequest_WithAReadOnlyToken_ReturnUnauthorized()
         {
             if (AuthenticationSettings.SecurityEnabled)


### PR DESCRIPTION
## Description
Revert commenting of grant admin consent, since the AAD team has enable the API back again

## Related issues
[AB#83049](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/83049)

## Testing
E2E should pass
