### PR TITLE
Paginate Extended Query Tag Errors

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Controllers/ExtendedQueryTagController.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/ExtendedQueryTagController.cs
@@ -89,6 +89,8 @@ namespace Microsoft.Health.Dicom.Api.Controllers
         /// <summary>
         /// Handles requests to get all extended query tags.
         /// </summary>
+        /// <param name="limit">The maximum number of results to retrieve.</param>
+        /// <param name="offset">The offset from which to retrieve paginated results.</param>
         /// <returns>
         /// Returns Bad Request if given path can't be parsed. Returns Not Found if given path doesn't map to a stored
         /// extended query tag or if no extended query tags are stored. Returns OK with a JSON body of all tags in other cases.
@@ -150,6 +152,8 @@ namespace Microsoft.Health.Dicom.Api.Controllers
         /// Handles requests to get extended query tag errors.
         /// </summary>
         /// <param name="tagPath">Path for requested extended query tag.</param>
+        /// <param name="limit">The maximum number of results to retrieve.</param>
+        /// <param name="offset">The offset from which to retrieve paginated results.</param>
         /// <returns>
         /// Returns Bad Request if given path can't be parsed. Returns Not Found if given path doesn't map to a stored
         /// error. Returns OK with a JSON body of requested tag error in other cases.
@@ -162,12 +166,15 @@ namespace Microsoft.Health.Dicom.Api.Controllers
         [VersionedRoute(KnownRoutes.GetExtendedQueryTagErrorsRoute)]
         [Route(KnownRoutes.GetExtendedQueryTagErrorsRoute)]
         [AuditEventType(AuditEventSubType.GetExtendedQueryTagErrors)]
-        public async Task<IActionResult> GetTagErrorsAsync(string tagPath)
+        public async Task<IActionResult> GetTagErrorsAsync(
+            [FromRoute] string tagPath,
+            [FromQuery, Range(1, 200)] int limit = 100,
+            [FromQuery, Range(0, int.MaxValue)] int offset = 0)
         {
             _logger.LogInformation("DICOM Web Get Extended Query Tag Errors request received for extended query tag: {tagPath}", tagPath);
 
             EnsureFeatureIsEnabled();
-            GetExtendedQueryTagErrorsResponse response = await _mediator.GetExtendedQueryTagErrorsAsync(tagPath, HttpContext.RequestAborted);
+            GetExtendedQueryTagErrorsResponse response = await _mediator.GetExtendedQueryTagErrorsAsync(tagPath, limit, offset, HttpContext.RequestAborted);
 
             return StatusCode((int)HttpStatusCode.OK, response);
         }

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/ExtendedQueryTagErrorsServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/ExtendedQueryTagErrorsServiceTests.cs
@@ -70,12 +70,13 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.ExtendedQueryTag
                 return true;
             });
 
-            _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tagPath).Returns(new List<ExtendedQueryTagError>());
-            GetExtendedQueryTagErrorsResponse response = await _extendedQueryTagErrorsService.GetExtendedQueryTagErrorsAsync(tagPath);
+            _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tagPath, 100, 200).Returns(Array.Empty<ExtendedQueryTagError>());
+            GetExtendedQueryTagErrorsResponse response = await _extendedQueryTagErrorsService.GetExtendedQueryTagErrorsAsync(tagPath, 100, 200);
 
             _dicomTagParser.Received(1).TryParse(
                 Arg.Is(tagPath),
                 out Arg.Any<DicomTag[]>());
+            await _extendedQueryTagErrorStore.Received(1).GetExtendedQueryTagErrorsAsync(tagPath, 100, 200);
 
             Assert.Empty(response.ExtendedQueryTagErrors);
         }
@@ -93,9 +94,9 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.ExtendedQueryTag
                 return true;
             });
 
