### PR TITLE
Add Link to Errors from Extended Query Tag Resource if Present

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Controllers/ExtendedQueryTagController.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/ExtendedQueryTagController.cs
@@ -159,8 +159,8 @@ namespace Microsoft.Health.Dicom.Api.Controllers
         [ProducesResponseType(typeof(GetExtendedQueryTagErrorsResponse), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
-        [VersionedRoute(KnownRoutes.GetExtendedQueryTagErrorsRoute)]
-        [Route(KnownRoutes.GetExtendedQueryTagErrorsRoute)]
+        [VersionedRoute(KnownRoutes.GetExtendedQueryTagErrorsRoute, Name = KnownRouteNames.VersionedGetExtendedQueryTagErrors)]
+        [Route(KnownRoutes.GetExtendedQueryTagErrorsRoute, Name = KnownRouteNames.GetExtendedQueryTagErrors)]
         [AuditEventType(AuditEventSubType.GetExtendedQueryTagErrors)]
         public async Task<IActionResult> GetTagErrorsAsync(string tagPath)
         {

--- a/src/Microsoft.Health.Dicom.Api/Features/Routing/KnownRouteNames.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Routing/KnownRouteNames.cs
@@ -24,5 +24,8 @@ namespace Microsoft.Health.Dicom.Api.Features.Routing
 
         internal const string VersionedGetExtendedQueryTag = nameof(VersionedGetExtendedQueryTag);
         internal const string GetExtendedQueryTag = nameof(GetExtendedQueryTag);
+
+        internal const string VersionedGetExtendedQueryTagErrors = nameof(VersionedGetExtendedQueryTagErrors);
+        internal const string GetExtendedQueryTagErrors = nameof(GetExtendedQueryTagErrors);
     }
 }

--- a/src/Microsoft.Health.Dicom.Api/Features/Routing/UrlResolver.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Routing/UrlResolver.cs
@@ -66,6 +66,19 @@ namespace Microsoft.Health.Dicom.Api.Features.Routing
         }
 
         /// <inheritdoc />
