### PR TITLE
Create Extended Query Tag Errors Endpoint

### DIFF
--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Controllers/ExtendedQueryTagControllerTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Controllers/ExtendedQueryTagControllerTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Health.Dicom.Api.UnitTests.Extensions
         public async Task GivenTagPath_WhenCallingApi_ThenShouldReturnOk()
         {
             IMediator mediator = Substitute.For<IMediator>();
-            string path = "11330001";
+            const string path = "11330001";
 
             var controller = new ExtendedQueryTagController(
                 mediator,
@@ -93,8 +93,8 @@ namespace Microsoft.Health.Dicom.Api.UnitTests.Extensions
             mediator
                 .Send(
                     Arg.Is<GetExtendedQueryTagErrorsRequest>(x => x.Path == path),
-                        Arg.Is(controller.HttpContext.RequestAborted))
-                    .Returns(expected);
+                    Arg.Is(controller.HttpContext.RequestAborted))
+                .Returns(expected);
 
             IActionResult response = await controller.GetTagErrorAsync(path);
             Assert.IsType<ObjectResult>(response);

--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Controllers/ExtendedQueryTagControllerTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Controllers/ExtendedQueryTagControllerTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Health.Dicom.Api.UnitTests.Extensions
                 NullLogger<ExtendedQueryTagController>.Instance);
 
             await Assert.ThrowsAsync<ExtendedQueryTagFeatureDisabledException>(() => controller.GetTagAsync(DicomTag.PageNumberVector.GetPath()));
-            await Assert.ThrowsAsync<ExtendedQueryTagFeatureDisabledException>(() => controller.GetTagErrorAsync(DicomTag.PageNumberVector.GetPath()));
+            await Assert.ThrowsAsync<ExtendedQueryTagFeatureDisabledException>(() => controller.GetTagErrorsAsync(DicomTag.PageNumberVector.GetPath()));
             await Assert.ThrowsAsync<ExtendedQueryTagFeatureDisabledException>(() => controller.GetAllTagsAsync());
             await Assert.ThrowsAsync<ExtendedQueryTagFeatureDisabledException>(() => controller.PostAsync(Array.Empty<AddExtendedQueryTagEntry>()));
             await Assert.ThrowsAsync<ExtendedQueryTagFeatureDisabledException>(() => controller.DeleteAsync(DicomTag.PageNumberVector.GetPath()));
@@ -96,7 +96,7 @@ namespace Microsoft.Health.Dicom.Api.UnitTests.Extensions
                     Arg.Is(controller.HttpContext.RequestAborted))
                 .Returns(expected);
 
-            IActionResult response = await controller.GetTagErrorAsync(path);
+            IActionResult response = await controller.GetTagErrorsAsync(path);
             Assert.IsType<ObjectResult>(response);
 
             var actual = response as ObjectResult;

--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Controllers/ExtendedQueryTagControllerTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Controllers/ExtendedQueryTagControllerTests.cs
@@ -64,9 +64,48 @@ namespace Microsoft.Health.Dicom.Api.UnitTests.Extensions
                 NullLogger<ExtendedQueryTagController>.Instance);
 
             await Assert.ThrowsAsync<ExtendedQueryTagFeatureDisabledException>(() => controller.GetTagAsync(DicomTag.PageNumberVector.GetPath()));
+            await Assert.ThrowsAsync<ExtendedQueryTagFeatureDisabledException>(() => controller.GetTagErrorAsync(DicomTag.PageNumberVector.GetPath()));
             await Assert.ThrowsAsync<ExtendedQueryTagFeatureDisabledException>(() => controller.GetAllTagsAsync());
             await Assert.ThrowsAsync<ExtendedQueryTagFeatureDisabledException>(() => controller.PostAsync(Array.Empty<AddExtendedQueryTagEntry>()));
             await Assert.ThrowsAsync<ExtendedQueryTagFeatureDisabledException>(() => controller.DeleteAsync(DicomTag.PageNumberVector.GetPath()));
