### PR TITLE
Saving IHttpContextAccessor

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Features/Routing/UrlResolver.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Routing/UrlResolver.cs
@@ -19,9 +19,6 @@ namespace Microsoft.Health.Dicom.Api.Features.Routing
     {
         private readonly IUrlHelperFactory _urlHelperFactory;
 
-        // If we update the search implementation to not use these, we should remove
-        // the registration since enabling these accessors has performance implications.
-        // https://github.com/aspnet/Hosting/issues/793
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IActionContextAccessor _actionContextAccessor;
 


### PR DESCRIPTION
The comment suggests that requesting `IHttpContextAccessor` has performance implications, based on [this issue](https://github.com/aspnet/Hosting/issues/793). However, the three follow-up comments beginning [here](https://github.com/aspnet/Hosting/issues/793#issuecomment-224828588) clarify that this was speculation.