-            _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tagPath).Returns(new List<ExtendedQueryTagError>());
-            await _extendedQueryTagErrorsService.GetExtendedQueryTagErrorsAsync(tagPath);
-            await _extendedQueryTagErrorStore.Received(1).GetExtendedQueryTagErrorsAsync(tagPath);
+            _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tagPath, 10, 50).Returns(Array.Empty<ExtendedQueryTagError>());
+            await _extendedQueryTagErrorsService.GetExtendedQueryTagErrorsAsync(tagPath, 10, 50);
+            await _extendedQueryTagErrorStore.Received(1).GetExtendedQueryTagErrorsAsync(tagPath, 10, 50);
             _dicomTagParser.Received(1).TryParse(
                 Arg.Is(tagPath),
                 out Arg.Any<DicomTag[]>());
@@ -121,9 +122,9 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.ExtendedQueryTag
                 return true;
             });
 
-            _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tagPath).Returns(expected);
-            GetExtendedQueryTagErrorsResponse response = await _extendedQueryTagErrorsService.GetExtendedQueryTagErrorsAsync(tagPath);
-            await _extendedQueryTagErrorStore.Received(1).GetExtendedQueryTagErrorsAsync(tagPath);
+            _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tagPath, 5, 100).Returns(expected);
+            GetExtendedQueryTagErrorsResponse response = await _extendedQueryTagErrorsService.GetExtendedQueryTagErrorsAsync(tagPath, 5, 100);
+            await _extendedQueryTagErrorStore.Received(1).GetExtendedQueryTagErrorsAsync(tagPath, 5, 100);
             _dicomTagParser.Received(1).TryParse(
                 Arg.Is(tagPath),
                 out Arg.Any<DicomTag[]>());

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Messages/ExtendedQueryTag/GetExtendedQueryTagErrorsRequestTest.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Messages/ExtendedQueryTag/GetExtendedQueryTagErrorsRequestTest.cs
@@ -1,0 +1,22 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Dicom.Core.Exceptions;
+using Microsoft.Health.Dicom.Core.Messages.ExtendedQueryTag;
+using Xunit;
+
+namespace Microsoft.Health.Dicom.Core.UnitTests.Messages.ExtendedQueryTag
+{
+    public class GetExtendedQueryTagErrorsRequestTest
+    {
+        [Fact]
+        public void GivenInvalidParameters_WhenCreateRequest_ThenThrowBadRequestException()
+        {
+            Assert.Throws<BadRequestException>(() => new GetExtendedQueryTagErrorsRequest("foo", 0, 0));
+            Assert.Throws<BadRequestException>(() => new GetExtendedQueryTagErrorsRequest("bar", 201, 0));
+            Assert.Throws<BadRequestException>(() => new GetExtendedQueryTagErrorsRequest("baz", 10, -12));
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Core/Extensions/DicomMediatorExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Extensions/DicomMediatorExtensions.cs
@@ -171,10 +171,10 @@ namespace Microsoft.Health.Dicom.Core.Extensions
         }
 
         public static Task<GetExtendedQueryTagErrorsResponse> GetExtendedQueryTagErrorsAsync(
-            this IMediator mediator, string extendedQueryTagPath, CancellationToken cancellationToken)
+            this IMediator mediator, string extendedQueryTagPath, int limit, int offset, CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
-            return mediator.Send(new GetExtendedQueryTagErrorsRequest(extendedQueryTagPath), cancellationToken);
+            return mediator.Send(new GetExtendedQueryTagErrorsRequest(extendedQueryTagPath, limit, offset), cancellationToken);
         }
 
         public static Task<OperationStatusResponse> GetOperationStatusAsync(

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/ExtendedQueryTagErrorsService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/ExtendedQueryTagErrorsService.cs
@@ -27,14 +27,18 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
             _dicomTagParser = EnsureArg.IsNotNull(dicomTagParser, nameof(dicomTagParser));
         }
 
-        public async Task<GetExtendedQueryTagErrorsResponse> GetExtendedQueryTagErrorsAsync(string tagPath, CancellationToken cancellationToken)
+        public async Task<GetExtendedQueryTagErrorsResponse> GetExtendedQueryTagErrorsAsync(string tagPath, int limit, int offset, CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(tagPath, nameof(tagPath));
             string numericalTagPath = _dicomTagParser.TryParse(tagPath, out DicomTag[] tags, supportMultiple: false)
                 ? tags[0].GetPath()
                 : throw new InvalidExtendedQueryTagPathException(string.Format(DicomCoreResource.InvalidExtendedQueryTag, tagPath ?? string.Empty));
 
-            IReadOnlyList<ExtendedQueryTagError> extendedQueryTagErrors = await _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(numericalTagPath, cancellationToken);
+            IReadOnlyList<ExtendedQueryTagError> extendedQueryTagErrors = await _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(
+                numericalTagPath,
+                limit,
+                offset,
+                cancellationToken);
             return new GetExtendedQueryTagErrorsResponse(extendedQueryTagErrors);
         }
 

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/GetExtendedQueryTagErrorsHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/GetExtendedQueryTagErrorsHandler.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
                 throw new UnauthorizedDicomActionException(DataActions.Read);
             }
 
