### PR TITLE
Update swagger generation

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Configs/DicomServerConfiguration.cs
+++ b/src/Microsoft.Health.Dicom.Api/Configs/DicomServerConfiguration.cs
@@ -21,5 +21,7 @@ namespace Microsoft.Health.Dicom.Api.Configs
         public ServicesConfiguration Services { get; } = new ServicesConfiguration();
 
         public AuditConfiguration Audit { get; } = new AuditConfiguration("X-MS-AZUREDICOM-AUDIT-");
+
+        public SwaggerConfiguration Swagger { get; } = new SwaggerConfiguration();
     }
 }

--- a/src/Microsoft.Health.Dicom.Api/Configs/SwaggerConfiguration.cs
+++ b/src/Microsoft.Health.Dicom.Api/Configs/SwaggerConfiguration.cs
@@ -1,0 +1,19 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.Health.Dicom.Api.Configs
+{
+    public class SwaggerConfiguration
+    {
+        public Uri ServerUri { get; set; }
+
+        public string Title { get; } = "Medical Imaging Server for DICOM";
+
+        public OpenApiLicense License { get; } = new OpenApiLicense();
+    }
+}

--- a/src/Microsoft.Health.Dicom.Api/Features/Swagger/ConfigureSwaggerOptions.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Swagger/ConfigureSwaggerOptions.cs
@@ -7,33 +7,48 @@ using EnsureThat;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Microsoft.Health.Dicom.Api.Configs;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
-namespace Microsoft.Health.Dicom.Api.Registration.Swagger
+namespace Microsoft.Health.Dicom.Api.Features.Swagger
 {
     public class ConfigureSwaggerOptions : IConfigureOptions<SwaggerGenOptions>
     {
         private readonly IApiVersionDescriptionProvider _provider;
+        private readonly SwaggerConfiguration _swaggerConfiguration;
 
-        public ConfigureSwaggerOptions(IApiVersionDescriptionProvider provider)
+        public ConfigureSwaggerOptions(IApiVersionDescriptionProvider provider, IOptions<SwaggerConfiguration> swaggerConfiguration)
         {
-            EnsureArg.IsNotNull(provider, nameof(provider));
-
-            _provider = provider;
+            _provider = EnsureArg.IsNotNull(provider, nameof(provider));
+            _swaggerConfiguration = EnsureArg.IsNotNull(swaggerConfiguration?.Value, nameof(swaggerConfiguration));
         }
 
         public void Configure(SwaggerGenOptions options)
         {
+            if (_swaggerConfiguration.ServerUri != null)
+            {
+                options.AddServer(new OpenApiServer { Url = _swaggerConfiguration.ServerUri.ToString() });
+            }
+
+            OpenApiLicense license = null;
+            if (!string.IsNullOrWhiteSpace(_swaggerConfiguration.License.Name))
+            {
+                license = new OpenApiLicense
+                {
+                    Name = _swaggerConfiguration.License.Name,
+                    Url = _swaggerConfiguration.License.Url,
+                };
+            }
             foreach (ApiVersionDescription description in _provider.ApiVersionDescriptions)
             {
                 options.SwaggerDoc(
                     description.GroupName,
                     new OpenApiInfo
                     {
-                        Title = "Medical Imaging Server for DICOM",
+                        Title = _swaggerConfiguration.Title,
                         Version = description.ApiVersion.ToString(),
-                        License = new OpenApiLicense { Name = "MIT License", Url = new System.Uri("https://github.com/microsoft/dicom-server/blob/main/LICENSE") }
+                        License = license,
                     });
             }
         }

--- a/src/Microsoft.Health.Dicom.Api/Features/Swagger/ErrorCodeOperationFilter.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Swagger/ErrorCodeOperationFilter.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
-namespace Microsoft.Health.Dicom.Api.Registration.Swagger
+namespace Microsoft.Health.Dicom.Api.Features.Swagger
 {
     public class ErrorCodeOperationFilter : IOperationFilter
     {

--- a/src/Microsoft.Health.Dicom.Api/Features/Swagger/RetrieveOperationFilter.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Swagger/RetrieveOperationFilter.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
-namespace Microsoft.Health.Dicom.Api.Registration.Swagger
+namespace Microsoft.Health.Dicom.Api.Features.Swagger
 {
     public class RetrieveOperationFilter : IOperationFilter
     {

--- a/src/Microsoft.Health.Dicom.Api/Features/Swagger/SwaggerDefaultValues.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Swagger/SwaggerDefaultValues.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
-namespace Microsoft.Health.Dicom.Api.Registration.Swagger
+namespace Microsoft.Health.Dicom.Api.Features.Swagger
 {
     /// <summary>
     /// Represents the Swagger/Swashbuckle operation filter used to document the implicit API version parameter.

--- a/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
@@ -28,7 +28,7 @@ using Microsoft.Health.Dicom.Api.Features.BackgroundServices;
 using Microsoft.Health.Dicom.Api.Features.Context;
 using Microsoft.Health.Dicom.Api.Features.Formatters;
 using Microsoft.Health.Dicom.Api.Features.Routing;
-using Microsoft.Health.Dicom.Api.Registration.Swagger;
+using Microsoft.Health.Dicom.Api.Features.Swagger;
 using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Core.Features.Context;
 using Microsoft.Health.Dicom.Core.Features.Routing;
@@ -82,6 +82,7 @@ namespace Microsoft.AspNetCore.Builder
             services.AddSingleton(Options.Create(dicomServerConfiguration.Services.DeletedInstanceCleanup));
             services.AddSingleton(Options.Create(dicomServerConfiguration.Services.StoreServiceSettings));
             services.AddSingleton(Options.Create(dicomServerConfiguration.Audit));
+            services.AddSingleton(Options.Create(dicomServerConfiguration.Swagger));
 
             services.RegisterAssemblyModules(Assembly.GetExecutingAssembly(), dicomServerConfiguration);
             services.RegisterAssemblyModules(typeof(InitializationModule).Assembly, dicomServerConfiguration);
@@ -190,7 +191,7 @@ namespace Microsoft.AspNetCore.Builder
 
                     app.UseSwagger(c =>
                     {
-                        c.RouteTemplate = "{documentName}/api.yaml";
+                        c.RouteTemplate = "{documentName}/api.{json|yaml}";
                     });
 
                     //Disabling swagger ui until accesability team gets back to us

--- a/src/Microsoft.Health.Dicom.Web/appsettings.json
+++ b/src/Microsoft.Health.Dicom.Web/appsettings.json
@@ -30,6 +30,12 @@
         },
         "ServerIdentity": {
           "UserAssignedAppId": null
+        },
+        "Swagger": {
+          "License": {
+            "Name": "MIT License",
+            "Url": "https://github.com/microsoft/dicom-server/blob/main/LICENSE"
+          }
         }
     },
     "Logging": {


### PR DESCRIPTION
## Description
This PR updates the swagger generation in the following ways:
* Moves strings to be config settings, settable via configuration
* Allows for generation of both `yaml` and `json` swagger files.
* Allows for setting a server url in the generated swagger
* Moves swagger classes to `features` folder.

## Related issues
Addresses [AB#84341](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/84341).

## Testing
Manual testing of generated swagger files.