+        }
+
+        [Fact]
+        public async Task GivenTagPath_WhenCallingApi_ThenShouldReturnOk()
+        {
+            IMediator mediator = Substitute.For<IMediator>();
+            string path = "11330001";
+
+            var controller = new ExtendedQueryTagController(
+                mediator,
+                Options.Create(new FeatureConfiguration { EnableExtendedQueryTags = true }),
+                NullLogger<ExtendedQueryTagController>.Instance);
+            controller.ControllerContext.HttpContext = new DefaultHttpContext();
+
+            var expected = new GetExtendedQueryTagErrorsResponse(
+                new List<ExtendedQueryTagError>
+                {
+                    new ExtendedQueryTagError(DateTime.UtcNow, Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "Error 1"),
+                    new ExtendedQueryTagError(DateTime.UtcNow, Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "Error 2"),
+                    new ExtendedQueryTagError(DateTime.UtcNow, Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "Error 3"),
+                });
+
+            mediator
+                .Send(
+                    Arg.Is<GetExtendedQueryTagErrorsRequest>(x => x.Path == path),
+                        Arg.Is(controller.HttpContext.RequestAborted))
+                    .Returns(expected);
+
+            IActionResult response = await controller.GetTagErrorAsync(path);
+            Assert.IsType<ObjectResult>(response);
+
+            var actual = response as ObjectResult;
+            Assert.Equal((int)HttpStatusCode.OK, actual.StatusCode);
+            Assert.Same(expected, actual.Value);
+
+            await mediator.Received(1).Send(
+                Arg.Is<GetExtendedQueryTagErrorsRequest>(x => x.Path == path),
+                Arg.Is(controller.HttpContext.RequestAborted));
         }
 
         [Fact]

--- a/src/Microsoft.Health.Dicom.Api/Controllers/ExtendedQueryTagController.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/ExtendedQueryTagController.cs
@@ -138,6 +138,32 @@ namespace Microsoft.Health.Dicom.Api.Controllers
                 (int)HttpStatusCode.OK, response.ExtendedQueryTag);
         }
 