-            return await _getExtendedQueryTagErrorsService.GetExtendedQueryTagErrorsAsync(request.Path, cancellationToken);
+            return await _getExtendedQueryTagErrorsService.GetExtendedQueryTagErrorsAsync(request.Path, request.Limit, request.Offset, cancellationToken);
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/IExtendedQueryTagErrorStore.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/IExtendedQueryTagErrorStore.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,9 +20,16 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         /// Get extended query tags errors by tag path.
         /// </summary>
         /// <param name="tagPath">The tag path.</param>
+        /// <param name="limit">The maximum number of results to retrieve.</param>
+        /// <param name="offset">The offset from which to retrieve paginated results.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A list of Extended Query Tag Errors.</returns>
-        Task<IReadOnlyList<ExtendedQueryTagError>> GetExtendedQueryTagErrorsAsync(string tagPath, CancellationToken cancellationToken = default);
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <para><paramref name="limit"/> is less than <c>1</c></para>
+        /// <para>-or-</para>
+        /// <para><paramref name="offset"/> is less than <c>0</c>.</para>
+        /// </exception>
+        Task<IReadOnlyList<ExtendedQueryTagError>> GetExtendedQueryTagErrorsAsync(string tagPath, int limit, int offset = 0, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Asynchronously adds an error for a specified Extended Query Tag.

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/IExtendedQueryTagErrorsService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/IExtendedQueryTagErrorsService.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Health.Dicom.Core.Features.Validation;
@@ -32,8 +33,15 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         /// Asynchronously gets errors for a specified Extended Query Tag.
         /// </summary>
         /// <param name="tagPath">Path to the extended query tag that is requested.</param>
+        /// <param name="limit">The maximum number of results to retrieve.</param>
+        /// <param name="offset">The offset from which to retrieve paginated results.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The response.</returns>
-        Task<GetExtendedQueryTagErrorsResponse> GetExtendedQueryTagErrorsAsync(string tagPath, CancellationToken cancellationToken = default);
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <para><paramref name="limit"/> is less than <c>1</c></para>
+        /// <para>-or-</para>
+        /// <para><paramref name="offset"/> is less than <c>0</c>.</para>
+        /// </exception>
+        Task<GetExtendedQueryTagErrorsResponse> GetExtendedQueryTagErrorsAsync(string tagPath, int limit, int offset = 0, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/IGetExtendedQueryTagsService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/IGetExtendedQueryTagsService.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The response.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        /// <para><paramref name="limit"/> is less than <c>1</c> or greater than <c>200</c></para>
+        /// <para><paramref name="limit"/> is less than <c>1</c></para>
         /// <para>-or-</para>
         /// <para><paramref name="offset"/> is less than <c>0</c>.</para>
         /// </exception>

--- a/src/Microsoft.Health.Dicom.Core/Features/Validation/PersonNameValidation.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Validation/PersonNameValidation.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Validation
                 }
                 catch (ElementValidationException ex) when (ex.ErrorCode == ValidationErrorCode.ExceedMaxLength)
                 {
-                    // Reprocess the exception to make more meaningful message                    
+                    // Reprocess the exception to make more meaningful message
                     throw ElementValidationExceptionFactory.CreatePersonNameGroupExceedMaxLengthException(name, value);
                 }
 

--- a/src/Microsoft.Health.Dicom.Core/Messages/ExtendedQueryTag/GetExtendedQueryTagErrorsRequest.cs
+++ b/src/Microsoft.Health.Dicom.Core/Messages/ExtendedQueryTag/GetExtendedQueryTagErrorsRequest.cs
@@ -5,17 +5,34 @@
 
 using EnsureThat;
 using MediatR;
+using Microsoft.Health.Dicom.Core.Exceptions;
 
 namespace Microsoft.Health.Dicom.Core.Messages.ExtendedQueryTag
 {
     public class GetExtendedQueryTagErrorsRequest : IRequest<GetExtendedQueryTagErrorsResponse>
     {
-        public GetExtendedQueryTagErrorsRequest(string path)
+        public GetExtendedQueryTagErrorsRequest(string path, int limit, int offset)
         {
             EnsureArg.IsNotNullOrWhiteSpace(path, nameof(path));
+            if (limit < 1 || limit > 200)
+            {
+                throw new BadRequestException(string.Format(DicomCoreResource.PaginationLimitOutOfRange, limit, 1, 200));
+            }
+
+            if (offset < 0)
+            {
+                throw new BadRequestException(string.Format(DicomCoreResource.PaginationNegativeOffset, offset));
+            }
+
             Path = path;
+            Limit = limit;
+            Offset = offset;
         }
 
         public string Path { get; }
+
+        public int Limit { get; }
+
+        public int Offset { get; }
     }
 }

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/Error/SqlExtendedQueryTagErrorStore.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/Error/SqlExtendedQueryTagErrorStore.cs
@@ -34,10 +34,10 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag.Error
                 cancellationToken);
         }
 
