### PR TITLE
Add default value for backward compatibility

### DIFF
--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.diff.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.diff.sql
@@ -535,7 +535,7 @@ GO
 /***************************************************************************************/
 CREATE OR ALTER PROCEDURE dbo.AddExtendedQueryTags (
     @extendedQueryTags dbo.AddExtendedQueryTagsInputTableType_1 READONLY,
-    @maxAllowedCount INT,
+    @maxAllowedCount INT = 128, -- Default value for backwards compatibility
     @ready BIT = 0
 )
 AS

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.sql
@@ -2020,7 +2020,7 @@ GO
 /***************************************************************************************/
 CREATE OR ALTER PROCEDURE dbo.AddExtendedQueryTags (
     @extendedQueryTags dbo.AddExtendedQueryTagsInputTableType_1 READONLY,
-    @maxAllowedCount INT,
+    @maxAllowedCount INT = 128, -- Default value for backwards compatibility
     @ready BIT = 0
 )
 AS

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Model/VLatest.Generated.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Model/VLatest.Generated.cs
@@ -309,10 +309,10 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.Schema.Model
             }
 
             private readonly AddExtendedQueryTagsInputTableTypeV1TableValuedParameterDefinition _extendedQueryTags = new AddExtendedQueryTagsInputTableTypeV1TableValuedParameterDefinition("@extendedQueryTags");
-            private readonly ParameterDefinition<System.Int32> _maxAllowedCount = new ParameterDefinition<System.Int32>("@maxAllowedCount", global::System.Data.SqlDbType.Int, false);
+            private readonly ParameterDefinition<System.Nullable<System.Int32>> _maxAllowedCount = new ParameterDefinition<System.Nullable<System.Int32>>("@maxAllowedCount", global::System.Data.SqlDbType.Int, true);
             private readonly ParameterDefinition<System.Nullable<System.Boolean>> _ready = new ParameterDefinition<System.Nullable<System.Boolean>>("@ready", global::System.Data.SqlDbType.Bit, true);
 
-            public void PopulateCommand(SqlCommandWrapper command, global::System.Collections.Generic.IEnumerable<AddExtendedQueryTagsInputTableTypeV1Row> extendedQueryTags, System.Int32 maxAllowedCount, System.Nullable<System.Boolean> ready)
+            public void PopulateCommand(SqlCommandWrapper command, global::System.Collections.Generic.IEnumerable<AddExtendedQueryTagsInputTableTypeV1Row> extendedQueryTags, System.Nullable<System.Int32> maxAllowedCount, System.Nullable<System.Boolean> ready)
             {
                 command.CommandType = global::System.Data.CommandType.StoredProcedure;
                 command.CommandText = "dbo.AddExtendedQueryTags";
@@ -321,7 +321,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.Schema.Model
                 _ready.AddParameter(command.Parameters, ready);
             }
 
-            public void PopulateCommand(SqlCommandWrapper command, System.Int32 maxAllowedCount, System.Nullable<System.Boolean> ready, AddExtendedQueryTagsTableValuedParameters tableValuedParameters)
+            public void PopulateCommand(SqlCommandWrapper command, System.Nullable<System.Int32> maxAllowedCount, System.Nullable<System.Boolean> ready, AddExtendedQueryTagsTableValuedParameters tableValuedParameters)
             {
                 PopulateCommand(command, maxAllowedCount: maxAllowedCount, ready: ready, extendedQueryTags: tableValuedParameters.ExtendedQueryTags);
             }


### PR DESCRIPTION
## Description
Add default value to SP AddExtendedQueryTag for backward compatibility -- allow old binaries work with new SQL schema

## Related issues
Addresses [AB#85211](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/85211)

## Testing
All tests pass.
