### PR TITLE
Add produces and consumes attributes to API routes

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Controllers/ChangeFeedController.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/ChangeFeedController.cs
@@ -16,6 +16,7 @@ using Microsoft.Health.Dicom.Api.Features.Routing;
 using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Core.Features.Audit;
 using Microsoft.Health.Dicom.Core.Features.ChangeFeed;
+using Microsoft.Health.Dicom.Core.Web;
 using DicomAudit = Microsoft.Health.Dicom.Api.Features.Audit;
 
 namespace Microsoft.Health.Dicom.Api.Controllers
@@ -38,6 +39,7 @@ namespace Microsoft.Health.Dicom.Api.Controllers
         }
 
         [HttpGet]
+        [Produces(KnownContentTypes.ApplicationJson)]
         [ProducesResponseType(typeof(IEnumerable<ChangeFeedEntry>), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.BadRequest)]
@@ -58,6 +60,7 @@ namespace Microsoft.Health.Dicom.Api.Controllers
         }
 
         [HttpGet]
+        [Produces(KnownContentTypes.ApplicationJson)]
         [ProducesResponseType(typeof(ChangeFeedEntry), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.Unauthorized)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.BadRequest)]

--- a/src/Microsoft.Health.Dicom.Api/Controllers/ExtendedQueryTagController.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/ExtendedQueryTagController.cs
@@ -21,6 +21,7 @@ using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Core.Features.Audit;
 using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 using Microsoft.Health.Dicom.Core.Messages.ExtendedQueryTag;
+using Microsoft.Health.Dicom.Core.Web;
 using DicomAudit = Microsoft.Health.Dicom.Api.Features.Audit;
 
 namespace Microsoft.Health.Dicom.Api.Controllers
@@ -45,6 +46,8 @@ namespace Microsoft.Health.Dicom.Api.Controllers
         }
 
         [BodyModelStateValidator]
+        [Produces(KnownContentTypes.ApplicationJson)]
+        [Consumes(KnownContentTypes.ApplicationJson)]
         [ProducesResponseType(typeof(AddExtendedQueryTagResponse), (int)HttpStatusCode.Accepted)]
         [HttpPost]
         [VersionedRoute(KnownRoutes.ExtendedQueryTagRoute)]
@@ -61,6 +64,7 @@ namespace Microsoft.Health.Dicom.Api.Controllers
                (int)HttpStatusCode.Accepted, response);
         }
 
+        [Produces(KnownContentTypes.ApplicationJson)]
         [ProducesResponseType(typeof(DeleteExtendedQueryTagResponse), (int)HttpStatusCode.NoContent)]
         [HttpDelete]
         [VersionedRoute(KnownRoutes.DeleteExtendedQueryTagRoute)]
@@ -83,6 +87,7 @@ namespace Microsoft.Health.Dicom.Api.Controllers
         /// Returns Bad Request if given path can't be parsed. Returns Not Found if given path doesn't map to a stored
         /// extended query tag or if no extended query tags are stored. Returns OK with a JSON body of all tags in other cases.
         /// </returns>
+        [Produces(KnownContentTypes.ApplicationJson)]
         [ProducesResponseType(typeof(IEnumerable<GetExtendedQueryTagEntry>), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
         [HttpGet]
@@ -108,6 +113,7 @@ namespace Microsoft.Health.Dicom.Api.Controllers
         /// Returns Bad Request if given path can't be parsed. Returns Not Found if given path doesn't map to a stored
         /// extended query tag. Returns OK with a JSON body of requested tag in other cases.
         /// </returns>
+        [Produces(KnownContentTypes.ApplicationJson)]
         [ProducesResponseType(typeof(GetExtendedQueryTagEntry), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]

--- a/src/Microsoft.Health.Dicom.Api/Controllers/QueryController.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/QueryController.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Health.Dicom.Api.Controllers
 
         [HttpGet]
         [AcceptContentFilter(new[] { KnownContentTypes.ApplicationDicomJson }, allowSingle: true, allowMultiple: false)]
+        [Produces(KnownContentTypes.ApplicationDicomJson)]
         [ProducesResponseType(typeof(IEnumerable<DicomDataset>), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.NoContent)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.BadRequest)]
@@ -63,6 +64,7 @@ namespace Microsoft.Health.Dicom.Api.Controllers
 
         [HttpGet]
         [AcceptContentFilter(new[] { KnownContentTypes.ApplicationDicomJson }, allowSingle: true, allowMultiple: false)]
+        [Produces(KnownContentTypes.ApplicationDicomJson)]
         [ProducesResponseType(typeof(IEnumerable<DicomDataset>), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.NoContent)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.BadRequest)]
@@ -83,6 +85,7 @@ namespace Microsoft.Health.Dicom.Api.Controllers
 
         [HttpGet]
         [AcceptContentFilter(new[] { KnownContentTypes.ApplicationDicomJson }, allowSingle: true, allowMultiple: false)]
+        [Produces(KnownContentTypes.ApplicationDicomJson)]
         [ProducesResponseType(typeof(IEnumerable<DicomDataset>), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.NoContent)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.BadRequest)]
@@ -104,6 +107,7 @@ namespace Microsoft.Health.Dicom.Api.Controllers
 
         [HttpGet]
         [AcceptContentFilter(new[] { KnownContentTypes.ApplicationDicomJson }, allowSingle: true, allowMultiple: false)]
+        [Produces(KnownContentTypes.ApplicationDicomJson)]
         [ProducesResponseType(typeof(IEnumerable<DicomDataset>), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.NoContent)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.BadRequest)]