-        public async Task<IReadOnlyList<ExtendedQueryTagError>> GetExtendedQueryTagErrorsAsync(string tagPath, CancellationToken cancellationToken = default)
+        public async Task<IReadOnlyList<ExtendedQueryTagError>> GetExtendedQueryTagErrorsAsync(string tagPath, int limit, int offset, CancellationToken cancellationToken = default)
         {
             ISqlExtendedQueryTagErrorStore store = await _cache.GetAsync(cancellationToken);
-            return await store.GetExtendedQueryTagErrorsAsync(tagPath, cancellationToken);
+            return await store.GetExtendedQueryTagErrorsAsync(tagPath, limit, offset, cancellationToken);
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/Error/SqlExtendedQueryTagErrorStoreV1.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/Error/SqlExtendedQueryTagErrorStoreV1.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag.Error
             throw new BadRequestException(DicomSqlServerResource.SchemaVersionNeedsToBeUpgraded);
         }
 
-        public virtual Task<IReadOnlyList<ExtendedQueryTagError>> GetExtendedQueryTagErrorsAsync(string tagPath, CancellationToken cancellationToken = default)
+        public virtual Task<IReadOnlyList<ExtendedQueryTagError>> GetExtendedQueryTagErrorsAsync(string tagPath, int limit, int offset, CancellationToken cancellationToken = default)
         {
             throw new BadRequestException(DicomSqlServerResource.SchemaVersionNeedsToBeUpgraded);
         }

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/Error/SqlExtendedQueryTagErrorStoreV4.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/Error/SqlExtendedQueryTagErrorStoreV4.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag.Error
             }
         }
 
