### PR TITLE
Fix Re-indexing Dependency Injection

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
@@ -6,8 +6,6 @@
 using System;
 using System.Reflection;
 using System.Text.Json.Serialization;
-using Dicom;
-using Dicom.Serialization;
 using EnsureThat;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
@@ -35,7 +33,6 @@ using Microsoft.Health.Dicom.Core.Features.Routing;
 using Microsoft.Health.Dicom.Core.Registration;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.IO;
-using Newtonsoft.Json;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Microsoft.AspNetCore.Builder
@@ -90,15 +87,14 @@ namespace Microsoft.AspNetCore.Builder
 
             services.AddOptions();
 
-            services.AddMvc(options =>
-            {
-                options.EnableEndpointRouting = false;
-                options.RespectBrowserAcceptHeader = true;
-                options.OutputFormatters.Insert(0, new DicomJsonOutputFormatter());
-            }).AddJsonOptions(jsonOptions =>
-            {
-                jsonOptions.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
-            });
+            services
+                .AddMvc(options =>
+                {
+                    options.EnableEndpointRouting = false;
+                    options.RespectBrowserAcceptHeader = true;
+                    options.OutputFormatters.Insert(0, new DicomJsonOutputFormatter());
+                })
+                .AddJsonSerializerOptions(o => o.Converters.Add(new JsonStringEnumConverter()));
 
             services.AddApiVersioning(c =>
             {
@@ -128,18 +124,9 @@ namespace Microsoft.AspNetCore.Builder
             services.AddTransient<IStartupFilter, DicomServerStartupFilter>();
 
             // Register the Json Serializer to use
-            var jsonSerializer = new JsonSerializer();
-            jsonSerializer.Converters.Add(new JsonDicomConverter());
-            services.AddSingleton(jsonSerializer);
+            services.AddDicomJsonNetSerialization();
 
             services.TryAddSingleton<RecyclableMemoryStreamManager>();
-
-            // Disable fo-dicom data item validation. Disabling at global level
-            // Opt-in validation instead of opt-out
-            // De-serializing to Dataset while read has no Dataset level option to disable validation
-#pragma warning disable CS0618 // Type or member is obsolete
-            DicomValidation.AutoValidation = false;
-#pragma warning restore CS0618 // Type or member is obsolete
 
             return new DicomServerBuilder(services);
         }

--- a/src/Microsoft.Health.Dicom.Api/Registration/JsonMvcBuilderExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Api/Registration/JsonMvcBuilderExtensions.cs
@@ -1,0 +1,24 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Text.Json;
+using EnsureThat;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    internal static class JsonMvcBuilderExtensions
+    {
+        public static IMvcBuilder AddJsonSerializerOptions(this IMvcBuilder builder, Action<JsonSerializerOptions> configure)
+        {
+            EnsureArg.IsNotNull(builder, nameof(builder));
+            EnsureArg.IsNotNull(configure, nameof(configure));
+
+            builder.AddJsonOptions(o => configure(o.JsonSerializerOptions));
+            builder.Services.Configure(configure);
+            return builder;
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Core/Microsoft.Health.Dicom.Core.csproj
+++ b/src/Microsoft.Health.Dicom.Core/Microsoft.Health.Dicom.Core.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Efferent.Native" Version="4.0.0" />
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="fo-dicom" Version="4.0.7" />
+    <PackageReference Include="fo-dicom.Json" Version="4.0.7" NoWarn="NU1701" />
     <PackageReference Include="MediatR" Version="9.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.17.0" />

--- a/src/Microsoft.Health.Dicom.Core/Registration/JsonServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Registration/JsonServiceCollectionExtensions.cs
@@ -1,0 +1,33 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Dicom;
+using Dicom.Serialization;
+using EnsureThat;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class JsonServiceCollectionExtensions
+    {
+        public static IServiceCollection AddDicomJsonNetSerialization(this IServiceCollection services, bool autoValidation = false)
+        {
+            EnsureArg.IsNotNull(services, nameof(services));
+
+            // Register the Json Serializer to use
+            var jsonSerializer = new Newtonsoft.Json.JsonSerializer();
+            jsonSerializer.Converters.Add(new JsonDicomConverter());
+            services.AddSingleton(jsonSerializer);
+
+            // Disable fo-dicom data item validation. Disabling at global level
+            // Opt-in validation instead of opt-out
+            // De-serializing to Dataset while read has no Dataset level option to disable validation
+#pragma warning disable CS0618 // Type or member is obsolete
+            DicomValidation.AutoValidation = autoValidation;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            return services;
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Functions.Client.UnitTests/DicomAzureFunctionsHttpClientTests.cs
+++ b/src/Microsoft.Health.Dicom.Functions.Client.UnitTests/DicomAzureFunctionsHttpClientTests.cs
@@ -8,8 +8,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Net.Mime;
-using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
@@ -17,14 +19,15 @@ using Microsoft.Health.Dicom.Core.Exceptions;
 using Microsoft.Health.Dicom.Core.Messages.Operations;
 using Microsoft.Health.Dicom.Core.Models.Operations;
 using Microsoft.Health.Dicom.Functions.Client.Configs;
-using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.Health.Dicom.Functions.Client.UnitTests
 {
     public class DicomAzureFunctionsHttpClientTests
     {
-        private static readonly IOptions<FunctionsClientOptions> DefaultConfig = Options.Create(
+        private readonly IOptions<JsonSerializerOptions> _jsonSerializerOptions;
+
+        private static readonly IOptions<FunctionsClientOptions> DefaultOptions = Options.Create(
             new FunctionsClientOptions
             {
                 BaseAddress = new Uri("https://dicom.core/unit/tests/", UriKind.Absolute),
@@ -35,19 +38,30 @@ namespace Microsoft.Health.Dicom.Functions.Client.UnitTests
                 }
             });
 
+        public DicomAzureFunctionsHttpClientTests()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new JsonStringEnumConverter());
+            _jsonSerializerOptions = Options.Create(options);
+        }
+
         [Fact]
         public void GivenNullArguments_WhenConstructing_ThenThrowArgumentNullException()
         {
             var handler = new MockMessageHandler(new HttpResponseMessage(HttpStatusCode.NotFound));
             Assert.Throws<ArgumentNullException>(
-                () => new DicomAzureFunctionsHttpClient(null, DefaultConfig));
+                () => new DicomAzureFunctionsHttpClient(null, _jsonSerializerOptions, DefaultOptions));
 
             Assert.Throws<ArgumentNullException>(
-                () => new DicomAzureFunctionsHttpClient(new HttpClient(handler), null));
+                () => new DicomAzureFunctionsHttpClient(new HttpClient(handler), null, DefaultOptions));
+
+            Assert.Throws<ArgumentNullException>(
+                () => new DicomAzureFunctionsHttpClient(new HttpClient(handler), _jsonSerializerOptions, null));
 
             Assert.Throws<ArgumentNullException>(
                 () => new DicomAzureFunctionsHttpClient(
                     new HttpClient(handler),
+                    _jsonSerializerOptions,
                     Options.Create<FunctionsClientOptions>(null)));
         }
 
@@ -59,7 +73,7 @@ namespace Microsoft.Health.Dicom.Functions.Client.UnitTests
         public async Task GivenInvalidId_WhenGettingStatus_ThenThrowArgumentException(string id)
         {
             var handler = new MockMessageHandler(new HttpResponseMessage(HttpStatusCode.NotFound));
-            var client = new DicomAzureFunctionsHttpClient(new HttpClient(handler), DefaultConfig);
+            var client = new DicomAzureFunctionsHttpClient(new HttpClient(handler), _jsonSerializerOptions, DefaultOptions);
 
             Type exceptionType = id is null ? typeof(ArgumentNullException) : typeof(ArgumentException);
             await Assert.ThrowsAsync(exceptionType, () => client.GetStatusAsync(id, CancellationToken.None));
@@ -71,7 +85,7 @@ namespace Microsoft.Health.Dicom.Functions.Client.UnitTests
         public async Task GivenNotFound_WhenGettingStatus_ThenReturnNull()
         {
             var handler = new MockMessageHandler(new HttpResponseMessage(HttpStatusCode.NotFound));
-            var client = new DicomAzureFunctionsHttpClient(new HttpClient(handler), DefaultConfig);
+            var client = new DicomAzureFunctionsHttpClient(new HttpClient(handler), _jsonSerializerOptions, DefaultOptions);
 
             string id = Guid.NewGuid().ToString();
             using var source = new CancellationTokenSource();
@@ -88,7 +102,7 @@ namespace Microsoft.Health.Dicom.Functions.Client.UnitTests
         public async Task GivenUnsuccessfulStatusCode_WhenGettingStatus_ThenThrowHttpRequestException(HttpStatusCode expected)
         {
             var handler = new MockMessageHandler(new HttpResponseMessage(expected));
-            var client = new DicomAzureFunctionsHttpClient(new HttpClient(handler), DefaultConfig);
+            var client = new DicomAzureFunctionsHttpClient(new HttpClient(handler), _jsonSerializerOptions, DefaultOptions);
 
             string id = Guid.NewGuid().ToString();
             using var source = new CancellationTokenSource();
@@ -110,16 +124,16 @@ namespace Microsoft.Health.Dicom.Functions.Client.UnitTests
 @$"
 {{
   ""OperationId"": ""{id}"",
-  ""Type"": ""Reindex"",
-  ""CreatedTime"": ""{createdDateTime}"",
-  ""LastUpdatedTime"": ""{createdDateTime.AddMinutes(15)}"",
-  ""Status"": ""Running""
+  ""Type"": ""{OperationType.Reindex}"",
+  ""CreatedTime"": ""{createdDateTime:O}"",
+  ""LastUpdatedTime"": ""{createdDateTime.AddMinutes(15):O}"",
+  ""Status"": ""{OperationRuntimeStatus.Running}""
 }}
 "
-                )
+                ),
             };
             var handler = new MockMessageHandler(response);
-            var client = new DicomAzureFunctionsHttpClient(new HttpClient(handler), DefaultConfig);
+            var client = new DicomAzureFunctionsHttpClient(new HttpClient(handler), _jsonSerializerOptions, DefaultOptions);
 
             using var source = new CancellationTokenSource();
 
@@ -139,7 +153,7 @@ namespace Microsoft.Health.Dicom.Functions.Client.UnitTests
         public async Task GivenNullTagKEys_WhenStartingReindex_ThenThrowArgumentNullException()
         {
             var handler = new MockMessageHandler(new HttpResponseMessage(HttpStatusCode.NotFound));
-            var client = new DicomAzureFunctionsHttpClient(new HttpClient(handler), DefaultConfig);
+            var client = new DicomAzureFunctionsHttpClient(new HttpClient(handler), _jsonSerializerOptions, DefaultOptions);
 
             await Assert.ThrowsAsync<ArgumentNullException>(
                 () => client.StartQueryTagIndexingAsync(null, CancellationToken.None));
@@ -151,7 +165,7 @@ namespace Microsoft.Health.Dicom.Functions.Client.UnitTests
         public async Task GivenNoTagKeys_WhenStartingReindex_ThenThrowArgumentNullException()
         {
             var handler = new MockMessageHandler(new HttpResponseMessage(HttpStatusCode.NotFound));
-            var client = new DicomAzureFunctionsHttpClient(new HttpClient(handler), DefaultConfig);
+            var client = new DicomAzureFunctionsHttpClient(new HttpClient(handler), _jsonSerializerOptions, DefaultOptions);
 
             await Assert.ThrowsAsync<ArgumentException>(
                 () => client.StartQueryTagIndexingAsync(Array.Empty<int>(), CancellationToken.None));
@@ -166,7 +180,7 @@ namespace Microsoft.Health.Dicom.Functions.Client.UnitTests
         public async Task GivenUnsuccessfulStatusCode_WhenStartingReindex_ThenThrowHttpRequestException(HttpStatusCode expected)
         {
             var handler = new MockMessageHandler(new HttpResponseMessage(expected));
-            var client = new DicomAzureFunctionsHttpClient(new HttpClient(handler), DefaultConfig);
+            var client = new DicomAzureFunctionsHttpClient(new HttpClient(handler), _jsonSerializerOptions, DefaultOptions);
 
             var input = new List<int> { 1, 2, 3 };
             using var source = new CancellationTokenSource();
@@ -183,7 +197,7 @@ namespace Microsoft.Health.Dicom.Functions.Client.UnitTests
         public async Task GivenConflict_WhenStartingReindex_ThenThrowAlreadyExistsException()
         {
             var handler = new MockMessageHandler(new HttpResponseMessage(HttpStatusCode.Conflict));
-            var client = new DicomAzureFunctionsHttpClient(new HttpClient(handler), DefaultConfig);
+            var client = new DicomAzureFunctionsHttpClient(new HttpClient(handler), _jsonSerializerOptions, DefaultOptions);
 
             var input = new List<int> { 1, 2, 3 };
             using var source = new CancellationTokenSource();
@@ -199,7 +213,7 @@ namespace Microsoft.Health.Dicom.Functions.Client.UnitTests
             string expected = Guid.NewGuid().ToString();
             var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(expected) };
             var handler = new MockMessageHandler(response);
-            var client = new DicomAzureFunctionsHttpClient(new HttpClient(handler), DefaultConfig);
+            var client = new DicomAzureFunctionsHttpClient(new HttpClient(handler), _jsonSerializerOptions, DefaultOptions);
 
             using var source = new CancellationTokenSource();
             var input = new List<int> { 1, 2, 3 };
@@ -218,17 +232,13 @@ namespace Microsoft.Health.Dicom.Functions.Client.UnitTests
             Assert.Equal(MediaTypeNames.Application.Json, msg.Headers.Accept.Single().MediaType);
         }
 
-        private static async Task AssertExpectedStartAddRequestAsync(HttpRequestMessage msg, IReadOnlyList<int> tags)
+        private async Task AssertExpectedStartAddRequestAsync(HttpRequestMessage msg, IReadOnlyList<int> tags)
         {
             await AssertExpectedRequestAsync(msg, HttpMethod.Post, new Uri("https://dicom.core/unit/tests/Reindex"));
 
-            var content = msg.Content as StringContent;
+            var content = msg.Content as JsonContent;
             Assert.NotNull(content);
-            Assert.Equal(Encoding.UTF8.HeaderName, content.Headers.ContentType.CharSet);
-            Assert.Equal(MediaTypeNames.Application.Json, content.Headers.ContentType.MediaType);
-            Assert.Equal(
-                JsonConvert.SerializeObject(tags, DicomAzureFunctionsHttpClient.JsonSettings),
-                await content.ReadAsStringAsync());
+            Assert.Equal(JsonSerializer.Serialize(tags, _jsonSerializerOptions.Value), await content.ReadAsStringAsync());
         }
 
         private static Task AssertExpectedRequestAsync(HttpRequestMessage msg, HttpMethod expectedMethod, Uri expectedUri)

--- a/src/Microsoft.Health.Dicom.Functions.Client.UnitTests/Microsoft.Health.Dicom.Functions.Client.UnitTests.csproj
+++ b/src/Microsoft.Health.Dicom.Functions.Client.UnitTests/Microsoft.Health.Dicom.Functions.Client.UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/src/Microsoft.Health.Dicom.Functions.Client/DicomAzureFunctionsHttpClient.cs
+++ b/src/Microsoft.Health.Dicom.Functions.Client/DicomAzureFunctionsHttpClient.cs
@@ -37,20 +37,21 @@ namespace Microsoft.Health.Dicom.Functions.Client
         /// </summary>
         /// <param name="client">The HTTP client used to communicate with the HTTP triggered functions.</param>
         /// <param name="jsonSerializerOptions">Settings to be used when serializing or deserializing JSON.</param>
-        /// <param name="config">A configuration that specifies how to communicate with the Azure Functions.</param>
+        /// <param name="options">A configuration that specifies how to communicate with the Azure Functions.</param>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="client"/>, <paramref name="config"/>, or the value of the configuration is <see langword="null"/>.
+        /// <paramref name="client"/>, <paramref name="jsonSerializerOptions"/>, <paramref name="options"/>, or
+        /// either <see cref="IOptions{TOptions}.Value"/> is <see langword="null"/>.
         /// </exception>
         public DicomAzureFunctionsHttpClient(
             HttpClient client,
             IOptions<JsonSerializerOptions> jsonSerializerOptions,
-            IOptions<FunctionsClientOptions> config)
+            IOptions<FunctionsClientOptions> options)
         {
             _client = EnsureArg.IsNotNull(client, nameof(client));
             _jsonSerializerOptions = EnsureArg.IsNotNull(jsonSerializerOptions?.Value, nameof(jsonSerializerOptions));
-            _options = EnsureArg.IsNotNull(config?.Value, nameof(config));
+            _options = EnsureArg.IsNotNull(options?.Value, nameof(options));
 
-            client.BaseAddress = config.Value.BaseAddress;
+            client.BaseAddress = options.Value.BaseAddress;
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.Health.Dicom.Functions.Client/Microsoft.Health.Dicom.Functions.Client.csproj
+++ b/src/Microsoft.Health.Dicom.Functions.Client/Microsoft.Health.Dicom.Functions.Client.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="$(HealthcareSharedPackageVersion)" />
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.8" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Polly" Version="7.2.2" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
   </ItemGroup>

--- a/src/Microsoft.Health.Dicom.Functions.Client/Registration/DicomServerBuilderFunctionClientRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Functions.Client/Registration/DicomServerBuilderFunctionClientRegistrationExtensions.cs
@@ -9,12 +9,12 @@ using System.Net.Http;
 using EnsureThat;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Dicom.Core.Features.Operations;
 using Microsoft.Health.Dicom.Core.Registration;
 using Microsoft.Health.Dicom.Functions.Client.Configs;
-using Microsoft.Health.Extensions.DependencyInjection;
 using Polly;
 using Polly.Contrib.WaitAndRetry;
 using Polly.Extensions.Http;
@@ -53,9 +53,7 @@ namespace Microsoft.Health.Dicom.Functions.Client
 
             IServiceCollection services = dicomServerBuilder.Services;
 
-            services.Configure<FunctionsClientOptions>(configurationRoot
-                .GetSection(FunctionsClientOptions.SectionName));
-
+            services.TryAddScoped<IDicomOperationsClient, DicomAzureFunctionsHttpClient>();
             services
                 .AddHttpClient<DicomAzureFunctionsHttpClient>()
                 .AddHttpMessageHandler(
@@ -72,11 +70,7 @@ namespace Microsoft.Health.Dicom.Functions.Client
 
                         return new PolicyHttpMessageHandler(policy);
                     });
-
-            services.Add<DicomAzureFunctionsHttpClient>()
-                .Scoped()
-                .AsSelf()
-                .AsImplementedInterfaces();
+            services.Configure<FunctionsClientOptions>(configurationRoot.GetSection(FunctionsClientOptions.SectionName));
 
             return dicomServerBuilder;
         }

--- a/src/Microsoft.Health.Dicom.Functions.UnitTests/Indexing/ReindexDurableFunctionTests.Trigger.cs
+++ b/src/Microsoft.Health.Dicom.Functions.UnitTests/Indexing/ReindexDurableFunctionTests.Trigger.cs
@@ -10,7 +10,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Mime;
-using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -19,7 +19,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 using Microsoft.Health.Dicom.Functions.Indexing;
 using Microsoft.Health.Dicom.Functions.Indexing.Models;
-using Newtonsoft.Json;
 using NSubstitute;
 using Xunit;
 
@@ -139,7 +138,7 @@ namespace Microsoft.Health.Dicom.Functions.UnitTests.Indexing
 
         private static HttpRequest CreateRequest(IReadOnlyCollection<int> tagKeys)
         {
-            byte[] buffer = tagKeys == null ? Array.Empty<byte>() : Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(tagKeys));
+            byte[] buffer = tagKeys == null ? Array.Empty<byte>() : JsonSerializer.SerializeToUtf8Bytes(tagKeys);
 
             var context = new DefaultHttpContext();
             context.Request.Method = HttpMethod.Post.Method;

--- a/src/Microsoft.Health.Dicom.Functions.UnitTests/Indexing/ReindexDurableFunctionTests.Trigger.cs
+++ b/src/Microsoft.Health.Dicom.Functions.UnitTests/Indexing/ReindexDurableFunctionTests.Trigger.cs
@@ -136,9 +136,9 @@ namespace Microsoft.Health.Dicom.Functions.UnitTests.Indexing
                     cancellationToken: Arg.Any<CancellationToken>());
         }
 
-        private static HttpRequest CreateRequest(IReadOnlyCollection<int> tagKeys)
+        private HttpRequest CreateRequest(IReadOnlyCollection<int> tagKeys)
         {
-            byte[] buffer = tagKeys == null ? Array.Empty<byte>() : JsonSerializer.SerializeToUtf8Bytes(tagKeys);
+            byte[] buffer = tagKeys == null ? Array.Empty<byte>() : JsonSerializer.SerializeToUtf8Bytes(tagKeys, _jsonSerializerOptions);
 
             var context = new DefaultHttpContext();
             context.Request.Method = HttpMethod.Post.Method;

--- a/src/Microsoft.Health.Dicom.Functions.UnitTests/Indexing/ReindexDurableFunctionTests.cs
+++ b/src/Microsoft.Health.Dicom.Functions.UnitTests/Indexing/ReindexDurableFunctionTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Text.Json;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 using Microsoft.Health.Dicom.Core.Features.Indexing;
@@ -20,6 +21,7 @@ namespace Microsoft.Health.Dicom.Functions.UnitTests.Indexing
         private readonly IInstanceStore _instanceStore;
         private readonly IInstanceReindexer _instanceReindexer;
         private readonly ISchemaVersionResolver _schemaVersionResolver;
+        private readonly JsonSerializerOptions _jsonSerializerOptions;
         private readonly QueryTagIndexingOptions _options;
 
         public ReindexDurableFunctionTests()
@@ -28,12 +30,14 @@ namespace Microsoft.Health.Dicom.Functions.UnitTests.Indexing
             _instanceStore = Substitute.For<IInstanceStore>();
             _instanceReindexer = Substitute.For<IInstanceReindexer>();
             _schemaVersionResolver = Substitute.For<ISchemaVersionResolver>();
+            _jsonSerializerOptions = new JsonSerializerOptions();
             _options = new QueryTagIndexingOptions();
             _reindexDurableFunction = new ReindexDurableFunction(
                 _extendedQueryTagStore,
                 _instanceStore,
                 _instanceReindexer,
                 _schemaVersionResolver,
+                Options.Create(_jsonSerializerOptions),
                 Options.Create(_options));
         }
     }

