### PR TITLE
Make full script re-runnable

### DIFF
--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/3.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/3.sql
@@ -15,7 +15,7 @@ IF EXISTS (
     FROM sys.tables
     WHERE name = 'Instance')
 BEGIN
-	ROLLBACK TRANSACTION
+    ROLLBACK TRANSACTION
     RETURN
 END
 
@@ -1559,19 +1559,19 @@ GO
 
 IF NOT EXISTS (
     SELECT * 
-	FROM sys.fulltext_indexes 
-	where object_id = object_id('dbo.Study'))
+    FROM sys.fulltext_indexes 
+    where object_id = object_id('dbo.Study'))
 BEGIN
-	CREATE FULLTEXT INDEX ON Study(PatientNameWords, ReferringPhysicianNameWords LANGUAGE 1033)
-	KEY INDEX IXC_Study
-	WITH STOPLIST = OFF;
+    CREATE FULLTEXT INDEX ON Study(PatientNameWords, ReferringPhysicianNameWords LANGUAGE 1033)
+    KEY INDEX IXC_Study
+    WITH STOPLIST = OFF;
 END
 GO
 
 IF NOT EXISTS (
     SELECT * 
-	FROM sys.fulltext_indexes 
-	where object_id = object_id('dbo.ExtendedQueryTagPersonName'))
+    FROM sys.fulltext_indexes 
+    where object_id = object_id('dbo.ExtendedQueryTagPersonName'))
 BEGIN
     CREATE FULLTEXT INDEX ON ExtendedQueryTagPersonName(TagValueWords LANGUAGE 1033)
     KEY INDEX IXC_ExtendedQueryTagPersonName_WatermarkAndTagKey


### PR DESCRIPTION
## Description
The schema manager does not run full script in transaction. So making 3.sql re-runnable.

## Related issues
[AB#83514](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/83514)

## Testing
Run the SQL multiple times. 
