### PR TITLE
Add Pagination to Extended Query Tag

### DIFF
--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Controllers/ExtendedQueryTagControllerTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Controllers/ExtendedQueryTagControllerTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Health.Dicom.Api.UnitTests.Extensions
 
             await Assert.ThrowsAsync<ExtendedQueryTagFeatureDisabledException>(() => controller.GetTagAsync(DicomTag.PageNumberVector.GetPath()));
             await Assert.ThrowsAsync<ExtendedQueryTagFeatureDisabledException>(() => controller.GetTagErrorsAsync(DicomTag.PageNumberVector.GetPath()));
-            await Assert.ThrowsAsync<ExtendedQueryTagFeatureDisabledException>(() => controller.GetAllTagsAsync());
+            await Assert.ThrowsAsync<ExtendedQueryTagFeatureDisabledException>(() => controller.GetTagsAsync());
             await Assert.ThrowsAsync<ExtendedQueryTagFeatureDisabledException>(() => controller.PostAsync(Array.Empty<AddExtendedQueryTagEntry>()));
             await Assert.ThrowsAsync<ExtendedQueryTagFeatureDisabledException>(() => controller.DeleteAsync(DicomTag.PageNumberVector.GetPath()));
         }

--- a/src/Microsoft.Health.Dicom.Api/Controllers/ExtendedQueryTagController.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/ExtendedQueryTagController.cs
@@ -93,19 +93,25 @@ namespace Microsoft.Health.Dicom.Api.Controllers
         /// Returns Bad Request if given path can't be parsed. Returns Not Found if given path doesn't map to a stored
         /// extended query tag or if no extended query tags are stored. Returns OK with a JSON body of all tags in other cases.
         /// </returns>