-        public override async Task<IReadOnlyList<ExtendedQueryTagError>> GetExtendedQueryTagErrorsAsync(string tagPath, CancellationToken cancellationToken = default)
+        public override async Task<IReadOnlyList<ExtendedQueryTagError>> GetExtendedQueryTagErrorsAsync(string tagPath, int limit, int offset, CancellationToken cancellationToken = default)
         {
             List<ExtendedQueryTagError> results = new List<ExtendedQueryTagError>();
 

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/Error/SqlExtendedQueryTagErrorStoreV4.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/Error/SqlExtendedQueryTagErrorStoreV4.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag.Error
             using SqlConnectionWrapper sqlConnectionWrapper = await ConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken);
             using SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateSqlCommand();
 
-            VLatest.GetExtendedQueryTagErrors.PopulateCommand(sqlCommandWrapper, tagPath);
+            VLatest.GetExtendedQueryTagErrors.PopulateCommand(sqlCommandWrapper, tagPath, limit, offset);
 
             try
             {

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.diff.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.diff.sql
@@ -31,14 +31,32 @@ BEGIN
     )
 END
 IF NOT EXISTS (
-    SELECT * 
-    FROM sys.indexes 
+    SELECT *
+    FROM sys.indexes
     WHERE name='IXC_ExtendedQueryTagError' AND object_id = OBJECT_ID('dbo.ExtendedQueryTagError'))
 BEGIN
     CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagError ON dbo.ExtendedQueryTagError
     (
         TagKey,
         Watermark
+    )
+END
+GO
+
+IF NOT EXISTS (
+    SELECT *
+    FROM sys.indexes
+    WHERE name='IX_ExtendedQueryTagError_CreatedTime_Watermark_TagKey' AND object_id = OBJECT_ID('dbo.ExtendedQueryTagError'))
+BEGIN
+    CREATE NONCLUSTERED INDEX IX_ExtendedQueryTagError_CreatedTime_Watermark_TagKey ON dbo.ExtendedQueryTagError
+    (
+        CreatedTime,
+        Watermark,
+        TagKey
+    )
+    INCLUDE
+    (
+        ErrorCode
     )
 END
 GO
@@ -861,7 +879,7 @@ BEGIN
     INNER JOIN dbo.Instance AS I
     ON XQTE.Watermark = I.Watermark
     WHERE XQTE.TagKey = @tagKey
-    ORDER BY CreatedTime ASC
+    ORDER BY CreatedTime ASC, XQTE.Watermark ASC, TagKey ASC
     OFFSET @offset ROWS
     FETCH NEXT @limit ROWS ONLY
 END

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.diff.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.diff.sql
@@ -824,11 +824,18 @@ GO
 -- PARAMETERS
 --     @tagPath
 --         * The TagPath for the extended query tag for which we retrieve error(s).
+--     @limit
+--         * The maximum number of results to retrieve.
+--     @offset
+--         * The offset from which to retrieve paginated results.
 --
 -- RETURN VALUE
 --     The tag error fields and the corresponding instance UIDs.
 /***************************************************************************************/
-CREATE OR ALTER PROCEDURE dbo.GetExtendedQueryTagErrors (@tagPath VARCHAR(64))
+CREATE OR ALTER PROCEDURE dbo.GetExtendedQueryTagErrors
+    @tagPath VARCHAR(64),
+    @limit   INT,
+    @offset  INT
 AS
 BEGIN
     SET NOCOUNT     ON
@@ -854,6 +861,9 @@ BEGIN
     INNER JOIN dbo.Instance AS I
     ON XQTE.Watermark = I.Watermark
     WHERE XQTE.TagKey = @tagKey
+    ORDER BY CreatedTime ASC
+    OFFSET @offset ROWS
+    FETCH NEXT @limit ROWS ONLY
 END
 GO
 

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.sql
@@ -420,6 +420,17 @@ CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagError ON dbo.ExtendedQueryTagE
     Watermark
 )
 