--- a/src/Microsoft.Health.Dicom.Functions.UnitTests/Management/DurableClientProxyTests.cs
+++ b/src/Microsoft.Health.Dicom.Functions.UnitTests/Management/DurableClientProxyTests.cs
@@ -58,13 +58,13 @@ namespace Microsoft.Health.Dicom.Functions.UnitTests.Management
         [InlineData("")]
         [InlineData("   ")]
         [InlineData("\t  \r\n")]
-        public async Task GivenInvalidId_WhenGettingStatus_ThenReturnNotFound(string id)
+        public async Task GivenInvalidId_WhenGettingStatus_ThenReturnBadRequest(string id)
         {
             var context = new DefaultHttpContext();
             IDurableOrchestrationClient client = Substitute.For<IDurableOrchestrationClient>();
 
             HttpResponseMessage actual = await _proxy.GetStatusAsync(context.Request, client, id, NullLogger.Instance);
-            Assert.Equal(HttpStatusCode.NotFound, actual.StatusCode);
+            Assert.Equal(HttpStatusCode.BadRequest, actual.StatusCode);
 
             await client.DidNotReceiveWithAnyArgs().GetStatusAsync(default(string));
         }

--- a/src/Microsoft.Health.Dicom.Functions.UnitTests/Microsoft.Health.Dicom.Functions.UnitTests.csproj
+++ b/src/Microsoft.Health.Dicom.Functions.UnitTests/Microsoft.Health.Dicom.Functions.UnitTests.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="4.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.4.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="System.Text.Json" Version="5.0.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/src/Microsoft.Health.Dicom.Functions/Configuration/DicomBlobContainerConfiguration.cs
+++ b/src/Microsoft.Health.Dicom.Functions/Configuration/DicomBlobContainerConfiguration.cs
@@ -1,0 +1,17 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Microsoft.Health.Dicom.Functions.Configuration
+{
+    internal class DicomBlobContainerConfiguration
+    {
+        public const string SectionName = "Containers";
+
+        [Required]
+        public string Metadata { get; set; }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Functions/Indexing/ReindexDurableFunction.Trigger.cs
+++ b/src/Microsoft.Health.Dicom.Functions/Indexing/ReindexDurableFunction.Trigger.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Health.Dicom.Functions.Indexing
                 extendedQueryTagKeys = await JsonSerializer.DeserializeAsync<IReadOnlyList<int>>(request.Body, _jsonOptions, source.Token);
                 if (extendedQueryTagKeys == null || extendedQueryTagKeys.Count == 0)
                 {
-                    throw new JsonException("Expected at least 1 element in array.");
+                    throw new JsonException("Expected a JSON array with at least 1 element.");
                 }
             }
             catch (JsonException e)

--- a/src/Microsoft.Health.Dicom.Functions/Indexing/ReindexDurableFunction.Trigger.cs
+++ b/src/Microsoft.Health.Dicom.Functions/Indexing/ReindexDurableFunction.Trigger.cs
@@ -4,11 +4,11 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
-using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Mime;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -21,14 +21,11 @@ using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 using Microsoft.Health.Dicom.Core.Features.Model;
 using Microsoft.Health.Dicom.Functions.Extensions;
 using Microsoft.Health.Dicom.Functions.Indexing.Models;
-using Newtonsoft.Json;
 
 namespace Microsoft.Health.Dicom.Functions.Indexing
 {
     public partial class ReindexDurableFunction
     {
-        private static readonly JsonSerializer DefaultJsonSerializer = JsonSerializer.CreateDefault();
-
         /// <summary>
         /// Asynchronously starts the creation of an index for the provided query tags over the previously added data.
         /// </summary>
@@ -60,17 +57,18 @@ namespace Microsoft.Health.Dicom.Functions.Indexing
 
             // TODO: In .NET 5, use HttpRequestJsonExtensions.ReadFromJsonAsync which can gracefully handle different
             //       encodings. Here we'll expect a UTF-8 encoding which we can control as the client.
-            // We use Newtonsoft here for consistency across our other serializers
-            // (Although we could leverage the PipeReader if we used System.Text.Json)
             IReadOnlyList<int> extendedQueryTagKeys;
-            using (StreamReader streamReader = new StreamReader(request.Body, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true))
-            using (JsonReader reader = new JsonTextReader(streamReader))
+            try
             {
-                extendedQueryTagKeys = DefaultJsonSerializer.Deserialize<IReadOnlyList<int>>(reader);
+                extendedQueryTagKeys = await JsonSerializer.DeserializeAsync<IReadOnlyList<int>>(request.Body, _jsonOptions, source.Token);
+                if (extendedQueryTagKeys == null || extendedQueryTagKeys.Count == 0)
+                {
+                    throw new JsonException("Expected at least 1 element in array.");
+                }
             }
-
-            if (extendedQueryTagKeys == null || extendedQueryTagKeys.Count == 0)
+            catch (JsonException e)
             {
+                logger.LogError(e, "Cannot deserialize extended query tag keys.");
                 return new HttpResponseMessage { StatusCode = HttpStatusCode.BadRequest };
             }
 

--- a/src/Microsoft.Health.Dicom.Functions/Indexing/ReindexDurableFunction.cs
+++ b/src/Microsoft.Health.Dicom.Functions/Indexing/ReindexDurableFunction.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Text.Json;
 using EnsureThat;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
@@ -22,6 +23,7 @@ namespace Microsoft.Health.Dicom.Functions.Indexing
         private readonly IInstanceStore _instanceStore;
         private readonly IInstanceReindexer _instanceReindexer;
         private readonly ISchemaVersionResolver _schemaVersionResolver;
+        private readonly JsonSerializerOptions _jsonOptions;
         private readonly QueryTagIndexingOptions _options;
 
         public ReindexDurableFunction(
@@ -29,12 +31,14 @@ namespace Microsoft.Health.Dicom.Functions.Indexing
             IInstanceStore instanceStore,
             IInstanceReindexer instanceReindexer,
             ISchemaVersionResolver schemaVersionResolver,
+            IOptions<JsonSerializerOptions> jsonOptions,
             IOptions<QueryTagIndexingOptions> configOptions)
         {
             _extendedQueryTagStore = EnsureArg.IsNotNull(extendedQueryTagStore, nameof(extendedQueryTagStore));
             _instanceStore = EnsureArg.IsNotNull(instanceStore, nameof(instanceStore));
             _instanceReindexer = EnsureArg.IsNotNull(instanceReindexer, nameof(instanceReindexer));
             _schemaVersionResolver = EnsureArg.IsNotNull(schemaVersionResolver, nameof(schemaVersionResolver));
+            _jsonOptions = EnsureArg.IsNotNull(jsonOptions?.Value, nameof(jsonOptions));
             _options = EnsureArg.IsNotNull(configOptions?.Value, nameof(configOptions));
         }
     }

--- a/src/Microsoft.Health.Dicom.Functions/Management/DurableClientProxy.cs
+++ b/src/Microsoft.Health.Dicom.Functions/Management/DurableClientProxy.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Health.Dicom.Functions.Management
 
             if (string.IsNullOrWhiteSpace(instanceId))
             {
-                return new HttpResponseMessage { StatusCode = HttpStatusCode.NotFound };
+                return new HttpResponseMessage { StatusCode = HttpStatusCode.BadRequest };
             }
 
             // GetStatusAsync doesn't accept a token, so the best we can do is cancel before execution

--- a/src/Microsoft.Health.Dicom.Functions/Management/DurableClientProxy.cs
+++ b/src/Microsoft.Health.Dicom.Functions/Management/DurableClientProxy.cs
@@ -5,6 +5,11 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Net;
+using System.Net.Http;
+using System.Net.Mime;
+using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -14,6 +19,7 @@ using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.Dicom.Core.Messages.Operations;
 using Microsoft.Health.Dicom.Core.Models.Operations;
 using Microsoft.Health.Dicom.Functions.Extensions;
@@ -23,9 +29,14 @@ namespace Microsoft.Health.Dicom.Functions.Management
     /// <summary>
     /// Represents a set of Azure Functions that servce as a proxy for the <see cref="IDurableOrchestrationClient"/>.
     /// </summary>
-    public static class DurableClientProxyFunctions
+    public class DurableClientProxy
     {
         internal static readonly ImmutableHashSet<OperationType> PublicOperationTypes = ImmutableHashSet.Create(OperationType.Reindex);
+
+        private readonly JsonSerializerOptions _jsonOptions;
+
+        public DurableClientProxy(IOptions<JsonSerializerOptions> jsonOptions)
+            => _jsonOptions = EnsureArg.IsNotNull(jsonOptions?.Value, nameof(jsonOptions));
 
         /// <summary>
         /// Gets the status of an orchestration instance.
@@ -52,7 +63,7 @@ namespace Microsoft.Health.Dicom.Functions.Management
         /// <exception cref="OperationCanceledException">The host is shutting down or the connection was aborted.</exception>
         // TODO: Replace Anonymous with auth for all HTTP endpoints
         [FunctionName(nameof(GetStatusAsync))]
-        public static async Task<IActionResult> GetStatusAsync(
+        public async Task<HttpResponseMessage> GetStatusAsync(
             [HttpTrigger(AuthorizationLevel.Anonymous, "GET", Route = "Orchestrations/Instances/{instanceId}")] HttpRequest request,
             [DurableClient] IDurableOrchestrationClient client,
             string instanceId,
@@ -69,7 +80,7 @@ namespace Microsoft.Health.Dicom.Functions.Management
 
             if (string.IsNullOrWhiteSpace(instanceId))
             {
-                return new BadRequestResult();
+                return new HttpResponseMessage { StatusCode = HttpStatusCode.NotFound };
             }
 
             // GetStatusAsync doesn't accept a token, so the best we can do is cancel before execution
@@ -77,8 +88,12 @@ namespace Microsoft.Health.Dicom.Functions.Management
 
             OperationStatusResponse status = await GetOperationStatusAsync(client, instanceId);
             return status != null && PublicOperationTypes.Contains(status.Type)
-                ? new OkObjectResult(status)
-                : new NotFoundResult();
+                ? new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(JsonSerializer.Serialize(status, _jsonOptions), Encoding.UTF8, MediaTypeNames.Application.Json),
+                }
+                : new HttpResponseMessage { StatusCode = HttpStatusCode.NotFound };
         }
 
         private static async Task<OperationStatusResponse> GetOperationStatusAsync(IDurableOrchestrationClient client, string instanceId)

--- a/src/Microsoft.Health.Dicom.Functions/Microsoft.Health.Dicom.Functions.csproj
+++ b/src/Microsoft.Health.Dicom.Functions/Microsoft.Health.Dicom.Functions.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.2" />
     <PackageReference Include="Microsoft.Health.Blob" Version="$(HealthcareSharedPackageVersion)" />
     <PackageReference Include="Microsoft.Health.SqlServer" Version="$(HealthcareSharedPackageVersion)" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.1.3" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" PrivateAssets="All" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Microsoft.Health.Dicom.Functions/Registration/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Functions/Registration/ServiceCollectionExtensions.cs
@@ -40,8 +40,10 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddRecyclableMemoryStreamManager(this IServiceCollection services, Func<RecyclableMemoryStreamManager> factory = null)
         {
             EnsureArg.IsNotNull(services, nameof(services));
-            factory ??= () => new RecyclableMemoryStreamManager();
 
+            // The custom service provider used by Azure Functions cannot seem to resolve the
+            // RecyclableMemoryStreamManager ctor overloads without help, so we instantiate it ourselves
+            factory ??= () => new RecyclableMemoryStreamManager();
             services.TryAddSingleton(factory());
 
             return services;

--- a/src/Microsoft.Health.Dicom.Functions/Startup.cs
+++ b/src/Microsoft.Health.Dicom.Functions/Startup.cs
@@ -6,12 +6,12 @@
 using EnsureThat;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Health.Dicom.Core.Configs;
 using Microsoft.Health.Dicom.Core.Modules;
 using Microsoft.Health.Dicom.Functions.Configuration;
 using Microsoft.Health.Dicom.Functions.Indexing;
 using Microsoft.Health.Dicom.Functions.Management;
-using Microsoft.Health.Dicom.Functions.Registration;
 
 [assembly: FunctionsStartup(typeof(Microsoft.Health.Dicom.Functions.Startup))]
 namespace Microsoft.Health.Dicom.Functions
@@ -30,6 +30,8 @@ namespace Microsoft.Health.Dicom.Functions
             builder.Services
                 .AddFunctionsOptions<QueryTagIndexingOptions>(config, QueryTagIndexingOptions.SectionName)
                 .AddFunctionsOptions<PurgeHistoryOptions>(config, PurgeHistoryOptions.SectionName)
+                .AddRecyclableMemoryStreamManager()
+                .AddDicomJsonNetSerialization()
                 .AddStorageServices(config)
                 .AddHttpServices();
 

--- a/src/Microsoft.Health.Dicom.Functions/host.json
+++ b/src/Microsoft.Health.Dicom.Functions/host.json
@@ -21,6 +21,9 @@
   },
   "BlobStore": {
     "ConnectionString": null,
+    "Containers": {
+      "Metadata": "metadatacontainer"
+    },
     "RequestOptions": {
       "ExponentialRetryBackoffDeltaInSeconds": 4,
       "ExponentialRetryMaxAttempts": 6,

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.diff.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.diff.sql
@@ -476,7 +476,7 @@ AS
 
     BEGIN TRANSACTION
 
-        MERGE INTO dbo.ExtendedQueryTagOperation AS XQTO
+        MERGE INTO dbo.ExtendedQueryTagOperation WITH(HOLDLOCK) AS XQTO
         USING
         (
             SELECT input.TagKey

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.sql
@@ -1959,7 +1959,7 @@ AS
 
     BEGIN TRANSACTION
 
-        MERGE INTO dbo.ExtendedQueryTagOperation AS XQTO
+        MERGE INTO dbo.ExtendedQueryTagOperation WITH(HOLDLOCK) AS XQTO
         USING
         (
             SELECT input.TagKey

--- a/src/Microsoft.Health.Dicom.SqlServer/Registration/DicomSqlServerRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Registration/DicomSqlServerRegistrationExtensions.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             // Add SQL-specific implementations
             services
+                .AddSqlIndexDataStores()
                 .AddSqlInstanceStores()
                 .AddSqlExtendedQueryTagStores();
 


### PR DESCRIPTION
## Description
- Fix dependency injection service container to include missing services like the SQL index stores, JSON.NET serializers, and RecycleableMemoryStreamManager
- Normalize serialization between web server and client to use System.Text.Json over JSON.NET in preparation for fo-dicom 5 and .NET 6

## Related issues
N/A

## Testing
Test locally
