### PR TITLE
Latest binary be able to run run on old Sql Schema(V3)

### DIFF
--- a/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/SqlExtendedQueryTagStoreV2.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/SqlExtendedQueryTagStoreV2.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
             }
         }
 
-        private async Task<List<ExtendedQueryTagStoreEntry>> GetAllExtendedQueryTagsAsync(CancellationToken cancellationToken = default)
+        protected async Task<List<ExtendedQueryTagStoreEntry>> GetAllExtendedQueryTagsAsync(CancellationToken cancellationToken = default)
         {
             List<ExtendedQueryTagStoreEntry> results = new List<ExtendedQueryTagStoreEntry>();
 

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/SqlExtendedQueryTagStoreV2.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/SqlExtendedQueryTagStoreV2.cs
@@ -80,6 +80,20 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
                 }
             }
         }
+        public override async Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsAsync(int limit, int offset, CancellationToken cancellationToken = default)
+        {
+            EnsureArg.IsGte(offset, 0, nameof(offset));
+            EnsureArg.IsGte(limit, 0, nameof(limit));
+
+            var tags = await GetAllExtendedQueryTagsAsync(cancellationToken);
+            if (offset >= tags.Count)
+            {
+                return Array.Empty<ExtendedQueryTagStoreEntry>();
+            }
+
+            tags.Sort((entry1, entry2) => entry1.Key - entry2.Key);
+            return tags.GetRange(offset, Math.Min(limit, tags.Count - offset));
+        }
 
         public override async Task<ExtendedQueryTagStoreEntry> GetExtendedQueryTagAsync(string path, CancellationToken cancellationToken = default)
         {
@@ -145,7 +159,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
             }
         }
 
-        protected async Task<List<ExtendedQueryTagStoreEntry>> GetAllExtendedQueryTagsAsync(CancellationToken cancellationToken = default)
+        private async Task<List<ExtendedQueryTagStoreEntry>> GetAllExtendedQueryTagsAsync(CancellationToken cancellationToken = default)
         {
             List<ExtendedQueryTagStoreEntry> results = new List<ExtendedQueryTagStoreEntry>();
 

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/SqlExtendedQueryTagStoreV3.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/SqlExtendedQueryTagStoreV3.cs
@@ -3,7 +3,12 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 using Microsoft.Health.Dicom.SqlServer.Features.Schema;
 using Microsoft.Health.SqlServer.Features.Client;
 
@@ -19,5 +24,16 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
         }
 
         public override SchemaVersion Version => SchemaVersion.V3;
+        public override async Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsAsync(int limit, int offset, CancellationToken cancellationToken = default)
+        {
+            var tags = await GetAllExtendedQueryTagsAsync(cancellationToken);
+            tags.Sort((entry1, entry2) => entry1.Key - entry2.Key);
+            if (offset < 0 || offset >= tags.Count || limit <= 0)
+            {
+                return Array.Empty<ExtendedQueryTagStoreEntry>();
+            }
+
+            return tags.GetRange(offset, Math.Min(limit, tags.Count - offset));
+        }
     }
 }

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/SqlExtendedQueryTagStoreV3.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/SqlExtendedQueryTagStoreV3.cs
@@ -3,12 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 using Microsoft.Health.Dicom.SqlServer.Features.Schema;
 using Microsoft.Health.SqlServer.Features.Client;
 
@@ -24,16 +19,5 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
         }
 
         public override SchemaVersion Version => SchemaVersion.V3;
-        public override async Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsAsync(int limit, int offset, CancellationToken cancellationToken = default)
-        {
-            var tags = await GetAllExtendedQueryTagsAsync(cancellationToken);
-            tags.Sort((entry1, entry2) => entry1.Key - entry2.Key);
-            if (offset < 0 || offset >= tags.Count || limit <= 0)
-            {
-                return Array.Empty<ExtendedQueryTagStoreEntry>();
-            }
-
-            return tags.GetRange(offset, Math.Min(limit, tags.Count - offset));
-        }
     }
 }

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.diff.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.diff.sql
@@ -10,7 +10,7 @@ BEGIN
     ALTER TABLE dbo.ExtendedQueryTag
     ADD
         QueryStatus TINYINT DEFAULT 1 NOT NULL,
-        ErrorCount  INT NOT NULL
+        ErrorCount  INT DEFAULT 0 NOT NULL
 END
 
 /*************************************************************

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.sql
@@ -389,7 +389,7 @@ CREATE TABLE dbo.ExtendedQueryTag (
     TagLevel                TINYINT              NOT NULL,
     TagStatus               TINYINT              NOT NULL,
     QueryStatus             TINYINT              DEFAULT 1 NOT NULL,
-    ErrorCount              INT                  NOT NULL
+    ErrorCount              INT                  DEFAULT 0 NOT NULL
 )
 
 CREATE UNIQUE CLUSTERED INDEX IXC_ExtendedQueryTag ON dbo.ExtendedQueryTag


### PR DESCRIPTION
## Description
Latest binary be able to run run on old Sql Schema(V3)

## Related issues
Addresses [issue #].

## Testing
All end to end tests can run on V3 Sql schema except extended query tags.