+CREATE NONCLUSTERED INDEX IX_ExtendedQueryTagError_CreatedTime_Watermark_TagKey ON dbo.ExtendedQueryTagError
+(
+    CreatedTime,
+    Watermark,
+    TagKey
+)
+INCLUDE
+(
+    ErrorCode
+)
+
 /*************************************************************
     Extended Query Tag Operation Table
     Stores the association between tags and their reindexing operation
@@ -1967,7 +1978,7 @@ BEGIN
     INNER JOIN dbo.Instance AS I
     ON XQTE.Watermark = I.Watermark
     WHERE XQTE.TagKey = @tagKey
-    ORDER BY CreatedTime ASC
+    ORDER BY CreatedTime ASC, XQTE.Watermark ASC, TagKey ASC
     OFFSET @offset ROWS
     FETCH NEXT @limit ROWS ONLY
 END

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.sql
@@ -1930,11 +1930,18 @@ GO
 -- PARAMETERS
 --     @tagPath
 --         * The TagPath for the extended query tag for which we retrieve error(s).
+--     @limit
+--         * The maximum number of results to retrieve.
+--     @offset
+--         * The offset from which to retrieve paginated results.
 --
 -- RETURN VALUE
 --     The tag error fields and the corresponding instance UIDs.
 /***************************************************************************************/
-CREATE OR ALTER PROCEDURE dbo.GetExtendedQueryTagErrors (@tagPath VARCHAR(64))
+CREATE OR ALTER PROCEDURE dbo.GetExtendedQueryTagErrors
+    @tagPath VARCHAR(64),
+    @limit   INT,
+    @offset  INT
 AS
 BEGIN
     SET NOCOUNT     ON
@@ -1960,6 +1967,9 @@ BEGIN
     INNER JOIN dbo.Instance AS I
     ON XQTE.Watermark = I.Watermark
     WHERE XQTE.TagKey = @tagKey
+    ORDER BY CreatedTime ASC
+    OFFSET @offset ROWS
+    FETCH NEXT @limit ROWS ONLY
 END
 GO
 

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Model/VLatest.Generated.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Model/VLatest.Generated.cs
@@ -146,6 +146,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.Schema.Model
             internal readonly BigIntColumn Watermark = new BigIntColumn("Watermark");
             internal readonly DateTime2Column CreatedTime = new DateTime2Column("CreatedTime", 7);
             internal readonly Index IXC_ExtendedQueryTagError = new Index("IXC_ExtendedQueryTagError");
+            internal readonly Index IX_ExtendedQueryTagError_CreatedTime_Watermark_TagKey = new Index("IX_ExtendedQueryTagError_CreatedTime_Watermark_TagKey");
         }
 
         internal class ExtendedQueryTagLongTable : Table

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Model/VLatest.Generated.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Model/VLatest.Generated.cs
@@ -784,12 +784,16 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.Schema.Model
             }
 
             private readonly ParameterDefinition<System.String> _tagPath = new ParameterDefinition<System.String>("@tagPath", global::System.Data.SqlDbType.VarChar, false, 64);
+            private readonly ParameterDefinition<System.Int32> _limit = new ParameterDefinition<System.Int32>("@limit", global::System.Data.SqlDbType.Int, false);
+            private readonly ParameterDefinition<System.Int32> _offset = new ParameterDefinition<System.Int32>("@offset", global::System.Data.SqlDbType.Int, false);
 
-            public void PopulateCommand(SqlCommandWrapper command, System.String tagPath)
+            public void PopulateCommand(SqlCommandWrapper command, System.String tagPath, System.Int32 limit, System.Int32 offset)
             {
                 command.CommandType = global::System.Data.CommandType.StoredProcedure;
                 command.CommandText = "dbo.GetExtendedQueryTagErrors";
                 _tagPath.AddParameter(command.Parameters, tagPath);
+                _limit.AddParameter(command.Parameters, limit);
+                _offset.AddParameter(command.Parameters, offset);
             }
         }
 

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/ExtendedQueryTagErrorStoreTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/ExtendedQueryTagErrorStoreTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
                errorCode,
                watermark);
 