@@ -124,6 +128,7 @@ namespace Microsoft.Health.Dicom.Api.Controllers
 
         [HttpGet]
         [AcceptContentFilter(new[] { KnownContentTypes.ApplicationDicomJson }, allowSingle: true, allowMultiple: false)]
+        [Produces(KnownContentTypes.ApplicationDicomJson)]
         [ProducesResponseType(typeof(IEnumerable<DicomDataset>), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.NoContent)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.BadRequest)]
@@ -145,6 +150,7 @@ namespace Microsoft.Health.Dicom.Api.Controllers
 
         [HttpGet]
         [AcceptContentFilter(new[] { KnownContentTypes.ApplicationDicomJson }, allowSingle: true, allowMultiple: false)]
+        [Produces(KnownContentTypes.ApplicationDicomJson)]
         [ProducesResponseType(typeof(IEnumerable<DicomDataset>), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.NoContent)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.BadRequest)]

--- a/src/Microsoft.Health.Dicom.Api/Controllers/RetrieveController.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/RetrieveController.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Health.Dicom.Api.Controllers
             _logger = logger;
         }
 
+        //Todo: need to add produces for the multipart ones from here: https://github.com/microsoft/dicom-server/blob/main/docs/resources/conformance-statement.md#retrieve-instances-within-study-or-series
         [ProducesResponseType(typeof(IEnumerable<Stream>), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
@@ -65,6 +66,7 @@ namespace Microsoft.Health.Dicom.Api.Controllers
         }
 
         [AcceptContentFilter(new[] { KnownContentTypes.ApplicationDicomJson }, allowSingle: true, allowMultiple: false)]
+        [Produces(KnownContentTypes.ApplicationDicomJson)]
         [ProducesResponseType(typeof(IEnumerable<DicomDataset>), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
@@ -83,6 +85,7 @@ namespace Microsoft.Health.Dicom.Api.Controllers
             return CreateResult(response);
         }
 
+        //todo: need to add produces for multipart ones from here https://github.com/microsoft/dicom-server/blob/main/docs/resources/conformance-statement.md#retrieve-instances-within-study-or-series
         [ProducesResponseType(typeof(IEnumerable<Stream>), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
@@ -104,6 +107,7 @@ namespace Microsoft.Health.Dicom.Api.Controllers
         }
 
         [AcceptContentFilter(new[] { KnownContentTypes.ApplicationDicomJson }, allowSingle: true, allowMultiple: false)]
+        [Produces(KnownContentTypes.ApplicationDicomJson)]
         [ProducesResponseType(typeof(IEnumerable<Stream>), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
@@ -123,6 +127,7 @@ namespace Microsoft.Health.Dicom.Api.Controllers
             return CreateResult(response);
         }
 
+        //todo: need to add produces for multipart from here https://github.com/microsoft/dicom-server/blob/main/docs/resources/conformance-statement.md#retrieve-an-instance
         [ProducesResponseType(typeof(IEnumerable<Stream>), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
@@ -148,6 +153,7 @@ namespace Microsoft.Health.Dicom.Api.Controllers
         }
 
         [AcceptContentFilter(new[] { KnownContentTypes.ApplicationDicomJson }, allowSingle: true, allowMultiple: false)]
+        [Produces(KnownContentTypes.ApplicationDicomJson)]
         [ProducesResponseType(typeof(IEnumerable<Stream>), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
@@ -171,6 +177,7 @@ namespace Microsoft.Health.Dicom.Api.Controllers
             return CreateResult(response);
         }
 
+        //todo: need to add produces for multipart from here https://github.com/microsoft/dicom-server/blob/main/docs/resources/conformance-statement.md#retrieve-frames
         [ProducesResponseType(typeof(Stream), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(IEnumerable<Stream>), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.BadRequest)]

--- a/src/Microsoft.Health.Dicom.Api/Controllers/StoreController.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/StoreController.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Health.Dicom.Api.Controllers
         }
 
         [AcceptContentFilter(new[] { KnownContentTypes.ApplicationDicomJson }, allowSingle: true, allowMultiple: false)]
+        [Produces(KnownContentTypes.ApplicationDicomJson)]
+        [Consumes(KnownContentTypes.ApplicationDicom)] //TODO: Need to add multipart/related; type="application/dicom"
         [ProducesResponseType(typeof(DicomDataset), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(DicomDataset), (int)HttpStatusCode.Accepted)]
         [ProducesResponseType((int)HttpStatusCode.NoContent)]

--- a/src/Microsoft.Health.Dicom.Api/Controllers/StoreController.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/StoreController.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Health.Dicom.Api.Controllers
 
         [AcceptContentFilter(new[] { KnownContentTypes.ApplicationDicomJson }, allowSingle: true, allowMultiple: false)]
         [Produces(KnownContentTypes.ApplicationDicomJson)]
-        [Consumes(KnownContentTypes.ApplicationDicom)] //TODO: Need to add multipart/related; type="application/dicom"
+        [Consumes(KnownContentTypes.ApplicationDicom, new[] { KnownContentTypes.MultipartRelated })] //TODO: Need to add multipart/related; type="application/dicom"
         [ProducesResponseType(typeof(DicomDataset), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(DicomDataset), (int)HttpStatusCode.Accepted)]
         [ProducesResponseType((int)HttpStatusCode.NoContent)]


### PR DESCRIPTION
## Description
Add produces and consumes attributes to the existing routes.

Need input on how to add these for multipart accept and content type.

## Related issues
[AB#83343](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/83343)

## Testing
Describe how this change was tested.