+        /// <summary>
+        /// Handles requests to get extended query tag errors.
+        /// </summary>
+        /// <param name="tagPath">Path for requested extended query tag.</param>
+        /// <returns>
+        /// Returns Bad Request if given path can't be parsed. Returns Not Found if given path doesn't map to a stored
+        /// error. Returns OK with a JSON body of requested tag error in other cases.
+        /// </returns>
+        [HttpGet]
+        [Produces(KnownContentTypes.ApplicationJson)]
+        [ProducesResponseType(typeof(GetExtendedQueryTagErrorsResponse), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
+        [VersionedRoute(KnownRoutes.GetExtendedQueryTagErrorsRoute)]
+        [Route(KnownRoutes.GetExtendedQueryTagErrorsRoute)]
+        [AuditEventType(AuditEventSubType.GetExtendedQueryTagErrors)]
+        public async Task<IActionResult> GetTagErrorAsync(string tagPath)
+        {
+            _logger.LogInformation("DICOM Web Get Extended Query Tag Errors request received for extended query tag: {tagPath}", tagPath);
+
+            EnsureFeatureIsEnabled();
+            GetExtendedQueryTagErrorsResponse response = await _mediator.GetExtendedQueryTagErrorsAsync(tagPath, HttpContext.RequestAborted);
+
+            return StatusCode((int)HttpStatusCode.OK, response);
+        }
+
         private void EnsureFeatureIsEnabled()
         {
             if (!_featureEnabled)

--- a/src/Microsoft.Health.Dicom.Api/Controllers/ExtendedQueryTagController.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/ExtendedQueryTagController.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Health.Dicom.Api.Controllers
         [VersionedRoute(KnownRoutes.GetExtendedQueryTagErrorsRoute)]
         [Route(KnownRoutes.GetExtendedQueryTagErrorsRoute)]
         [AuditEventType(AuditEventSubType.GetExtendedQueryTagErrors)]
-        public async Task<IActionResult> GetTagErrorAsync(string tagPath)
+        public async Task<IActionResult> GetTagErrorsAsync(string tagPath)
         {
             _logger.LogInformation("DICOM Web Get Extended Query Tag Errors request received for extended query tag: {tagPath}", tagPath);
 

--- a/src/Microsoft.Health.Dicom.Api/Features/Routing/KnownRoutes.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Routing/KnownRoutes.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Health.Dicom.Api.Features.Routing
         private const string SeriesRouteSegment = "series";
         private const string InstancesRouteSegment = "instances";
         private const string MetadataSegment = "metadata";
+        private const string ErrorsSegment = "errors";
         private const string ExtendedQueryTagsRouteSegment = "extendedquerytags";
         private const string OperationsSegment = "operations";
 
@@ -45,6 +46,7 @@ namespace Microsoft.Health.Dicom.Api.Features.Routing
         public const string ExtendedQueryTagRoute = ExtendedQueryTagsRouteSegment;
         public const string DeleteExtendedQueryTagRoute = ExtendedQueryTagsRouteSegment + "/" + ExtendedQueryTagPathRouteSegment;
         public const string GetExtendedQueryTagRoute = ExtendedQueryTagsRouteSegment + "/" + ExtendedQueryTagPathRouteSegment;
+        public const string GetExtendedQueryTagErrorsRoute = GetExtendedQueryTagRoute + "/" + ErrorsSegment;
 
         public const string HealthCheck = "/health/check";
 

--- a/src/Microsoft.Health.Dicom.Core/Extensions/DicomMediatorExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Extensions/DicomMediatorExtensions.cs
@@ -169,6 +169,13 @@ namespace Microsoft.Health.Dicom.Core.Extensions
             return mediator.Send(new GetExtendedQueryTagRequest(extendedQueryTagPath), cancellationToken);
         }
 
+        public static Task<GetExtendedQueryTagErrorsResponse> GetExtendedQueryTagErrorsAsync(
+            this IMediator mediator, string extendedQueryTagPath, CancellationToken cancellationToken)
+        {
+            EnsureArg.IsNotNull(mediator, nameof(mediator));
+            return mediator.Send(new GetExtendedQueryTagErrorsRequest(extendedQueryTagPath), cancellationToken);
+        }
+
         public static Task<OperationStatusResponse> GetOperationStatusAsync(
            this IMediator mediator,
            string id,

--- a/src/Microsoft.Health.Dicom.Core/Features/Audit/AuditEventSubType.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Audit/AuditEventSubType.cs
@@ -33,5 +33,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Audit
         public const string GetAllExtendedQueryTags = "get-all-extended-query-tag";
 
         public const string GetExtendedQueryTag = "get-extended-query-tag";
+
+        public const string GetExtendedQueryTagErrors = "get-extended-query-tag-errors";
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/ExtendedQueryTagError.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/ExtendedQueryTagError.cs
@@ -1,0 +1,39 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+
+namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
+{
+    /// <summary>
+    /// Represents each Extended Query Tag Error that will be surfaced to the user.
+    /// </summary>
+    public class ExtendedQueryTagError
+    {
+        public ExtendedQueryTagError(DateTime timestamp,
+            string studyInstanceUid,
+            string seriesInstanceUid,
+            string sopInstanceUid,
+            string errorMessage)
+        {
+            StudyInstanceUid = EnsureArg.IsNotNull(studyInstanceUid); ;
+            SeriesInstanceUid = seriesInstanceUid;
+            SopInstanceUid = sopInstanceUid;
+            UtcTimestamp = timestamp;
+            ErrorMessage = EnsureArg.IsNotNullOrWhiteSpace(errorMessage); ;
+        }
+
+        public string StudyInstanceUid { get; }
+
+        public string SeriesInstanceUid { get; }
+
+        public string SopInstanceUid { get; }
+
+        public DateTime UtcTimestamp { get; }
+
+        public string ErrorMessage { get; }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/ExtendedQueryTagError.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/ExtendedQueryTagError.cs
@@ -13,17 +13,18 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
     /// </summary>
     public class ExtendedQueryTagError
     {
-        public ExtendedQueryTagError(DateTime timestamp,
+        public ExtendedQueryTagError(
+            DateTime timestamp,
             string studyInstanceUid,
             string seriesInstanceUid,
             string sopInstanceUid,
             string errorMessage)
         {
-            StudyInstanceUid = EnsureArg.IsNotNull(studyInstanceUid); ;
+            StudyInstanceUid = EnsureArg.IsNotNullOrWhiteSpace(studyInstanceUid);
             SeriesInstanceUid = seriesInstanceUid;
             SopInstanceUid = sopInstanceUid;
             UtcTimestamp = timestamp;
-            ErrorMessage = EnsureArg.IsNotNullOrWhiteSpace(errorMessage); ;
+            ErrorMessage = EnsureArg.IsNotNullOrWhiteSpace(errorMessage);
         }
 
         public string StudyInstanceUid { get; }

--- a/src/Microsoft.Health.Dicom.Core/Messages/ExtendedQueryTag/GetExtendedQueryTagErrorsRequest.cs
+++ b/src/Microsoft.Health.Dicom.Core/Messages/ExtendedQueryTag/GetExtendedQueryTagErrorsRequest.cs
@@ -1,0 +1,21 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using EnsureThat;
+using MediatR;
+
+namespace Microsoft.Health.Dicom.Core.Messages.ExtendedQueryTag
+{
+    public class GetExtendedQueryTagErrorsRequest : IRequest<GetExtendedQueryTagErrorsResponse>
+    {
+        public GetExtendedQueryTagErrorsRequest(string path)
+        {
+            EnsureArg.IsNotNullOrWhiteSpace(path, nameof(path));
+            Path = path;
+        }
+
+        public string Path { get; }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Core/Messages/ExtendedQueryTag/GetExtendedQueryTagErrorsResponse.cs
+++ b/src/Microsoft.Health.Dicom.Core/Messages/ExtendedQueryTag/GetExtendedQueryTagErrorsResponse.cs
@@ -1,0 +1,24 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using EnsureThat;
+using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
+
+namespace Microsoft.Health.Dicom.Core.Messages.ExtendedQueryTag
+{
+    public class GetExtendedQueryTagErrorsResponse
+    {
+        public GetExtendedQueryTagErrorsResponse(IReadOnlyCollection<ExtendedQueryTagError> extendedQueryTagErrors)
+        {
+            ExtendedQueryTagErrors = EnsureArg.IsNotNull(extendedQueryTagErrors);
+            ErrorCount = extendedQueryTagErrors.Count;
+        }
+
+        public int ErrorCount { get; }
+
+        public IReadOnlyCollection<ExtendedQueryTagError> ExtendedQueryTagErrors { get; }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Core/Messages/ExtendedQueryTag/GetExtendedQueryTagErrorsResponse.cs
+++ b/src/Microsoft.Health.Dicom.Core/Messages/ExtendedQueryTag/GetExtendedQueryTagErrorsResponse.cs
@@ -14,10 +14,7 @@ namespace Microsoft.Health.Dicom.Core.Messages.ExtendedQueryTag
         public GetExtendedQueryTagErrorsResponse(IReadOnlyCollection<ExtendedQueryTagError> extendedQueryTagErrors)
         {
             ExtendedQueryTagErrors = EnsureArg.IsNotNull(extendedQueryTagErrors);
-            ErrorCount = extendedQueryTagErrors.Count;
         }
-
-        public int ErrorCount { get; }
 
         public IReadOnlyCollection<ExtendedQueryTagError> ExtendedQueryTagErrors { get; }
     }


### PR DESCRIPTION
## Description
Add an endpoint for error querying.

GET  `/extendedquerytags/{tagPath}/errors`

Create response body for errors

## Related issues
Addresses [83510](https://microsofthealth.visualstudio.com/Health/_workitems/edit/83510).

## Testing
Tested through with postman request

![image](https://user-images.githubusercontent.com/26657972/125369485-564e7700-e34a-11eb-8dc9-c920a519ea67.png)

## TODO:

Add service