-            var errors = await _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tag.GetPath());
+            var errors = await _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tag.GetPath(), 1, 0);
 
             Assert.Equal(errors[0].StudyInstanceUid, studyInstanceUid);
             Assert.Equal(errors[0].SeriesInstanceUid, seriesInstanceUid);
@@ -93,7 +93,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             ValidationErrorCode errorCode = ValidationErrorCode.InvalidCharacters;
             await _extendedQueryTagErrorStore.AddExtendedQueryTagErrorAsync(tagKey, errorCode, watermark);
 
-            var extendedQueryTagErrorBeforeTagDeletion = await _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tag.GetPath());
+            var extendedQueryTagErrorBeforeTagDeletion = await _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tag.GetPath(), int.MaxValue, 0);
             Assert.Equal(1, extendedQueryTagErrorBeforeTagDeletion.Count);
 
             var extendedQueryTagBeforeTagDeletion = await _extendedQueryTagStore.GetExtendedQueryTagAsync(tag.GetPath());
@@ -103,7 +103,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             await Assert.ThrowsAsync<ExtendedQueryTagNotFoundException>(
                 () => _extendedQueryTagStore.GetExtendedQueryTagAsync(tag.GetPath()));
             await Assert.ThrowsAsync<ExtendedQueryTagNotFoundException>(
-                () => _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tag.GetPath()));
+                () => _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tag.GetPath(), 1, 0));
             Assert.False(await _errorStoreTestHelper.DoesExtendedQueryTagErrorExistAsync(tagKey));
         }
 
@@ -119,7 +119,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             int tagKey = await AddTagAsync(tag);
             ValidationErrorCode errorCode = ValidationErrorCode.MultiValues;
             await _extendedQueryTagErrorStore.AddExtendedQueryTagErrorAsync(tagKey, errorCode, watermark);
-            var extendedQueryTagErrorBeforeTagDeletion = await _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tag.GetPath());
+            var extendedQueryTagErrorBeforeTagDeletion = await _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tag.GetPath(), int.MaxValue, 0);
             Assert.Equal(1, extendedQueryTagErrorBeforeTagDeletion.Count);
 
             IReadOnlyList<Instance> instanceBeforeDeletion = await _indexDataStoreTestHelper.GetInstancesAsync(studyInstanceUid, seriesInstanceUid, sopInstanceUid);
@@ -127,7 +127,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
 
             await _indexDataStore.DeleteInstanceIndexAsync(studyInstanceUid, seriesInstanceUid, sopInstanceUid, Clock.UtcNow);
 
-            Assert.Empty(await _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tag.GetPath()));
+            Assert.Empty(await _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tag.GetPath(), 1, 0));
             Assert.False(await _errorStoreTestHelper.DoesExtendedQueryTagErrorExistAsync(tagKey));
 
             IReadOnlyList<Instance> instanceAfterDeletion = await _indexDataStoreTestHelper.GetInstancesAsync(studyInstanceUid, seriesInstanceUid, sopInstanceUid);
@@ -166,7 +166,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             await _indexDataStore.DeleteStudyIndexAsync(studyUid1, DateTime.UtcNow);
 
             // check errors
-            var errors = await _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tag.GetPath());
+            var errors = await _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tag.GetPath(), int.MaxValue, 0);
             Assert.Single(errors);
             Assert.Equal(studyUid3, errors[0].StudyInstanceUid);
             Assert.Equal(seriesUid3, errors[0].SeriesInstanceUid);
@@ -202,7 +202,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             await _indexDataStore.DeleteSeriesIndexAsync(studyUid, seriesUid1, DateTime.UtcNow);
 
             // check errors
