### PR TITLE
Speed Up PR and CI Pipelines with Parallel Security Stage

### DIFF
--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -14,7 +14,7 @@ pr: none
 
 stages:
 - stage: UpdateVersion
-  displayName: 'Determine Semver'
+  displayName: 'Determine Semantic Version'
   dependsOn: []
   jobs:
   - job: Semver
@@ -24,7 +24,7 @@ stages:
     - template: ./update-semver.yml
 
 - stage: BuildRunUnitTests
-  displayName: 'Build and Test'
+  displayName: 'Build and Run Unit Tests'
   dependsOn:
   - UpdateVersion
   variables:
@@ -83,21 +83,21 @@ stages:
   - template: versioning.yml
 
 - stage: RunIntegrationTests
-  displayName: 'Integration tests'
+  displayName: 'Run Integration Tests'
   dependsOn:
   - UpdateTestEnvironment
   jobs:
   - template: run-integration-tests.yml
 
 - stage: RunE2ETests
-  displayName: 'E2E tests'
+  displayName: 'Run E2E Tests'
   dependsOn:
   - UpdateTestEnvironment
   jobs:
   - template: run-e2e-tests.yml
 
 - stage: PublishNuget
-  displayName: 'Publish Nugets'
+  displayName: 'Publish NuGet Packages'
   dependsOn:
   - AnalyzeSecurity
   - ValidateAPIVersioning

--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -24,7 +24,7 @@ stages:
     - template: ./update-semver.yml
 
 - stage: BuildRunUnitTests
-  displayName: 'Build and run unit tests'
+  displayName: 'Build and Test'
   dependsOn:
   - UpdateVersion
   variables:
@@ -34,21 +34,22 @@ stages:
     majorMinorPatch: $[stageDependencies.UpdateVersion.Semver.outputs['DicomVersion.GitVersion.MajorMinorPatch']]
     nuGetVersion: $[stageDependencies.UpdateVersion.Semver.outputs['DicomVersion.GitVersion.SemVer']]
   jobs:
-  - job: Windows
-    pool:
-      vmImage: $(windowsVmImage)
-    steps:
-    - template: build.yml
-
   - job: Linux
     pool:
       vmImage: 'ubuntu-latest'
     steps:
     - template: build.yml
-      parameters:
-        packageArtifacts: false
-        analyzeSecurity: false
-        packageNugets: false
+
+- stage: AnalyzeSecurity
+  displayName: 'Run Security Analysis'
+  dependsOn:
+  - BuildRunUnitTests
+  jobs:
+  - job: Windows
+    pool:
+      vmImage: $(windowsVmImage)
+    steps:
+    - template: analyze.yml
 
 - stage: UpdateTestEnvironment
   displayName: 'Update Test Environment'
@@ -98,6 +99,8 @@ stages:
 - stage: PublishNuget
   displayName: 'Publish Nugets'
   dependsOn:
+  - AnalyzeSecurity
+  - ValidateAPIVersioning
   - RunIntegrationTests
   - RunE2ETests
   jobs:
@@ -110,6 +113,8 @@ stages:
 - stage: PublishContainer
   displayName: 'Publish Docker CI Container'
   dependsOn:
+  - AnalyzeSecurity
+  - ValidateAPIVersioning
   - RunIntegrationTests
   - RunE2ETests
   jobs:

--- a/build/.vsts-pr.yml
+++ b/build/.vsts-pr.yml
@@ -9,7 +9,7 @@ variables:
 
 stages:
 - stage: UpdateVersion
-  displayName: 'Determine Semver'
+  displayName: 'Determine Semantic Version'
   dependsOn: []
   jobs:
   - job: Semver
@@ -24,7 +24,7 @@ stages:
       name: SetBuildVersion
 
 - stage: BuildRunUnitTests
-  displayName: 'Build and run unit tests'
+  displayName: 'Build and Run Unit Tests'
   dependsOn:
   - UpdateVersion
   variables:
@@ -64,28 +64,28 @@ stages:
   - template: deploy.yml
 
 - stage: ValidateAPIVersioning
-  displayName: 'Detect Breaking Changes In API'
+  displayName: 'Detect Breaking Changes in REST API'
   dependsOn:
   - BuildRunUnitTests
   jobs:
   - template: versioning.yml
 
 - stage: RunIntegrationTests
-  displayName: 'Integration tests'
+  displayName: 'Run Integration tests'
   dependsOn:
   - DeployTestEnvironment
   jobs:
   - template: run-integration-tests.yml
 
 - stage: RunE2ETests
-  displayName: 'E2E tests'
+  displayName: 'Run E2E tests'
   dependsOn:
   - DeployTestEnvironment
   jobs:
   - template: run-e2e-tests.yml
 
 - stage: Cleanup
-  displayName: 'Cleanup Azure Environment'
+  displayName: 'Clean Up Azure Environment'
   dependsOn:
   - RunIntegrationTests
   - RunE2ETests

--- a/build/.vsts-pr.yml
+++ b/build/.vsts-pr.yml
@@ -41,29 +41,20 @@ stages:
     - template: build.yml
       parameters:
         packageArtifacts: true
-        analyzeSecurity: false
         packageNugets: false
 
-- stage: SecurityAnalyze
-  displayName: 'Security analyze'
+- stage: AnalyzeSecurity
+  displayName: 'Run Security Analysis'
   dependsOn:
