### PR TITLE
Add hint for delete instance to use seek instead of scan

### DIFF
--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.diff.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.diff.sql
@@ -19,7 +19,7 @@ END
     TagKey and Watermark is Primary Key
 **************************************************************/
 IF NOT EXISTS (
-    SELECT * 
+    SELECT *
     FROM sys.tables
     WHERE name = 'ExtendedQueryTagError')
 BEGIN
@@ -31,8 +31,8 @@ BEGIN
     )
 END
 IF NOT EXISTS (
-    SELECT * 
-    FROM sys.indexes 
+    SELECT *
+    FROM sys.indexes
     WHERE name='IXC_ExtendedQueryTagError' AND object_id = OBJECT_ID('dbo.ExtendedQueryTagError'))
 BEGIN
     CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTagError ON dbo.ExtendedQueryTagError
@@ -50,7 +50,7 @@ GO
     OperationId is the unique ID for the associated operation (like reindexing)
 **************************************************************/
 IF NOT EXISTS (
-    SELECT * 
+    SELECT *
     FROM sys.tables
     WHERE name = 'ExtendedQueryTagOperation')
 BEGIN
@@ -72,8 +72,8 @@ BEGIN
 END
 
 IF NOT EXISTS (
-    SELECT * 
-    FROM sys.indexes 
+    SELECT *
+    FROM sys.indexes
     WHERE name='IX_ExtendedQueryTagOperation_OperationId' AND object_id = OBJECT_ID('dbo.ExtendedQueryTagOperation'))
 BEGIN
     CREATE NONCLUSTERED INDEX IX_ExtendedQueryTagOperation_OperationId ON dbo.ExtendedQueryTagOperation
@@ -356,7 +356,7 @@ AS
     UPDATE dbo.ExtendedQueryTag
     SET QueryStatus = @queryStatus
     OUTPUT INSERTED.TagKey, INSERTED.TagPath, INSERTED.TagVR, INSERTED.TagPrivateCreator, INSERTED.TagLevel, INSERTED.TagStatus, INSERTED.QueryStatus, INSERTED.ErrorCount
-    WHERE TagPath = @tagPath 
+    WHERE TagPath = @tagPath
 GO
 
 /*************************************************************
@@ -469,7 +469,7 @@ BEGIN
            TagVR,
            TagPrivateCreator,
            TagLevel,
-           TagStatus,           
+           TagStatus,
            QueryStatus,
            ErrorCount
     FROM dbo.ExtendedQueryTag AS XQT
@@ -505,7 +505,7 @@ BEGIN
            TagVR,
            TagPrivateCreator,
            TagLevel,
-           TagStatus,           
+           TagStatus,
            QueryStatus,
            ErrorCount
     FROM dbo.ExtendedQueryTag AS XQT
@@ -649,7 +649,7 @@ AS
         IF EXISTS (SELECT 1 FROM @stringExtendedQueryTags)
         BEGIN
             MERGE INTO dbo.ExtendedQueryTagString WITH (HOLDLOCK) AS T
-            USING 
+            USING
             (
                 -- Locks tags in dbo.ExtendedQueryTag
                 SELECT input.TagKey, input.TagValue, input.TagLevel
@@ -687,7 +687,7 @@ AS
         IF EXISTS (SELECT 1 FROM @longExtendedQueryTags)
         BEGIN
             MERGE INTO dbo.ExtendedQueryTagLong WITH (HOLDLOCK) AS T
-            USING 
+            USING
             (
                 SELECT input.TagKey, input.TagValue, input.TagLevel
                 FROM @longExtendedQueryTags input
@@ -841,7 +841,7 @@ BEGIN
 
     -- Check existence
     IF (@@ROWCOUNT = 0)
-        THROW 50404, 'extended query tag not found', 1 
+        THROW 50404, 'extended query tag not found', 1
 
     SELECT
         TagKey,
@@ -905,7 +905,7 @@ AS
         SET CreatedTime = @currentDate,
             ErrorCode = @errorCode,
             @addedCount = 0
-        WHEN NOT MATCHED THEN 
+        WHEN NOT MATCHED THEN
             INSERT (TagKey, ErrorCode, Watermark, CreatedTime)
             VALUES (@tagKey, @errorCode, @watermark, @currentDate)
         OUTPUT INSERTED.TagKey;
@@ -965,7 +965,7 @@ AS
                TagVR,
                TagPrivateCreator,
                TagLevel,
-               TagStatus,               
+               TagStatus,
                QueryStatus,
                ErrorCount
         FROM @extendedQueryTagKeys AS input
@@ -1114,10 +1114,10 @@ AS
     SET XACT_ABORT  ON
 
     BEGIN TRANSACTION
-        
+
         DECLARE @tagStatus TINYINT
         DECLARE @tagKey INT
- 
+
         SELECT @tagKey = TagKey, @tagStatus = TagStatus
         FROM dbo.ExtendedQueryTag WITH(XLOCK)
         WHERE dbo.ExtendedQueryTag.TagPath = @tagPath
@@ -1152,7 +1152,7 @@ AS
             DELETE FROM dbo.ExtendedQueryTagPersonName WHERE TagKey = @tagKey
 
         -- Delete tag
-        DELETE FROM dbo.ExtendedQueryTag 
+        DELETE FROM dbo.ExtendedQueryTag
         WHERE TagKey = @tagKey
 
         DELETE FROM dbo.ExtendedQueryTagError
@@ -1223,12 +1223,12 @@ AS
     AND     SopInstanceUid = ISNULL(@sopInstanceUid, SopInstanceUid)
 
     IF @@ROWCOUNT = 0
-        THROW 50404, 'Instance not found', 1    
+        THROW 50404, 'Instance not found', 1
 
     -- Deleting tag errors
     DECLARE @deletedTags AS TABLE
     (
-        TagKey BIGINT  
+        TagKey BIGINT
     )
     DELETE XQTE
         OUTPUT deleted.TagKey
@@ -1250,10 +1250,10 @@ AS
         INSERT INTO @deletedTagCounts
             (TagKey, ErrorCount)
         SELECT TagKey, COUNT(1)
-        FROM @deletedTags    
+        FROM @deletedTags
         GROUP BY TagKey
 
-        UPDATE XQT 
+        UPDATE XQT
         SET XQT.ErrorCount = XQT.ErrorCount - DTC.ErrorCount
         FROM dbo.ExtendedQueryTag AS XQT
         INNER JOIN @deletedTagCounts AS DTC
@@ -1304,7 +1304,7 @@ AS
 
     UPDATE cf
     SET cf.CurrentWatermark = NULL
-    FROM dbo.ChangeFeed cf
+    FROM dbo.ChangeFeed cf WITH(FORCESEEK)
     JOIN @deletedInstances d
     ON cf.StudyInstanceUid = d.StudyInstanceUid
         AND cf.SeriesInstanceUid = d.SeriesInstanceUid


### PR DESCRIPTION
## Description
This PR addresses a deadlock issue when issuing a delete command. The stored procedure could encounter a deadlock if the SQL execution plan decided to use a scan instead of a seek while updating the change feed table. This is fixed by using the hint of `FORCESEEK` to always use a seek.

## Related issues
Addresses [AB#85178](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/85178).

## Testing
Manual testing.