+        public Uri ResolveQueryTagErrorsUri(string tagPath)
+        {
+            var hasVersion = _httpContextAccessor.HttpContext.Request.RouteValues.ContainsKey("version");
+
+            return RouteUri(
+                hasVersion ? KnownRouteNames.VersionedGetExtendedQueryTagErrors : KnownRouteNames.GetExtendedQueryTagErrors,
+                new RouteValueDictionary
+                {
+                    { KnownActionParameterNames.TagPath, tagPath },
+                });
+        }
+
+        /// <inheritdoc />
         public Uri ResolveRetrieveStudyUri(string studyInstanceUid)
         {
             EnsureArg.IsNotNull(studyInstanceUid, nameof(studyInstanceUid));

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/ExtendedQueryTagErrorReference.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/ExtendedQueryTagErrorReference.cs
@@ -1,0 +1,45 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+
+namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
+{
+    /// <summary>
+    /// Represents a reference to a one or more extended query tag errors.
+    /// </summary>
+    public class ExtendedQueryTagErrorReference
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExtendedQueryTagErrorReference"/> class.
+        /// </summary>
+        /// <param name="count">The number of errors.</param>
+        /// <param name="href">The resource URL for the operation.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="href"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="count"/> is less than <c>1</c>.
+        /// </exception>
+        public ExtendedQueryTagErrorReference(int count, Uri href)
+        {
+            Count = EnsureArg.IsGte(count, 0, nameof(count));
+            Href = EnsureArg.IsNotNull(href, nameof(href));
+        }
+
+        /// <summary>
+        /// Gets the number of errors.
+        /// </summary>
+        /// <value>The positive number of errors found at the <see cref="Href"/>.</value>
+        public int Count { get; }
+
+        /// <summary>
+        /// Gets the resource reference for the errors.
+        /// </summary>
+        /// <value>The unique resource URL for the extended query tag errors.</value>
+        public Uri Href { get; }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/ExtendedQueryTagStoreEntry.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/ExtendedQueryTagStoreEntry.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using EnsureThat;
+using Microsoft.Health.Dicom.Core.Features.Routing;
 
 namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
 {
@@ -52,10 +53,21 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         /// <summary>
         /// Convert to  <see cref="GetExtendedQueryTagEntry"/>.
         /// </summary>
+        /// <param name="resolver">An optional <see cref="IUrlResolver"/> for resolving resource paths.</param>
         /// <returns>The extended query tag entry.</returns>
-        public GetExtendedQueryTagEntry ToExtendedQueryTagEntry()
+        public GetExtendedQueryTagEntry ToExtendedQueryTagEntry(IUrlResolver resolver = null)
         {
-            return new GetExtendedQueryTagEntry { Path = Path, VR = VR, PrivateCreator = PrivateCreator, Level = Level, Status = Status };
+            return new GetExtendedQueryTagEntry
+            {
+                Path = Path,
+                VR = VR,
+                PrivateCreator = PrivateCreator,
+                Level = Level,
+                Status = Status,
+                Errors = ErrorCount > 0 && resolver != null
+                    ? new ExtendedQueryTagErrorReference(ErrorCount, resolver.ResolveQueryTagErrorsUri(Path))
+                    : null,
+            };
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/GetExtendedQueryTagEntry.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/GetExtendedQueryTagEntry.cs
@@ -20,9 +20,14 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         /// </summary>
         public QueryTagLevel Level { get; set; }
 
+        /// <summary>
+        /// Optional errors associated with the query tag.
+        /// </summary>
+        public ExtendedQueryTagErrorReference Errors { get; set; }
+
         public override string ToString()
         {
-            return $"Path: {Path}, VR:{VR}, PrivateCreator:{PrivateCreator}, Level:{Level}, Status:{Status}";
+            return $"Path: {Path}, VR:{VR}, PrivateCreator:{PrivateCreator}, Level:{Level}, Status:{Status}, Errors: {Errors?.Count ?? 0}";
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/GetExtendedQueryTagsService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/GetExtendedQueryTagsService.cs
@@ -13,6 +13,7 @@ using EnsureThat;
 using Microsoft.Health.Dicom.Core.Exceptions;
 using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Core.Features.Common;
+using Microsoft.Health.Dicom.Core.Features.Routing;
 using Microsoft.Health.Dicom.Core.Messages.ExtendedQueryTag;
 
 namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
@@ -21,14 +22,16 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
     {
         private readonly IExtendedQueryTagStore _extendedQueryTagStore;
         private readonly IDicomTagParser _dicomTagParser;
+        private readonly IUrlResolver _urlResolver;
 
-        public GetExtendedQueryTagsService(IExtendedQueryTagStore extendedQueryTagStore, IDicomTagParser dicomTagParser)
+        public GetExtendedQueryTagsService(
+            IExtendedQueryTagStore extendedQueryTagStore,
+            IDicomTagParser dicomTagParser,
+            IUrlResolver urlResolver)
         {
-            EnsureArg.IsNotNull(extendedQueryTagStore, nameof(extendedQueryTagStore));
-            EnsureArg.IsNotNull(dicomTagParser, nameof(dicomTagParser));
-
-            _extendedQueryTagStore = extendedQueryTagStore;
-            _dicomTagParser = dicomTagParser;
+            _extendedQueryTagStore = EnsureArg.IsNotNull(extendedQueryTagStore, nameof(extendedQueryTagStore));
+            _dicomTagParser = EnsureArg.IsNotNull(dicomTagParser, nameof(dicomTagParser));
+            _urlResolver = EnsureArg.IsNotNull(urlResolver, nameof(urlResolver));
         }
 
         public async Task<GetExtendedQueryTagResponse> GetExtendedQueryTagAsync(string tagPath, CancellationToken cancellationToken = default)
@@ -50,13 +53,13 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
             }
 
             ExtendedQueryTagStoreEntry extendedQueryTag = await _extendedQueryTagStore.GetExtendedQueryTagAsync(numericalTagPath, cancellationToken);
-            return new GetExtendedQueryTagResponse(extendedQueryTag.ToExtendedQueryTagEntry());
+            return new GetExtendedQueryTagResponse(extendedQueryTag.ToExtendedQueryTagEntry(_urlResolver));
         }
 
         public async Task<GetExtendedQueryTagsResponse> GetExtendedQueryTagsAsync(int limit, int offset = 0, CancellationToken cancellationToken = default)
         {
             IReadOnlyList<ExtendedQueryTagStoreEntry> extendedQueryTags = await _extendedQueryTagStore.GetExtendedQueryTagsAsync(limit, offset, cancellationToken);
-            return new GetExtendedQueryTagsResponse(extendedQueryTags.Select(x => x.ToExtendedQueryTagEntry()));
+            return new GetExtendedQueryTagsResponse(extendedQueryTags.Select(x => x.ToExtendedQueryTagEntry(_urlResolver)));
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Routing/IUrlResolver.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Routing/IUrlResolver.cs
@@ -28,6 +28,13 @@ namespace Microsoft.Health.Dicom.Core.Features.Routing
         Uri ResolveQueryTagUri(string tagPath);
 
         /// <summary>
+        /// Resolves the URI for retrieving the errors for an extended query tag.
+        /// </summary>
+        /// <param name="tagPath">The extended query tag path.</param>
+        /// <returns>An instance of <see cref="Uri"/> pointing to where the extended query tag errors can be retrieved.</returns>
+        Uri ResolveQueryTagErrorsUri(string tagPath);
+
+        /// <summary>
         /// Resolves the URI to retrieve a study.
         /// </summary>
         /// <param name="studyInstanceUid">The StudyInstanceUID.</param>

--- a/src/Microsoft.Health.Dicom.Core/Models/Operations/OperationReference.cs
+++ b/src/Microsoft.Health.Dicom.Core/Models/Operations/OperationReference.cs
@@ -20,9 +20,6 @@ namespace Microsoft.Health.Dicom.Core.Models.Operations
         /// </summary>
         /// <param name="id">The unique operation ID.</param>
         /// <param name="href">The resource URL for the operation.</param>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="href"/> is empty or consists of white space characters.
-        /// </exception>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="href"/> is <see langword="null"/>.
         /// </exception>

--- a/src/Microsoft.Health.Dicom.Tests.Common/Comparers/ExtendedQueryTagEntryEqualityComparer.cs
+++ b/src/Microsoft.Health.Dicom.Tests.Common/Comparers/ExtendedQueryTagEntryEqualityComparer.cs
@@ -26,18 +26,22 @@ namespace Microsoft.Health.Dicom.Tests.Common.Comparers
                 && string.Equals(x.VR, y.VR, StringComparison.OrdinalIgnoreCase)
                 && x.PrivateCreator == y.PrivateCreator
                 && x.Level == y.Level
-                && x.Status == y.Status;
+                && x.Status == y.Status
+                && x.Errors?.Count == y.Errors?.Count
+                && x.Errors?.Href == y.Errors?.Href;
         }
 
-        public int GetHashCode(GetExtendedQueryTagEntry extendedQueryTagEntry)
+        public int GetHashCode(GetExtendedQueryTagEntry entry)
         {
-            EnsureArg.IsNotNull(extendedQueryTagEntry, nameof(extendedQueryTagEntry));
-            return HashCode.Combine(
-                extendedQueryTagEntry.Path,
-                extendedQueryTagEntry.VR,
-                extendedQueryTagEntry.PrivateCreator,
-                extendedQueryTagEntry.Level,
-                extendedQueryTagEntry.Status);
+            EnsureArg.IsNotNull(entry, nameof(entry));
+            int hashCode = HashCode.Combine(
+                entry.Path,
+                entry.VR,
+                entry.PrivateCreator,
+                entry.Level,
+                entry.Status);
+
+            return entry.Errors != null ? HashCode.Combine(hashCode, entry.Errors.Count, entry.Errors.Href) : hashCode;
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Tests.Common/MockUrlResolver.cs
+++ b/src/Microsoft.Health.Dicom.Tests.Common/MockUrlResolver.cs
@@ -26,6 +26,14 @@ namespace Microsoft.Health.Dicom.Tests.Common
             return new Uri("/" + tagPath, UriKind.Relative);
         }
 
+        /// <inheritdoc />
+        public Uri ResolveQueryTagErrorsUri(string tagPath)
+        {
+            EnsureArg.IsNotNull(tagPath, nameof(tagPath));
+
+            return new Uri("/" + tagPath + "/errors", UriKind.Relative);
+        }
+
         public Uri ResolveRetrieveInstanceUri(InstanceIdentifier instanceIdentifier)
         {
             EnsureArg.IsNotNull(instanceIdentifier, nameof(instanceIdentifier));


### PR DESCRIPTION
## Description
- Add a new `Errors` object to the `ExtendedQueryTag` resource that will be populated if there is more than 1 error

## Related issues
[AB#85198](https://microsofthealth.visualstudio.com/Health/_workitems/edit/85198)

## Testing
PR pipeline