-  - UpdateVersion
-  variables:
-    assemblySemVer: $[stageDependencies.UpdateVersion.Semver.outputs['DicomVersion.GitVersion.AssemblySemVer']]
-    assemblySemFileVer: $[stageDependencies.UpdateVersion.Semver.outputs['DicomVersion.GitVersion.AssemblySemFileVer']]
-    informationalVersion: $[stageDependencies.UpdateVersion.Semver.outputs['DicomVersion.GitVersion.InformationalVersion']]
-    majorMinorPatch: $[stageDependencies.UpdateVersion.Semver.outputs['DicomVersion.GitVersion.MajorMinorPatch']]
-    nuGetVersion: $[stageDependencies.UpdateVersion.Semver.outputs['DicomVersion.GitVersion.SemVer']]
+  - BuildRunUnitTests
   jobs:
   - job: Windows
     pool:
       vmImage: $(windowsVmImage)
     steps:
-    - template: build.yml
+    - template: analyze.yml
       parameters:
-        packageArtifacts: false
-        analyzeSecurity: true
-        packageNugets: false
+        analyzePackages: false
 
 - stage: DeployTestEnvironment
   displayName: 'Deploy Test Environment'

--- a/build/analyze.yml
+++ b/build/analyze.yml
@@ -16,20 +16,20 @@ steps:
     inputs:
       buildType: 'current'
       downloadType: 'single'
-      downloadPath: '$(Pipeline.Workspace)/artifacts'
+      downloadPath: '$(Build.SourcesDirectory)/artifacts'
       artifactName: 'nuget'
 
 - task: ExtractFiles@1
   displayName: 'Extract DICOM Web Server Binaries'
   inputs:
     archiveFilePatterns: '$(Agent.TempDirectory)/artifacts/deploy/Microsoft.Health.Dicom.Web.zip'
-    destinationFolder: '$(Pipeline.Workspace)/artifacts/web'
+    destinationFolder: '$(Build.SourcesDirectory)/artifacts/web'
 
 - task: AntiMalware@4
   inputs:
     InputType: 'Basic'
     ScanType: 'CustomScan'
-    FileDirPath: '$(Pipeline.Workspace)/artifacts'
+    FileDirPath: '$(Build.SourcesDirectory)'
     EnableServices: true
     TreatSignatureUpdateFailureAs: 'Standard'
     SignatureFreshness: 'OneDay'

--- a/build/analyze.yml
+++ b/build/analyze.yml
@@ -1,17 +1,35 @@
+parameters:
+  analyzePackages: true
+
 steps:
-- task: ComponentGovernanceComponentDetection@0
+- task: DownloadBuildArtifacts@0
+  displayName: 'Download DICOM Binaries'
   inputs:
-    scanType: 'Register'
-    verbosity: 'Verbose'
-    alertWarningLevel: 'High'
-    failOnAlert: true
-    ignoreDirectories: '$(Build.SourcesDirectory)\samples\Azurite'
+    buildType: 'current'
+    downloadType: 'single'
+    downloadPath: '$(Agent.TempDirectory)/artifacts'
+    artifactName: 'deploy'
+
+- ${{ if eq(parameters.analyzePackages, 'true') }}:
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download DICOM NuGet Packages'
+    inputs:
+      buildType: 'current'
+      downloadType: 'single'
+      downloadPath: '$(Pipeline.Workspace)/artifacts'
+      artifactName: 'nuget'
+
+- task: ExtractFiles@1
+  displayName: 'Extract DICOM Web Server Binaries'
+  inputs:
+    archiveFilePatterns: '$(Agent.TempDirectory)/artifacts/deploy/Microsoft.Health.Dicom.Web.zip'
+    destinationFolder: '$(Pipeline.Workspace)/artifacts/web'
 
 - task: AntiMalware@4
   inputs:
     InputType: 'Basic'
     ScanType: 'CustomScan'
-    FileDirPath: '$(Build.SourcesDirectory)'
+    FileDirPath: '$(Pipeline.Workspace)/artifacts'
     EnableServices: true
     TreatSignatureUpdateFailureAs: 'Standard'
     SignatureFreshness: 'OneDay'

--- a/build/build.yml
+++ b/build/build.yml
@@ -2,15 +2,15 @@ parameters:
   packageArtifacts: true
   analyzeSecurity: true
   packageNugets: true
-  
+
 steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET Core sdk (for sql generation)'
+    displayName: 'Use .NET Core SDK (for SQL generation)'
     inputs:
       version: '3.1.401'
 
   - task: UseDotNet@2
-    displayName: 'Use .NET Core sdk'
+    displayName: 'Use .NET Core SDK'
     inputs:
       useGlobalJson: true
 
@@ -28,11 +28,15 @@ steps:
       projects: '**/*UnitTests/*.csproj'
       arguments: '--configuration $(buildConfiguration) --no-build'
 
+  - task: ComponentGovernanceComponentDetection@0
+    inputs:
+      scanType: 'Register'
+      verbosity: 'Verbose'
+      alertWarningLevel: 'High'
+      failOnAlert: true
+
   - ${{ if eq(parameters.packageArtifacts, 'true') }}:
     - template: package.yml
 
   - ${{ if eq(parameters.packageNugets, 'true') }}:
     - template: package-nugets.yml
-
-  - ${{ if eq(parameters.analyzeSecurity, 'true') }}:
-    - template: analyze.yml


### PR DESCRIPTION
## Description
- Move Security Analysis to its own dedicated stage that skips building
- Move component governance to the build as it requires a build to analyze dependencies
- Remove Windows build in favor of faster Linux builds

## Related issues
N/A

## Testing
Test pipelines