+        [HttpGet]
         [Produces(KnownContentTypes.ApplicationJson)]
         [ProducesResponseType(typeof(IEnumerable<GetExtendedQueryTagEntry>), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
-        [HttpGet]
         [VersionedRoute(KnownRoutes.ExtendedQueryTagRoute)]
         [Route(KnownRoutes.ExtendedQueryTagRoute)]
         [AuditEventType(AuditEventSubType.GetAllExtendedQueryTags)]
-        public async Task<IActionResult> GetAllTagsAsync()
+        public async Task<IActionResult> GetTagsAsync(
+            [FromQuery, Range(1, 200)] int limit = 100,
+            [FromQuery, Range(0, int.MaxValue)] int offset = 0)
         {
             _logger.LogInformation("DICOM Web Get Extended Query Tag request received for all extended query tags");
 
             EnsureFeatureIsEnabled();
-            GetAllExtendedQueryTagsResponse response = await _mediator.GetAllExtendedQueryTagsAsync(HttpContext.RequestAborted);
+            GetExtendedQueryTagsResponse response = await _mediator.GetExtendedQueryTagsAsync(
+                limit,
+                offset,
+                HttpContext.RequestAborted);
 
             return StatusCode(
                 (int)HttpStatusCode.OK, response.ExtendedQueryTags);

--- a/src/Microsoft.Health.Dicom.Api/Controllers/ExtendedQueryTagController.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/ExtendedQueryTagController.cs
@@ -105,6 +105,8 @@ namespace Microsoft.Health.Dicom.Api.Controllers
             [FromQuery, Range(1, 200)] int limit = 100,
             [FromQuery, Range(0, int.MaxValue)] int offset = 0)
         {
+            // TODO: Enforce the above data annotations with ModelState.IsValid or use the [ApiController] attribute
+            // for automatic error generation. However, we should change all errors across the API surface.
             _logger.LogInformation("DICOM Web Get Extended Query Tag request received for all extended query tags");
 
             EnsureFeatureIsEnabled();

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/AddExtendedQueryTagServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/AddExtendedQueryTagServiceTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.ExtendedQueryTag
                     Arg.Is(128),
                     Arg.Is(false),
                     Arg.Is(_tokenSource.Token))
-                .Returns(new List<int> { storeEntry.Key });
+                .Returns(new List<ExtendedQueryTagStoreEntry> { storeEntry });
             _client
                 .StartQueryTagIndexingAsync(
                     Arg.Is<IReadOnlyList<int>>(x => x.Single() == storeEntry.Key),

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/DeleteExtendedQueryTagServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/DeleteExtendedQueryTagServiceTests.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Dicom;
 using Microsoft.Health.Dicom.Core.Exceptions;
@@ -34,10 +33,18 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.ChangeFeed
         }
 
         [Fact]
-        public async Task GivenNotExistingTagPath_WhenDeleteExtendedQueryTagIsInvoked_ThenShouldThrowException()
+        public async Task GivenNotExistingTagPath_WhenDeleteExtendedQueryTagIsInvoked_ThenShouldPassException()
         {
-            _extendedQueryTagStore.GetExtendedQueryTagsAsync((string)default, default).ReturnsForAnyArgs(new List<ExtendedQueryTagStoreEntry>());
-            await Assert.ThrowsAsync<ExtendedQueryTagNotFoundException>(() => _extendedQueryTagService.DeleteExtendedQueryTagAsync(DicomTag.DeviceSerialNumber.GetPath()));
+            string path = DicomTag.DeviceSerialNumber.GetPath();
+            _extendedQueryTagStore
+                .GetExtendedQueryTagAsync(path, default)
+                .Returns(Task.FromException<ExtendedQueryTagStoreEntry>(new ExtendedQueryTagNotFoundException("Tag doesn't exist")));
+
+            await Assert.ThrowsAsync<ExtendedQueryTagNotFoundException>(() => _extendedQueryTagService.DeleteExtendedQueryTagAsync(path));
+
+            await _extendedQueryTagStore
+                .Received(1)
+                .GetExtendedQueryTagAsync(path, default);
         }
 
         [Fact]
@@ -46,10 +53,9 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.ChangeFeed
             DicomTag tag = DicomTag.DeviceSerialNumber;
             string tagPath = tag.GetPath();
             ExtendedQueryTagStoreEntry entry = tag.BuildExtendedQueryTagStoreEntry();
-            _extendedQueryTagStore.GetExtendedQueryTagsAsync((string)default, default).ReturnsForAnyArgs(new List<ExtendedQueryTagStoreEntry> { entry });
+            _extendedQueryTagStore.GetExtendedQueryTagAsync(tagPath, default).Returns(entry);
             await _extendedQueryTagService.DeleteExtendedQueryTagAsync(tagPath);
-            await _extendedQueryTagStore.ReceivedWithAnyArgs(1)
-                .DeleteExtendedQueryTagAsync(default, default);
+            await _extendedQueryTagStore.Received(1).DeleteExtendedQueryTagAsync(tagPath, entry.VR);
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/QueryTagServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/QueryTagServiceTests.cs
@@ -30,12 +30,12 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.ExtendedQueryTag
         [Fact]
         public async Task GivenValidInput_WhenGetExtendedQueryTagsIsCalledMultipleTimes_ThenExtendedQueryTagStoreIsCalledOnce()
         {
-            _extendedQueryTagStore.GetExtendedQueryTagsAsync((string)null, Arg.Any<CancellationToken>())
+            _extendedQueryTagStore.GetExtendedQueryTagsAsync(int.MaxValue, 0, Arg.Any<CancellationToken>())
                   .Returns(Array.Empty<ExtendedQueryTagStoreEntry>());
 
             await _queryTagService.GetQueryTagsAsync();
             await _queryTagService.GetQueryTagsAsync();
-            await _extendedQueryTagStore.Received(1).GetExtendedQueryTagsAsync((string)null, Arg.Any<CancellationToken>());
+            await _extendedQueryTagStore.Received(1).GetExtendedQueryTagsAsync(int.MaxValue, 0, Arg.Any<CancellationToken>());
         }
 
         [Fact]
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.ExtendedQueryTag
             FeatureConfiguration featureConfiguration = new FeatureConfiguration() { EnableExtendedQueryTags = false };
             IQueryTagService indexableDicomTagService = new QueryTagService(_extendedQueryTagStore, Options.Create(featureConfiguration));
             await indexableDicomTagService.GetQueryTagsAsync();
-            await _extendedQueryTagStore.DidNotReceive().GetExtendedQueryTagsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+            await _extendedQueryTagStore.DidNotReceiveWithAnyArgs().GetExtendedQueryTagsAsync(default, default, default);
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Messages/ExtendedQueryTag/GetExtendedQueryTagsRequestTest.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Messages/ExtendedQueryTag/GetExtendedQueryTagsRequestTest.cs
@@ -1,0 +1,22 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Dicom.Core.Exceptions;
+using Microsoft.Health.Dicom.Core.Messages.ExtendedQueryTag;
+using Xunit;
+
+namespace Microsoft.Health.Dicom.Core.UnitTests.Messages.ExtendedQueryTag
+{
+    public class GetExtendedQueryTagsRequestTest
+    {
+        [Fact]
+        public void GivenInvalidParameters_WhenCreateRequest_ThenThrowBadRequestException()
+        {
+            Assert.Throws<BadRequestException>(() => new GetExtendedQueryTagsRequest(0, 0));
+            Assert.Throws<BadRequestException>(() => new GetExtendedQueryTagsRequest(201, 0));
+            Assert.Throws<BadRequestException>(() => new GetExtendedQueryTagsRequest(10, -12));
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
@@ -585,6 +585,24 @@ namespace Microsoft.Health.Dicom.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Specified limit value {0} is outside the allowed range of {1}..{2}..
+        /// </summary>
+        internal static string PaginationLimitOutOfRange {
+            get {
+                return ResourceManager.GetString("PaginationLimitOutOfRange", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Specified offset value {0} cannot be negative..
+        /// </summary>
+        internal static string PaginationNegativeOffset {
+            get {
+                return ResourceManager.GetString("PaginationNegativeOffset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The private creator is not empty for standard tag &apos;{0}&apos;..
         /// </summary>
         internal static string PrivateCreatorNotEmpty {

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
@@ -397,4 +397,12 @@ The first part date {1} should be lesser than or equal to the second part date {
   <data name="SimpleErrorMessageUnexpectedVR" xml:space="preserve">
     <value>The extended query tag VR is not expected.</value>
   </data>
+  <data name="PaginationLimitOutOfRange" xml:space="preserve">
+    <value>Specified limit value {0} is outside the allowed range of {1}..{2}.</value>
+    <comment>{0} Specified page result limit. {1} min allowed. {2} max allowed.</comment>
+  </data>
+  <data name="PaginationNegativeOffset" xml:space="preserve">
+    <value>Specified offset value {0} cannot be negative.</value>
+    <comment>{0} Specified page offset.</comment>
+  </data>
 </root>

--- a/src/Microsoft.Health.Dicom.Core/Exceptions/ExtendedQueryTagNotFoundException.cs
+++ b/src/Microsoft.Health.Dicom.Core/Exceptions/ExtendedQueryTagNotFoundException.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Globalization;
+
 namespace Microsoft.Health.Dicom.Core.Exceptions
 {
     /// <summary>
@@ -10,8 +12,8 @@ namespace Microsoft.Health.Dicom.Core.Exceptions
     /// </summary>
     public class ExtendedQueryTagNotFoundException : ResourceNotFoundException
     {
-        public ExtendedQueryTagNotFoundException(string message)
-            : base(message)
+        public ExtendedQueryTagNotFoundException(string tagPath)
+            : base(string.Format(CultureInfo.InvariantCulture, DicomCoreResource.ExtendedQueryTagNotFound, tagPath))
         {
         }
     }

--- a/src/Microsoft.Health.Dicom.Core/Exceptions/ExtendedQueryTagNotFoundException.cs
+++ b/src/Microsoft.Health.Dicom.Core/Exceptions/ExtendedQueryTagNotFoundException.cs
@@ -3,8 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Globalization;
-
 namespace Microsoft.Health.Dicom.Core.Exceptions
 {
     /// <summary>
@@ -12,8 +10,8 @@ namespace Microsoft.Health.Dicom.Core.Exceptions
     /// </summary>
     public class ExtendedQueryTagNotFoundException : ResourceNotFoundException
     {
-        public ExtendedQueryTagNotFoundException(string tagPath)
-            : base(string.Format(CultureInfo.InvariantCulture, DicomCoreResource.ExtendedQueryTagNotFound, tagPath))
+        public ExtendedQueryTagNotFoundException(string message)
+            : base(message)
         {
         }
     }

--- a/src/Microsoft.Health.Dicom.Core/Extensions/DicomMediatorExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Extensions/DicomMediatorExtensions.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Health.Dicom.Core.Extensions
             this IMediator mediator, int limit, int offset, CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
-            return mediator.Send(new GetAllExtendedQueryTagsRequest(limit, offset), cancellationToken);
+            return mediator.Send(new GetExtendedQueryTagsRequest(limit, offset), cancellationToken);
         }
 
         public static Task<GetExtendedQueryTagResponse> GetExtendedQueryTagAsync(

--- a/src/Microsoft.Health.Dicom.Core/Extensions/DicomMediatorExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Extensions/DicomMediatorExtensions.cs
@@ -156,11 +156,11 @@ namespace Microsoft.Health.Dicom.Core.Extensions
             return mediator.Send(new DeleteExtendedQueryTagRequest(tagPath), cancellationToken);
         }
 
-        public static Task<GetAllExtendedQueryTagsResponse> GetAllExtendedQueryTagsAsync(
-            this IMediator mediator, CancellationToken cancellationToken)
+        public static Task<GetExtendedQueryTagsResponse> GetExtendedQueryTagsAsync(
+            this IMediator mediator, int limit, int offset, CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
-            return mediator.Send(new GetAllExtendedQueryTagsRequest(), cancellationToken);
+            return mediator.Send(new GetAllExtendedQueryTagsRequest(limit, offset), cancellationToken);
         }
 
         public static Task<GetExtendedQueryTagResponse> GetExtendedQueryTagAsync(

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/AddExtendedQueryTagService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/AddExtendedQueryTagService.cs
@@ -57,14 +57,14 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
                 .ToList();
 
             // Add the extended query tags to the DB
-            IReadOnlyList<int> addedKeys = await _extendedQueryTagStore.AddExtendedQueryTagsAsync(
+            IReadOnlyList<ExtendedQueryTagStoreEntry> added = await _extendedQueryTagStore.AddExtendedQueryTagsAsync(
                 normalized,
                 _maxAllowedCount,
                 ready: false,
                 cancellationToken: cancellationToken);
 
             // Start re-indexing
-            Guid operationId = await _client.StartQueryTagIndexingAsync(addedKeys, cancellationToken);
+            Guid operationId = await _client.StartQueryTagIndexingAsync(added.Select(x => x.Key).ToList(), cancellationToken);
             return new AddExtendedQueryTagResponse(new OperationReference(operationId, _uriResolver.ResolveOperationStatusUri(operationId)));
         }
     }

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/DeleteExtendedQueryTagService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/DeleteExtendedQueryTagService.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Collections.Generic;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
@@ -39,16 +38,8 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
             }
 
             string normalizedPath = tags[0].GetPath();
-            IReadOnlyList<ExtendedQueryTagStoreEntry> extendedQueryTagEntries = await _extendedQueryTagStore.GetExtendedQueryTagsAsync(normalizedPath, cancellationToken);
-
-            if (extendedQueryTagEntries.Count > 0)
-            {
-                await _extendedQueryTagStore.DeleteExtendedQueryTagAsync(normalizedPath, extendedQueryTagEntries[0].VR, cancellationToken);
-            }
-            else
-            {
-                throw new ExtendedQueryTagNotFoundException(string.Format(DicomCoreResource.ExtendedQueryTagNotFound, tagPath));
-            }
+            ExtendedQueryTagStoreEntry extendedQueryTagEntry = await _extendedQueryTagStore.GetExtendedQueryTagAsync(normalizedPath, cancellationToken);
+            await _extendedQueryTagStore.DeleteExtendedQueryTagAsync(normalizedPath, extendedQueryTagEntry.VR, cancellationToken);
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/GetExtendedQueryTagsHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/GetExtendedQueryTagsHandler.cs
@@ -15,18 +15,18 @@ using Microsoft.Health.Dicom.Core.Messages.ExtendedQueryTag;
 
 namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
 {
-    public class GetAllExtendedQueryTagsHandler : BaseHandler, IRequestHandler<GetAllExtendedQueryTagsRequest, GetAllExtendedQueryTagsResponse>
+    public class GetExtendedQueryTagsHandler : BaseHandler, IRequestHandler<GetAllExtendedQueryTagsRequest, GetExtendedQueryTagsResponse>
     {
         private readonly IGetExtendedQueryTagsService _getExtendedQueryTagsService;
 
-        public GetAllExtendedQueryTagsHandler(IAuthorizationService<DataActions> authorizationService, IGetExtendedQueryTagsService getExtendedQueryTagsService)
+        public GetExtendedQueryTagsHandler(IAuthorizationService<DataActions> authorizationService, IGetExtendedQueryTagsService getExtendedQueryTagsService)
             : base(authorizationService)
         {
             EnsureArg.IsNotNull(getExtendedQueryTagsService, nameof(getExtendedQueryTagsService));
             _getExtendedQueryTagsService = getExtendedQueryTagsService;
         }
 
-        public async Task<GetAllExtendedQueryTagsResponse> Handle(GetAllExtendedQueryTagsRequest request, CancellationToken cancellationToken)
+        public async Task<GetExtendedQueryTagsResponse> Handle(GetAllExtendedQueryTagsRequest request, CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(request, nameof(request));
 
@@ -35,7 +35,7 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
                 throw new UnauthorizedDicomActionException(DataActions.Read);
             }
 
-            return await _getExtendedQueryTagsService.GetAllExtendedQueryTagsAsync(cancellationToken);
+            return await _getExtendedQueryTagsService.GetExtendedQueryTagsAsync(request.Limit, request.Offset, cancellationToken);
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/GetExtendedQueryTagsHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/GetExtendedQueryTagsHandler.cs
@@ -15,7 +15,7 @@ using Microsoft.Health.Dicom.Core.Messages.ExtendedQueryTag;
 
 namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
 {
-    public class GetExtendedQueryTagsHandler : BaseHandler, IRequestHandler<GetAllExtendedQueryTagsRequest, GetExtendedQueryTagsResponse>
+    public class GetExtendedQueryTagsHandler : BaseHandler, IRequestHandler<GetExtendedQueryTagsRequest, GetExtendedQueryTagsResponse>
     {
         private readonly IGetExtendedQueryTagsService _getExtendedQueryTagsService;
 
@@ -26,7 +26,7 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
             _getExtendedQueryTagsService = getExtendedQueryTagsService;
         }
 
-        public async Task<GetExtendedQueryTagsResponse> Handle(GetAllExtendedQueryTagsRequest request, CancellationToken cancellationToken)
+        public async Task<GetExtendedQueryTagsResponse> Handle(GetExtendedQueryTagsRequest request, CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(request, nameof(request));
 

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/GetExtendedQueryTagsService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/GetExtendedQueryTagsService.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
             _dicomTagParser = dicomTagParser;
         }
 
-        public async Task<GetExtendedQueryTagResponse> GetExtendedQueryTagAsync(string tagPath, CancellationToken cancellationToken)
+        public async Task<GetExtendedQueryTagResponse> GetExtendedQueryTagAsync(string tagPath, CancellationToken cancellationToken = default)
         {
             string numericalTagPath = null;
             DicomTag[] tags;
@@ -49,21 +49,14 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
                 throw new InvalidExtendedQueryTagPathException(string.Format(DicomCoreResource.InvalidExtendedQueryTag, tagPath ?? string.Empty));
             }
 
-            IReadOnlyList<ExtendedQueryTagStoreEntry> extendedQueryTags = await _extendedQueryTagStore.GetExtendedQueryTagsAsync(numericalTagPath, cancellationToken);
-
-            if (!extendedQueryTags.Any())
-            {
-                throw new ExtendedQueryTagNotFoundException(string.Format(DicomCoreResource.ExtendedQueryTagNotFound, tagPath));
-            }
-
-            return new GetExtendedQueryTagResponse(extendedQueryTags[0].ToExtendedQueryTagEntry());
+            ExtendedQueryTagStoreEntry extendedQueryTag = await _extendedQueryTagStore.GetExtendedQueryTagAsync(numericalTagPath, cancellationToken);
+            return new GetExtendedQueryTagResponse(extendedQueryTag.ToExtendedQueryTagEntry());
         }
 
-        public async Task<GetAllExtendedQueryTagsResponse> GetAllExtendedQueryTagsAsync(CancellationToken cancellationToken)
+        public async Task<GetExtendedQueryTagsResponse> GetExtendedQueryTagsAsync(int limit, int offset = 0, CancellationToken cancellationToken = default)
         {
-            IReadOnlyList<ExtendedQueryTagStoreEntry> extendedQueryTags = await _extendedQueryTagStore.GetExtendedQueryTagsAsync((string)null, cancellationToken);
-
-            return new GetAllExtendedQueryTagsResponse(extendedQueryTags.Select(x => x.ToExtendedQueryTagEntry()));
+            IReadOnlyList<ExtendedQueryTagStoreEntry> extendedQueryTags = await _extendedQueryTagStore.GetExtendedQueryTagsAsync(limit, offset, cancellationToken);
+            return new GetExtendedQueryTagsResponse(extendedQueryTags.Select(x => x.ToExtendedQueryTagEntry()));
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/IExtendedQueryTagStore.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/IExtendedQueryTagStore.cs
@@ -26,22 +26,42 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         /// </param>
         /// <returns>
         /// A task representing the asynchronous add operation. The value of its <see cref="Task{TResult}.Result"/>
-        /// property contains the keys for the <paramref name="extendedQueryTagEntries"/> in the store.
+        /// property contains the added extended query tags.
         /// </returns>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        Task<IReadOnlyList<int>> AddExtendedQueryTagsAsync(
+        Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> AddExtendedQueryTagsAsync(
             IEnumerable<AddExtendedQueryTagEntry> extendedQueryTagEntries,
             int maxAllowedCount,
             bool ready = false,
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Get the stored extended query tag from ExtendedQueryTagStore by its path.
+        /// </summary>
+        /// <param name="tagPath">Path associated with requested extended query tag formatted as it is stored internally.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>
+        /// A task representing the asynchronous get operation. The value of its <see cref="Task{TResult}.Result"/>
+        /// property contains the tag's information as found in storage.
+        /// </returns>
+        Task<ExtendedQueryTagStoreEntry> GetExtendedQueryTagAsync(string tagPath, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Get stored extended query tags from ExtendedQueryTagStore, if provided, by tagPath.
         /// </summary>
-        /// <param name="path">Path associated with requested extended query tag formatted as it is stored internally.</param>
+        /// <param name="limit">The maximum number of results to retrieve.</param>
+        /// <param name="offset">The offset from which to retrieve paginated results.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>Extended Query tag entry/entries with path, VR, level and status.</returns>
-        Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsAsync(string path = null, CancellationToken cancellationToken = default);
+        /// <returns>
+        /// A task representing the asynchronous get operation. The value of its <see cref="Task{TResult}.Result"/>
+        /// property contains a list of the tags' information as found in storage.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <para><paramref name="limit"/> is less than <c>1</c> or greater than <c>200</c></para>
+        /// <para>-or-</para>
+        /// <para><paramref name="offset"/> is less than <c>0</c>.</para>
+        /// </exception>
+        Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsAsync(int limit, int offset = 0, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Asynchronously gets extended query tags by keys.

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/IExtendedQueryTagStore.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/IExtendedQueryTagStore.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         /// property contains a list of the tags' information as found in storage.
         /// </returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        /// <para><paramref name="limit"/> is less than <c>1</c> or greater than <c>200</c></para>
+        /// <para><paramref name="limit"/> is less than <c>1</c></para>
         /// <para>-or-</para>
         /// <para><paramref name="offset"/> is less than <c>0</c>.</para>
         /// </exception>

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/IGetExtendedQueryTagsService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/IGetExtendedQueryTagsService.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Health.Dicom.Core.Messages.ExtendedQueryTag;
@@ -22,8 +23,15 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         /// <summary>
         /// Gets all stored Extended Query Tags.
         /// </summary>
+        /// <param name="limit">The maximum number of results to retrieve.</param>
+        /// <param name="offset">The offset from which to retrieve paginated results.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The response.</returns>
-        public Task<GetAllExtendedQueryTagsResponse> GetAllExtendedQueryTagsAsync(CancellationToken cancellationToken = default);
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <para><paramref name="limit"/> is less than <c>1</c> or greater than <c>200</c></para>
+        /// <para>-or-</para>
+        /// <para><paramref name="offset"/> is less than <c>0</c>.</para>
+        /// </exception>
+        public Task<GetExtendedQueryTagsResponse> GetExtendedQueryTagsAsync(int limit, int offset = 0, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/QueryTagService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/QueryTagService.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         private async Task<List<QueryTag>> ResolveQueryTagsAsync(CancellationToken cancellationToken)
         {
             var tags = new List<QueryTag>(CoreQueryTags);
-            IReadOnlyList<ExtendedQueryTagStoreEntry> extendedQueryTags = await _extendedQueryTagStore.GetExtendedQueryTagsAsync(cancellationToken: cancellationToken);
+            IReadOnlyList<ExtendedQueryTagStoreEntry> extendedQueryTags = await _extendedQueryTagStore.GetExtendedQueryTagsAsync(int.MaxValue, 0, cancellationToken);
             tags.AddRange(extendedQueryTags.Select(entry => new QueryTag(entry)));
 
             return tags;

--- a/src/Microsoft.Health.Dicom.Core/Messages/ExtendedQueryTag/GetAllExtendedQueryTagsRequest.cs
+++ b/src/Microsoft.Health.Dicom.Core/Messages/ExtendedQueryTag/GetAllExtendedQueryTagsRequest.cs
@@ -7,10 +7,16 @@ using MediatR;
 
 namespace Microsoft.Health.Dicom.Core.Messages.ExtendedQueryTag
 {
-    public class GetAllExtendedQueryTagsRequest : IRequest<GetAllExtendedQueryTagsResponse>
+    public class GetAllExtendedQueryTagsRequest : IRequest<GetExtendedQueryTagsResponse>
     {
-        public GetAllExtendedQueryTagsRequest()
+        public GetAllExtendedQueryTagsRequest(int limit, int offset)
         {
+            Limit = limit;
+            Offset = offset;
         }
+
+        public int Limit { get; }
+
+        public int Offset { get; }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Messages/ExtendedQueryTag/GetExtendedQueryTagsRequest.cs
+++ b/src/Microsoft.Health.Dicom.Core/Messages/ExtendedQueryTag/GetExtendedQueryTagsRequest.cs
@@ -4,13 +4,24 @@
 // -------------------------------------------------------------------------------------------------
 
 using MediatR;
+using Microsoft.Health.Dicom.Core.Exceptions;
 
 namespace Microsoft.Health.Dicom.Core.Messages.ExtendedQueryTag
 {
-    public class GetAllExtendedQueryTagsRequest : IRequest<GetExtendedQueryTagsResponse>
+    public class GetExtendedQueryTagsRequest : IRequest<GetExtendedQueryTagsResponse>
     {
-        public GetAllExtendedQueryTagsRequest(int limit, int offset)
+        public GetExtendedQueryTagsRequest(int limit, int offset)
         {
+            if (limit < 1 || limit > 200)
+            {
+                throw new BadRequestException(string.Format(DicomCoreResource.PaginationLimitOutOfRange, limit, 1, 200));
+            }
+
+            if (offset < 0)
+            {
+                throw new BadRequestException(string.Format(DicomCoreResource.PaginationNegativeOffset, offset));
+            }
+
             Limit = limit;
             Offset = offset;
         }

--- a/src/Microsoft.Health.Dicom.Core/Messages/ExtendedQueryTag/GetExtendedQueryTagsResponse.cs
+++ b/src/Microsoft.Health.Dicom.Core/Messages/ExtendedQueryTag/GetExtendedQueryTagsResponse.cs
@@ -8,9 +8,9 @@ using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 
 namespace Microsoft.Health.Dicom.Core.Messages.ExtendedQueryTag
 {
-    public class GetAllExtendedQueryTagsResponse
+    public class GetExtendedQueryTagsResponse
     {
-        public GetAllExtendedQueryTagsResponse(IEnumerable<GetExtendedQueryTagEntry> extendedQueryTagEntries)
+        public GetExtendedQueryTagsResponse(IEnumerable<GetExtendedQueryTagEntry> extendedQueryTagEntries)
         {
             ExtendedQueryTags = extendedQueryTagEntries;
         }

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/SqlExtendedQueryTagStore.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/SqlExtendedQueryTagStore.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
         public SqlExtendedQueryTagStore(VersionedCache<ISqlExtendedQueryTagStore> cache)
             => _cache = EnsureArg.IsNotNull(cache, nameof(cache));
 
-        public async Task<IReadOnlyList<int>> AddExtendedQueryTagsAsync(IEnumerable<AddExtendedQueryTagEntry> extendedQueryTagEntries, int maxAllowedCount, bool ready = false, CancellationToken cancellationToken = default)
+        public async Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> AddExtendedQueryTagsAsync(IEnumerable<AddExtendedQueryTagEntry> extendedQueryTagEntries, int maxAllowedCount, bool ready = false, CancellationToken cancellationToken = default)
         {
             ISqlExtendedQueryTagStore store = await _cache.GetAsync(cancellationToken: cancellationToken);
             return await store.AddExtendedQueryTagsAsync(extendedQueryTagEntries, maxAllowedCount, ready, cancellationToken);
@@ -44,10 +44,16 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
             await store.DeleteExtendedQueryTagAsync(tagPath, vr, cancellationToken);
         }
 
-        public async Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsAsync(string path = null, CancellationToken cancellationToken = default)
+        public async Task<ExtendedQueryTagStoreEntry> GetExtendedQueryTagAsync(string tagPath, CancellationToken cancellationToken = default)
         {
             ISqlExtendedQueryTagStore store = await _cache.GetAsync(cancellationToken: cancellationToken);
-            return await store.GetExtendedQueryTagsAsync(path, cancellationToken);
+            return await store.GetExtendedQueryTagAsync(tagPath, cancellationToken);
+        }
+
+        public async Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsAsync(int limit, int offset, CancellationToken cancellationToken = default)
+        {
+            ISqlExtendedQueryTagStore store = await _cache.GetAsync(cancellationToken: cancellationToken);
+            return await store.GetExtendedQueryTagsAsync(limit, offset, cancellationToken);
         }
 
         public async Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsAsync(IReadOnlyList<int> queryTagKeys, CancellationToken cancellationToken = default)

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/SqlExtendedQueryTagStoreV1.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/SqlExtendedQueryTagStoreV1.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
     {
         public virtual SchemaVersion Version => SchemaVersion.V1;
 
-        public virtual Task<IReadOnlyList<int>> AddExtendedQueryTagsAsync(
+        public virtual Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> AddExtendedQueryTagsAsync(
             IEnumerable<AddExtendedQueryTagEntry> extendedQueryTagEntries,
             int maxCount,
             bool ready = false,
@@ -26,7 +26,12 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
             throw new BadRequestException(DicomSqlServerResource.SchemaVersionNeedsToBeUpgraded);
         }
 
-        public virtual Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsAsync(string path, CancellationToken cancellationToken = default)
+        public virtual Task<ExtendedQueryTagStoreEntry> GetExtendedQueryTagAsync(string tagPath, CancellationToken cancellationToken = default)
+        {
+            throw new BadRequestException(DicomSqlServerResource.SchemaVersionNeedsToBeUpgraded);
+        }
+
+        public virtual Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsAsync(int limit, int offset, CancellationToken cancellationToken = default)
         {
             throw new BadRequestException(DicomSqlServerResource.SchemaVersionNeedsToBeUpgraded);
         }

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/SqlExtendedQueryTagStoreV2.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/SqlExtendedQueryTagStoreV2.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
+using Microsoft.Health.Dicom.Core;
 using Microsoft.Health.Dicom.Core.Exceptions;
 using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 using Microsoft.Health.Dicom.SqlServer.Features.Schema;
@@ -42,7 +43,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
 
         protected ILogger Logger { get; }
 
-        public override async Task<IReadOnlyList<int>> AddExtendedQueryTagsAsync(
+        public override async Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> AddExtendedQueryTagsAsync(
             IEnumerable<AddExtendedQueryTagEntry> extendedQueryTagEntries,
             int maxCount,
             bool ready = false,
@@ -63,8 +64,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
                 try
                 {
                     await sqlCommandWrapper.ExecuteNonQueryAsync(cancellationToken);
-                    var allTags = (await GetExtendedQueryTagsAsync(path: null, cancellationToken: cancellationToken))
-                        .ToDictionary(x => x.Path, x => x.Key);
+                    var allTags = (await GetAllExtendedQueryTagsAsync(cancellationToken)).ToDictionary(x => x.Path);
 
                     return extendedQueryTagEntries
                         .Select(x => allTags[x.Path])
@@ -72,22 +72,17 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
                 }
                 catch (SqlException ex)
                 {
-                    switch (ex.Number)
+                    throw ex.Number switch
                     {
-                        case SqlErrorCodes.Conflict:
-                            throw new ExtendedQueryTagsAlreadyExistsException();
-
-                        default:
-                            throw new DataStoreException(ex);
-                    }
+                        SqlErrorCodes.Conflict => new ExtendedQueryTagsAlreadyExistsException(),
+                        _ => new DataStoreException(ex),
+                    };
                 }
             }
         }
 
-        public override async Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsAsync(string path, CancellationToken cancellationToken = default)
+        public override async Task<ExtendedQueryTagStoreEntry> GetExtendedQueryTagAsync(string path, CancellationToken cancellationToken = default)
         {
-            List<ExtendedQueryTagStoreEntry> results = new List<ExtendedQueryTagStoreEntry>();
-
             using (SqlConnectionWrapper sqlConnectionWrapper = await ConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken))
             using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateSqlCommand())
             {
@@ -96,25 +91,25 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
                 var executionTimeWatch = Stopwatch.StartNew();
                 using (var reader = await sqlCommandWrapper.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken))
                 {
-                    while (await reader.ReadAsync(cancellationToken))
+                    if (!await reader.ReadAsync(cancellationToken))
                     {
-                        (int tagKey, string tagPath, string tagVR, string tagPrivateCreator, int tagLevel, int tagStatus) = reader.ReadRow(
-                            V2.ExtendedQueryTag.TagKey,
-                            V2.ExtendedQueryTag.TagPath,
-                            V2.ExtendedQueryTag.TagVR,
-                            V2.ExtendedQueryTag.TagPrivateCreator,
-                            V2.ExtendedQueryTag.TagLevel,
-                            V2.ExtendedQueryTag.TagStatus);
-
-                        results.Add(new ExtendedQueryTagStoreEntry(tagKey, tagPath, tagVR, tagPrivateCreator, (QueryTagLevel)tagLevel, (ExtendedQueryTagStatus)tagStatus));
+                        throw new ExtendedQueryTagNotFoundException(string.Format(DicomCoreResource.ExtendedQueryTagNotFound, path));
                     }
+
+                    (int tagKey, string tagPath, string tagVR, string tagPrivateCreator, int tagLevel, int tagStatus) = reader.ReadRow(
+                        V2.ExtendedQueryTag.TagKey,
+                        V2.ExtendedQueryTag.TagPath,
+                        V2.ExtendedQueryTag.TagVR,
+                        V2.ExtendedQueryTag.TagPrivateCreator,
+                        V2.ExtendedQueryTag.TagLevel,
+                        V2.ExtendedQueryTag.TagStatus);
 
                     executionTimeWatch.Stop();
                     Logger.LogInformation(executionTimeWatch.ElapsedMilliseconds.ToString());
+
+                    return new ExtendedQueryTagStoreEntry(tagKey, tagPath, tagVR, tagPrivateCreator, (QueryTagLevel)tagLevel, (ExtendedQueryTagStatus)tagStatus);
                 }
             }
-
-            return results;
         }
 
         internal static AddExtendedQueryTagsInputTableTypeV1Row ToAddExtendedQueryTagsInputTableTypeV1Row(AddExtendedQueryTagEntry entry)
@@ -148,6 +143,40 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
                     }
                 }
             }
+        }
+
+        private async Task<List<ExtendedQueryTagStoreEntry>> GetAllExtendedQueryTagsAsync(CancellationToken cancellationToken = default)
+        {
+            List<ExtendedQueryTagStoreEntry> results = new List<ExtendedQueryTagStoreEntry>();
+
+            using (SqlConnectionWrapper sqlConnectionWrapper = await ConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken))
+            using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateSqlCommand())
+            {
+                // V2 version allows NULL to get all tags
+                V2.GetExtendedQueryTag.PopulateCommand(sqlCommandWrapper, null);
+
+                var executionTimeWatch = Stopwatch.StartNew();
+                using (var reader = await sqlCommandWrapper.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken))
+                {
+                    while (await reader.ReadAsync(cancellationToken))
+                    {
+                        (int tagKey, string tagPath, string tagVR, string tagPrivateCreator, int tagLevel, int tagStatus) = reader.ReadRow(
+                            V2.ExtendedQueryTag.TagKey,
+                            V2.ExtendedQueryTag.TagPath,
+                            V2.ExtendedQueryTag.TagVR,
+                            V2.ExtendedQueryTag.TagPrivateCreator,
+                            V2.ExtendedQueryTag.TagLevel,
+                            V2.ExtendedQueryTag.TagStatus);
+
+                        results.Add(new ExtendedQueryTagStoreEntry(tagKey, tagPath, tagVR, tagPrivateCreator, (QueryTagLevel)tagLevel, (ExtendedQueryTagStatus)tagStatus));
+                    }
+
+                    executionTimeWatch.Stop();
+                    Logger.LogInformation(executionTimeWatch.ElapsedMilliseconds.ToString());
+                }
+            }
+
+            return results;
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/SqlExtendedQueryTagStoreV4.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/SqlExtendedQueryTagStoreV4.cs
@@ -33,14 +33,14 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
 
         public override SchemaVersion Version => SchemaVersion.V4;
 
-        public override async Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsAsync(string path, CancellationToken cancellationToken = default)
+        public override async Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsAsync(int limit, int offset = 0, CancellationToken cancellationToken = default)
         {
             List<ExtendedQueryTagStoreEntry> results = new List<ExtendedQueryTagStoreEntry>();
 
             using (SqlConnectionWrapper sqlConnectionWrapper = await ConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken))
             using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateSqlCommand())
             {
-                VLatest.GetExtendedQueryTag.PopulateCommand(sqlCommandWrapper, path);
+                VLatest.GetExtendedQueryTags.PopulateCommand(sqlCommandWrapper, limit, offset);
 
                 var executionTimeWatch = Stopwatch.StartNew();
                 using (var reader = await sqlCommandWrapper.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken))
@@ -70,7 +70,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
         {
             EnsureArg.HasItems(queryTagKeys, nameof(queryTagKeys));
 
-            List<ExtendedQueryTagStoreEntry> results = new List<ExtendedQueryTagStoreEntry>();
+            var results = new List<ExtendedQueryTagStoreEntry>();
 
             using (SqlConnectionWrapper sqlConnectionWrapper = await ConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken))
             using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateSqlCommand())
@@ -131,7 +131,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
             return results;
         }
 
-        public override async Task<IReadOnlyList<int>> AddExtendedQueryTagsAsync(
+        public override async Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> AddExtendedQueryTagsAsync(
             IEnumerable<AddExtendedQueryTagEntry> extendedQueryTagEntries,
             int maxAllowedCount,
             bool ready = false,
@@ -148,14 +148,22 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
 
             try
             {
-                var keys = new List<int>();
+                var results = new List<ExtendedQueryTagStoreEntry>();
                 using SqlDataReader reader = await sqlCommandWrapper.ExecuteReaderAsync(cancellationToken);
                 while (await reader.ReadAsync(cancellationToken))
                 {
-                    keys.Add(reader.ReadRow(VLatest.ExtendedQueryTagString.TagKey));
+                    (int tagKey, string tagPath, string tagVR, string tagPrivateCreator, int tagLevel, int tagStatus) = reader.ReadRow(
+                            VLatest.ExtendedQueryTag.TagKey,
+                            VLatest.ExtendedQueryTag.TagPath,
+                            VLatest.ExtendedQueryTag.TagVR,
+                            VLatest.ExtendedQueryTag.TagPrivateCreator,
+                            VLatest.ExtendedQueryTag.TagLevel,
+                            VLatest.ExtendedQueryTag.TagStatus);
+
+                    results.Add(new ExtendedQueryTagStoreEntry(tagKey, tagPath, tagVR, tagPrivateCreator, (QueryTagLevel)tagLevel, (ExtendedQueryTagStatus)tagStatus));
                 }
 
-                return keys;
+                return results;
             }
             catch (SqlException ex)
             {

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/SqlExtendedQueryTagStoreV4.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/SqlExtendedQueryTagStoreV4.cs
@@ -35,7 +35,10 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
 
         public override async Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsAsync(int limit, int offset = 0, CancellationToken cancellationToken = default)
         {
-            List<ExtendedQueryTagStoreEntry> results = new List<ExtendedQueryTagStoreEntry>();
+            EnsureArg.IsGte(limit, 1, nameof(limit));
+            EnsureArg.IsGte(offset, 0, nameof(offset));
+
+            var results = new List<ExtendedQueryTagStoreEntry>();
 
             using (SqlConnectionWrapper sqlConnectionWrapper = await ConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken))
             using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateSqlCommand())

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.diff.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.diff.sql
@@ -963,6 +963,38 @@ GO
 
 /***************************************************************************************/
 -- STORED PROCEDURE
+--     GetExtendedQueryTag
+--
+-- DESCRIPTION
+--     Gets all extended query tags or given extended query tag by tag path
+--
+-- PARAMETERS
+--     @tagPath
+--         * The TagPath for the extended query tag to retrieve.
+-- RETURN VALUE
+--     The desired extended query tag, if found.
+/***************************************************************************************/
+CREATE OR ALTER PROCEDURE dbo.GetExtendedQueryTag (
+    @tagPath  VARCHAR(64) = NULL -- Support NULL for backwards compatibility
+)
+AS
+BEGIN
+    SET NOCOUNT     ON
+    SET XACT_ABORT  ON
+
+    SELECT TagKey,
+           TagPath,
+           TagVR,
+           TagPrivateCreator,
+           TagLevel,
+           TagStatus
+    FROM dbo.ExtendedQueryTag
+    WHERE TagPath = ISNULL(@tagPath, TagPath)
+END
+GO
+
+/***************************************************************************************/
+-- STORED PROCEDURE
 --     GetExtendedQueryTags
 --
 -- DESCRIPTION

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.diff.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.diff.sql
@@ -487,7 +487,7 @@ GO
 --         * Indicates whether the new query tags have been fully indexed
 --
 -- RETURN VALUE
---     The keys for the added tags.
+--     The added extended query tags.
 /***************************************************************************************/
 ALTER PROCEDURE dbo.AddExtendedQueryTags (
     @extendedQueryTags dbo.AddExtendedQueryTagsInputTableType_1 READONLY,
@@ -531,7 +531,13 @@ AS
         -- Add the new tags with the given status
         INSERT INTO dbo.ExtendedQueryTag
             (TagKey, TagPath, TagPrivateCreator, TagVR, TagLevel, TagStatus)
-        OUTPUT INSERTED.TagKey
+        OUTPUT
+            INSERTED.TagKey,
+            INSERTED.TagPath,
+            INSERTED.TagVR,
+            INSERTED.TagPrivateCreator,
+            INSERTED.TagLevel,
+            INSERTED.TagStatus
         SELECT NEXT VALUE FOR TagKeySequence, TagPath, TagPrivateCreator, TagVR, TagLevel, @ready FROM @extendedQueryTags
 
     COMMIT TRANSACTION
@@ -957,31 +963,38 @@ GO
 
 /***************************************************************************************/
 -- STORED PROCEDURE
---     GetExtendedQueryTag(s)
+--     GetExtendedQueryTags
 --
 -- DESCRIPTION
---     Gets all extended query tags or given extended query tag by tag path
+--     Gets a possibly paginated set of query tags as indicated by the parameters
 --
 -- PARAMETERS
---     @tagPath
---         * The TagPath for the extended query tag to retrieve.
+--     @limit
+--         * The maximum number of results to retrieve.
+--     @offset
+--         * The offset from which to retrieve paginated results.
+--
+-- RETURN VALUE
+--     The set of query tags.
 /***************************************************************************************/
-ALTER PROCEDURE dbo.GetExtendedQueryTag (
-    @tagPath  VARCHAR(64) = NULL
-)
+CREATE OR ALTER PROCEDURE dbo.GetExtendedQueryTags
+    @limit INT,
+    @offset INT
 AS
 BEGIN
     SET NOCOUNT     ON
     SET XACT_ABORT  ON
 
-    SELECT  TagKey,
-            TagPath,
-            TagVR,
-            TagPrivateCreator,
-            TagLevel,
-            TagStatus
-    FROM    dbo.ExtendedQueryTag
-    WHERE   TagPath                 = ISNULL(@tagPath, TagPath)
+    SELECT TagKey,
+           TagPath,
+           TagVR,
+           TagPrivateCreator,
+           TagLevel,
+           TagStatus
+    FROM dbo.ExtendedQueryTag
+    ORDER BY TagKey ASC
+    OFFSET @offset ROWS
+    FETCH NEXT @limit ROWS ONLY
 END
 GO
 

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.sql
@@ -1814,6 +1814,43 @@ GO
 
 /***************************************************************************************/
 -- STORED PROCEDURE
+--     GetExtendedQueryTags
+--
+-- DESCRIPTION
+--     Gets a possibly paginated set of query tags as indicated by the parameters
+--
+-- PARAMETERS
+--     @limit
+--         * The maximum number of results to retrieve.
+--     @offset
+--         * The offset from which to retrieve paginated results.
+--
+-- RETURN VALUE
+--     The set of query tags.
+/***************************************************************************************/
+CREATE OR ALTER PROCEDURE dbo.GetExtendedQueryTags
+    @limit INT,
+    @offset INT
+AS
+BEGIN
+    SET NOCOUNT     ON
+    SET XACT_ABORT  ON
+
+    SELECT TagKey,
+           TagPath,
+           TagVR,
+           TagPrivateCreator,
+           TagLevel,
+           TagStatus
+    FROM dbo.ExtendedQueryTag
+    ORDER BY TagKey ASC
+    OFFSET @offset ROWS
+    FETCH NEXT @limit ROWS ONLY
+END
+GO
+
+/***************************************************************************************/
+-- STORED PROCEDURE
 --     GetExtendedQueryTagsByKey
 --
 -- DESCRIPTION
@@ -1939,7 +1976,7 @@ GO
 --         * Indicates whether the new query tags have been fully indexed
 --
 -- RETURN VALUE
---     The keys for the added tags.
+--     The added extended query tags.
 /***************************************************************************************/
 CREATE OR ALTER PROCEDURE dbo.AddExtendedQueryTags (
     @extendedQueryTags dbo.AddExtendedQueryTagsInputTableType_1 READONLY,
@@ -1983,7 +2020,13 @@ AS
         -- Add the new tags with the given status
         INSERT INTO dbo.ExtendedQueryTag
             (TagKey, TagPath, TagPrivateCreator, TagVR, TagLevel, TagStatus)
-        OUTPUT INSERTED.TagKey
+        OUTPUT
+            INSERTED.TagKey,
+            INSERTED.TagPath,
+            INSERTED.TagVR,
+            INSERTED.TagPrivateCreator,
+            INSERTED.TagLevel,
+            INSERTED.TagStatus
         SELECT NEXT VALUE FOR TagKeySequence, TagPath, TagPrivateCreator, TagVR, TagLevel, @ready FROM @extendedQueryTags
 
     COMMIT TRANSACTION

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.sql
@@ -1784,7 +1784,7 @@ GO
 
 /***************************************************************************************/
 -- STORED PROCEDURE
---     GetExtendedQueryTag(s)
+--     GetExtendedQueryTag
 --
 -- DESCRIPTION
 --     Gets all extended query tags or given extended query tag by tag path
@@ -1792,23 +1792,25 @@ GO
 -- PARAMETERS
 --     @tagPath
 --         * The TagPath for the extended query tag to retrieve.
+-- RETURN VALUE
+--     The desired extended query tag, if found.
 /***************************************************************************************/
-CREATE PROCEDURE dbo.GetExtendedQueryTag (
-    @tagPath  VARCHAR(64) = NULL
+CREATE OR ALTER PROCEDURE dbo.GetExtendedQueryTag (
+    @tagPath  VARCHAR(64) = NULL -- Support NULL for backwards compatibility
 )
 AS
 BEGIN
     SET NOCOUNT     ON
     SET XACT_ABORT  ON
 
-    SELECT  TagKey,
-            TagPath,
-            TagVR,
-            TagPrivateCreator,
-            TagLevel,
-            TagStatus
-    FROM    dbo.ExtendedQueryTag
-    WHERE   TagPath                 = ISNULL(@tagPath, TagPath)
+    SELECT TagKey,
+           TagPath,
+           TagVR,
+           TagPrivateCreator,
+           TagLevel,
+           TagStatus
+    FROM dbo.ExtendedQueryTag
+    WHERE TagPath = ISNULL(@tagPath, TagPath)
 END
 GO
 

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Model/VLatest.Generated.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Model/VLatest.Generated.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.Schema.Model
         internal readonly static GetChangeFeedLatestProcedure GetChangeFeedLatest = new GetChangeFeedLatestProcedure();
         internal readonly static GetExtendedQueryTagProcedure GetExtendedQueryTag = new GetExtendedQueryTagProcedure();
         internal readonly static GetExtendedQueryTagErrorsProcedure GetExtendedQueryTagErrors = new GetExtendedQueryTagErrorsProcedure();
+        internal readonly static GetExtendedQueryTagsProcedure GetExtendedQueryTags = new GetExtendedQueryTagsProcedure();
         internal readonly static GetExtendedQueryTagsByKeyProcedure GetExtendedQueryTagsByKey = new GetExtendedQueryTagsByKeyProcedure();
         internal readonly static GetExtendedQueryTagsByOperationProcedure GetExtendedQueryTagsByOperation = new GetExtendedQueryTagsByOperationProcedure();
         internal readonly static GetInstanceProcedure GetInstance = new GetInstanceProcedure();
@@ -786,6 +787,24 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.Schema.Model
                 command.CommandType = global::System.Data.CommandType.StoredProcedure;
                 command.CommandText = "dbo.GetExtendedQueryTagErrors";
                 _tagPath.AddParameter(command.Parameters, tagPath);
+            }
+        }
+
+        internal class GetExtendedQueryTagsProcedure : StoredProcedure
+        {
+            internal GetExtendedQueryTagsProcedure() : base("dbo.GetExtendedQueryTags")
+            {
+            }
+
+            private readonly ParameterDefinition<System.Int32> _limit = new ParameterDefinition<System.Int32>("@limit", global::System.Data.SqlDbType.Int, false);
+            private readonly ParameterDefinition<System.Int32> _offset = new ParameterDefinition<System.Int32>("@offset", global::System.Data.SqlDbType.Int, false);
+
+            public void PopulateCommand(SqlCommandWrapper command, System.Int32 limit, System.Int32 offset)
+            {
+                command.CommandType = global::System.Data.CommandType.StoredProcedure;
+                command.CommandText = "dbo.GetExtendedQueryTags";
+                _limit.AddParameter(command.Parameters, limit);
+                _offset.AddParameter(command.Parameters, offset);
             }
         }
 

--- a/src/Microsoft.Health.Dicom.SqlServer/Microsoft.Health.Dicom.SqlServer.csproj
+++ b/src/Microsoft.Health.Dicom.SqlServer/Microsoft.Health.Dicom.SqlServer.csproj
@@ -42,7 +42,6 @@
     </EmbeddedResource>
   </ItemGroup>
     <ItemGroup>
-    <Folder Include="Extensions\" />
     <Folder Include="Features\Schema\Model\" />
   </ItemGroup>
 

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/ExtendedQueryTagErrorStoreTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/ExtendedQueryTagErrorStoreTests.cs
@@ -76,10 +76,8 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
         [Fact]
         public async Task GivenNonExistingQueryTag_WhenAddExtendedQueryTagError_ThenShouldThrowException()
         {
-            var extendedQueryTag = await _extendedQueryTagStore.GetExtendedQueryTagsAsync();
-            Assert.Equal(0, extendedQueryTag.Count);
             await Assert.ThrowsAsync<ExtendedQueryTagNotFoundException>(
-                () => _extendedQueryTagErrorStore.AddExtendedQueryTagErrorAsync(1, ValidationErrorCode.InvalidCharacters, 1));
+                () => _extendedQueryTagErrorStore.AddExtendedQueryTagErrorAsync(int.MaxValue, ValidationErrorCode.InvalidCharacters, 1));
         }
 
         [Fact]
@@ -98,17 +96,15 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             var extendedQueryTagErrorBeforeTagDeletion = await _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tag.GetPath());
             Assert.Equal(1, extendedQueryTagErrorBeforeTagDeletion.Count);
 
-            var extendedQueryTagBeforeTagDeletion = await _extendedQueryTagStore.GetExtendedQueryTagsAsync(tag.GetPath());
-            Assert.Equal(1, extendedQueryTagBeforeTagDeletion.Count);
+            var extendedQueryTagBeforeTagDeletion = await _extendedQueryTagStore.GetExtendedQueryTagAsync(tag.GetPath());
 
             await _extendedQueryTagStore.DeleteExtendedQueryTagAsync(tag.GetPath(), tag.GetDefaultVR().Code);
 
             await Assert.ThrowsAsync<ExtendedQueryTagNotFoundException>(
+                () => _extendedQueryTagStore.GetExtendedQueryTagAsync(tag.GetPath()));
+            await Assert.ThrowsAsync<ExtendedQueryTagNotFoundException>(
                 () => _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tag.GetPath()));
             Assert.False(await _errorStoreTestHelper.DoesExtendedQueryTagErrorExistAsync(tagKey));
-
-            var extendedQueryTagAfterTagDeletion = await _extendedQueryTagStore.GetExtendedQueryTagsAsync(tag.GetPath());
-            Assert.Equal(0, extendedQueryTagAfterTagDeletion.Count);
         }
 
         [Fact]
@@ -336,7 +332,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
         {
             AddExtendedQueryTagEntry extendedQueryTagEntry = tag.BuildAddExtendedQueryTagEntry();
             var list = await _extendedQueryTagStore.AddExtendedQueryTagsAsync(new AddExtendedQueryTagEntry[] { extendedQueryTagEntry }, 128);
-            return list[0];
+            return list[0].Key;
         }
     }
 }

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/IndexDataStoreTests.ExtendedQueryTag.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/IndexDataStoreTests.ExtendedQueryTag.cs
@@ -314,8 +314,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
 
         private async Task<IReadOnlyList<QueryTag>> AddExtendedQueryTags(IEnumerable<AddExtendedQueryTagEntry> extendedQueryTags)
         {
-            await _extendedQueryTagStore.AddExtendedQueryTagsAsync(extendedQueryTags, maxAllowedCount: 128, ready: true);
-            var extendedQueryTagEntries = await _extendedQueryTagStore.GetExtendedQueryTagsAsync();
+            var extendedQueryTagEntries = await _extendedQueryTagStore.AddExtendedQueryTagsAsync(extendedQueryTags, maxAllowedCount: 128, ready: true);
             return extendedQueryTagEntries.Select(entry => new QueryTag(entry)).ToList();
         }
 

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/IndexDataStoreTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/IndexDataStoreTests.cs
@@ -496,7 +496,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
         [Fact]
         public async Task GivenNoExtendedQueryTags_WhenCreateIndex_ThenShouldSucceed()
         {
-            var extendedTags = await _extendedQueryTagStore.GetExtendedQueryTagsAsync();
+            var extendedTags = await _extendedQueryTagStore.GetExtendedQueryTagsAsync(int.MaxValue);
             // make sure there is no extended query tags
             Assert.Empty(extendedTags);
 
@@ -508,15 +508,13 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
         public async Task GivenMaxTagKeyNotMatch_WhenCreateIndex_ThenShouldThrowException()
         {
             AddExtendedQueryTagEntry extendedQueryTagEntry = DicomTag.PatientAge.BuildAddExtendedQueryTagEntry();
-            await _extendedQueryTagStore.AddExtendedQueryTagsAsync(new[] { extendedQueryTagEntry }, maxAllowedCount: 128, ready: true);
-            var tagEntry = (await _extendedQueryTagStore.GetExtendedQueryTagsAsync())[0];
-            var modifiedTagEntry = new ExtendedQueryTagStoreEntry(tagEntry.Key, tagEntry.Path, tagEntry.VR, tagEntry.PrivateCreator, tagEntry.Level, tagEntry.Status);
-            var queryTags = new[] { new QueryTag(modifiedTagEntry) };
+            var tagEntry = (await _extendedQueryTagStore.AddExtendedQueryTagsAsync(new[] { extendedQueryTagEntry }, maxAllowedCount: 128, ready: true))[0];
             DicomDataset dataset = Samples.CreateRandomInstanceDataset();
 
             // Add a new tag
             await _extendedQueryTagStore.AddExtendedQueryTagsAsync(new[] { DicomTag.PatientName.BuildAddExtendedQueryTagEntry() }, maxAllowedCount: 128, ready: true);
 
+            var queryTags = new[] { new QueryTag(tagEntry) };
             long watermark = await _indexDataStore.BeginCreateInstanceIndexAsync(dataset, queryTags);
             await Assert.ThrowsAsync<ExtendedQueryTagsOutOfDateException>(
                 () => _indexDataStore.EndCreateInstanceIndexAsync(dataset, watermark, queryTags));

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/InstanceStoreTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/InstanceStoreTests.cs
@@ -211,10 +211,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
         }
 
         private async Task<ExtendedQueryTagStoreEntry> AddExtendedQueryTagAsync(AddExtendedQueryTagEntry addExtendedQueryTagEntry)
-        {
-            await _extendedQueryTagStore.AddExtendedQueryTagsAsync(new[] { addExtendedQueryTagEntry }, 128);
-            return (await _extendedQueryTagStore.GetExtendedQueryTagsAsync(path: addExtendedQueryTagEntry.Path)).First();
-        }
+            => (await _extendedQueryTagStore.AddExtendedQueryTagsAsync(new[] { addExtendedQueryTagEntry }, 128))[0];
 
         private async Task<Instance> CreateInstanceIndexAsync(DicomDataset dataset)
         {


### PR DESCRIPTION
## Description
- Add `limit` and `offset` parameters when getting extended query tags
- Refactor SQL storied procedures:
  - Add stored procedure for reading paginated data
  - Change AddExtendedQueryTag to return new tags
- Refactor IExtendedQueryTagStore and IGetExtendedQueryTagsService to better fit call patterns

## Related issues
[AB#85156](https://microsofthealth.visualstudio.com/Health/_workitems/edit/85156)

## Testing
Test locally and via PR