-            var errors = await _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tag.GetPath());
+            var errors = await _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tag.GetPath(), int.MaxValue, 0);
             Assert.Single(errors);
             Assert.Equal(studyUid, errors[0].StudyInstanceUid);
             Assert.Equal(seriesUid3, errors[0].SeriesInstanceUid);
@@ -237,7 +237,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             await _indexDataStore.DeleteInstanceIndexAsync(new InstanceIdentifier(studyUid1, seriesUid1, instanceUid1));
 
             // check errors
-            var errors = await _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tag1.GetPath());
+            var errors = await _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tag1.GetPath(), int.MaxValue, 0);
             Assert.Single(errors);
             Assert.Equal(studyUid2, errors[0].StudyInstanceUid);
             Assert.Equal(seriesUid2, errors[0].SeriesInstanceUid);
@@ -278,8 +278,8 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             await _indexDataStore.DeleteInstanceIndexAsync(new InstanceIdentifier(studyUid1, seriesUid1, instanceUid1));
 
             // check errors
-            Assert.Empty(await _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tag1.GetPath()));
-            var errors = await _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tag2.GetPath());
+            Assert.Empty(await _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tag1.GetPath(), 1, 0));
+            var errors = await _extendedQueryTagErrorStore.GetExtendedQueryTagErrorsAsync(tag2.GetPath(), int.MaxValue, 0);
             Assert.Single(errors);
             Assert.Equal(studyUid2, errors[0].StudyInstanceUid);
             Assert.Equal(seriesUid2, errors[0].SeriesInstanceUid);

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/ExtendedQueryTagStoreTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/ExtendedQueryTagStoreTests.cs
@@ -165,6 +165,39 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
         }
 
         [Fact]
+        public async Task GivenMultipleTags_WhenGettingPaginatedResults_ThenProperlyPaginateErrors()
+        {
+            // Add tags
+            await AddExtendedQueryTagsAsync(
+                new AddExtendedQueryTagEntry[]
+                {
+                    DicomTag.DeviceSerialNumber.BuildAddExtendedQueryTagEntry(),
+                    DicomTag.PatientAge.BuildAddExtendedQueryTagEntry(),
+                    DicomTag.PatientWeight.BuildAddExtendedQueryTagEntry(),
+                    DicomTag.PatientSize.BuildAddExtendedQueryTagEntry(),
+                },
+                ready: true);
+
+            IReadOnlyList<ExtendedQueryTagStoreEntry> tags;
+
+            // Page 1
+            tags = await _extendedQueryTagStore.GetExtendedQueryTagsAsync(1, 0);
+            Assert.Equal(1, tags.Count);
+            Assert.Equal(tags[0].Path, DicomTag.DeviceSerialNumber.GetPath());
+
+            // Page 2
+            tags = await _extendedQueryTagStore.GetExtendedQueryTagsAsync(2, 1);
+            Assert.Equal(2, tags.Count);
+            Assert.Equal(tags[0].Path, DicomTag.PatientAge.GetPath());
+            Assert.Equal(tags[1].Path, DicomTag.PatientWeight.GetPath());
+
+            // Page 3
+            tags = await _extendedQueryTagStore.GetExtendedQueryTagsAsync(1, 3);
+            Assert.Equal(1, tags.Count);
+            Assert.Equal(tags[0].Path, DicomTag.PatientSize.GetPath());
+        }
+
+        [Fact]
         public async Task GivenQueryTags_WhenGettingTagsByOperation_ThenOnlyAssignedTags()
         {
             DicomTag tag1 = DicomTag.DeviceSerialNumber;


### PR DESCRIPTION
## Description
- Enable pagination for extended query tag errors with same `limit` and `offset` parameters as QIDO

## Related issues
[AB#85156](https://microsofthealth.visualstudio.com/Health/_workitems/edit/85156/)

## Testing
PR pipeline
