### PR TITLE
Add Operation to Extended Query Tag Output

### DIFF
--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -68,14 +68,14 @@ stages:
 - stage: RunIntegrationTests
   displayName: 'Run Integration Tests'
   dependsOn:
-  - UpdateTestEnvironment
+  - UpdateCIEnvironment
   jobs:
   - template: run-integration-tests.yml
 
 - stage: RunE2ETests
   displayName: 'Run E2E Tests'
   dependsOn:
-  - UpdateTestEnvironment
+  - UpdateCIEnvironment
   jobs:
   - template: run-e2e-tests.yml
 

--- a/build/add-aad-test-environment.yml
+++ b/build/add-aad-test-environment.yml
@@ -16,9 +16,9 @@ steps:
       Install-Module -Name AzureAD -Force -Verbose -Scope CurrentUser
       $tenantId = "$(tenant-id)"
 
-      # Get admin token
+      # Get admin token      
       $username = "$(tenant-admin-user-name)"
-      $password_raw = "$(tenant-admin-user-password)"
+      $password_raw = '$(tenant-admin-user-password)'
       $password =  ConvertTo-SecureString -AsPlainText $password_raw -Force
       $adminCredential = New-Object PSCredential $username,$password
 
@@ -44,10 +44,13 @@ steps:
           Write-Host "'$(deploymentName)-ts' not found in '$(resourceGroupRegion)'"
       }
 
+      Write-Host "PENCHE: Connect-AzureAD"
+      Write-Host "PENCHE: Password $password_raw"
       $response = Invoke-RestMethod -Method 'Post' -Uri $adTokenUrl -ContentType "application/x-www-form-urlencoded" -Body $body
       Connect-AzureAD -TenantId $tenantId -AadAccessToken $response.access_token -AccountId $username
 
       Import-Module $(System.DefaultWorkingDirectory)/samples/scripts/PowerShell/DicomServer.psd1
       Import-Module $(System.DefaultWorkingDirectory)/release/scripts/PowerShell/DicomServerRelease/DicomServerRelease.psd1
 
+      Write-Host "PENCHE: Call Add-AadTestAuthEnvironment"
       $output = Add-AadTestAuthEnvironment -TestAuthEnvironmentPath $(System.DefaultWorkingDirectory)/testauthenvironment.json -EnvironmentName $(deploymentName) -TenantAdminCredential $adminCredential -EnvironmentLocation $(resourceGroupRegion)

--- a/build/add-aad-test-environment.yml
+++ b/build/add-aad-test-environment.yml
@@ -16,7 +16,7 @@ steps:
       Install-Module -Name AzureAD -Force -Verbose -Scope CurrentUser
       $tenantId = "$(tenant-id)"
 
-      # Get admin token      
+      # Get admin token
       $username = "$(tenant-admin-user-name)"
       $password_raw = '$(tenant-admin-user-password)'
       $password =  ConvertTo-SecureString -AsPlainText $password_raw -Force
@@ -29,10 +29,10 @@ steps:
           grant_type = "password"
           username   = $username
           password   = $password_raw
-          resource   = $resource 
+          resource   = $resource
           client_id  = "1950a258-227b-4e31-a9cf-717495945fc2" # Microsoft Azure PowerShell
       }
-              
+
       # If a deleted keyvault exists, remove it
       if (Get-AzKeyVault -VaultName "$(deploymentName)-ts" -Location "$(resourceGroupRegion)" -InRemovedState)
       {
@@ -44,13 +44,10 @@ steps:
           Write-Host "'$(deploymentName)-ts' not found in '$(resourceGroupRegion)'"
       }
 
-      Write-Host "PENCHE: Connect-AzureAD"
-      Write-Host "PENCHE: Password $password_raw"
       $response = Invoke-RestMethod -Method 'Post' -Uri $adTokenUrl -ContentType "application/x-www-form-urlencoded" -Body $body
       Connect-AzureAD -TenantId $tenantId -AadAccessToken $response.access_token -AccountId $username
 
       Import-Module $(System.DefaultWorkingDirectory)/samples/scripts/PowerShell/DicomServer.psd1
       Import-Module $(System.DefaultWorkingDirectory)/release/scripts/PowerShell/DicomServerRelease/DicomServerRelease.psd1
 
-      Write-Host "PENCHE: Call Add-AadTestAuthEnvironment"
       $output = Add-AadTestAuthEnvironment -TestAuthEnvironmentPath $(System.DefaultWorkingDirectory)/testauthenvironment.json -EnvironmentName $(deploymentName) -TenantAdminCredential $adminCredential -EnvironmentLocation $(resourceGroupRegion)

--- a/release/scripts/PowerShell/DicomServerRelease/Public/Add-AadTestAuthEnvironment.ps1
+++ b/release/scripts/PowerShell/DicomServerRelease/Public/Add-AadTestAuthEnvironment.ps1
@@ -39,6 +39,7 @@ function Add-AadTestAuthEnvironment {
 
     Set-StrictMode -Version Latest
 
+    Write-Host "PENCHE: Get AzureAD Context"
     # Get current AzureAd context
     try {
         $tenantInfo = Get-AzureADCurrentSessionInfo -ErrorAction Stop
@@ -47,6 +48,7 @@ function Add-AadTestAuthEnvironment {
         throw "Please log in to Azure AD with Connect-AzureAD cmdlet before proceeding"
     }
 
+    Write-Host "PENCHE: Get Azure Context"
     # Get current Az context
     try {
         $azContext = Get-AzContext

--- a/release/scripts/PowerShell/DicomServerRelease/Public/Add-AadTestAuthEnvironment.ps1
+++ b/release/scripts/PowerShell/DicomServerRelease/Public/Add-AadTestAuthEnvironment.ps1
@@ -39,7 +39,6 @@ function Add-AadTestAuthEnvironment {
 
     Set-StrictMode -Version Latest
 
-    Write-Host "PENCHE: Get AzureAD Context"
     # Get current AzureAd context
     try {
         $tenantInfo = Get-AzureADCurrentSessionInfo -ErrorAction Stop
@@ -48,7 +47,6 @@ function Add-AadTestAuthEnvironment {
         throw "Please log in to Azure AD with Connect-AzureAD cmdlet before proceeding"
     }
 
-    Write-Host "PENCHE: Get Azure Context"
     # Get current Az context
     try {
         $azContext = Get-AzContext
@@ -150,7 +148,7 @@ function Add-AadTestAuthEnvironment {
         $appIdSecureString = ConvertTo-SecureString -String $aadClientApplication.AppId -AsPlainText -Force
         Set-AzKeyVaultSecret -VaultName $KeyVaultName -Name "app--$($clientApp.Id)--id" -SecretValue $appIdSecureString | Out-Null
         Set-AzKeyVaultSecret -VaultName $KeyVaultName -Name "app--$($clientApp.Id)--secret" -SecretValue $secretSecureString | Out-Null
-        
+
         Set-DicomServerClientAppRoleAssignments -ApiAppId $application.AppId -AppId $aadClientApplication.AppId -AppRoles $clientApp.roles | Out-Null
     }
 
@@ -159,9 +157,9 @@ function Add-AadTestAuthEnvironment {
     $aadTenantId = (Get-AzureADCurrentSessionInfo).Tenant.Id.ToString()
     $tokenUrl  = "$aadEndpoint$aadTenantId/oauth2/token"
     $tokenUrlSecureString = ConvertTo-SecureString -String $tokenUrl -AsPlainText -Force
-        
+
     Set-AzKeyVaultSecret -VaultName $KeyVaultName -Name "security--tokenUrl" -SecretValue $tokenUrlSecureString | Out-Null
-    
+
     @{
         keyVaultName                  = $KeyVaultName
         environmentUsers              = $environmentUsers

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/DeleteExtendedQueryTagServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/DeleteExtendedQueryTagServiceTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.ChangeFeed
             string path = DicomTag.DeviceSerialNumber.GetPath();
             _extendedQueryTagStore
                 .GetExtendedQueryTagAsync(path, default)
-                .Returns(Task.FromException<ExtendedQueryTagStoreEntry>(new ExtendedQueryTagNotFoundException("Tag doesn't exist")));
+                .Returns(Task.FromException<ExtendedQueryTagStoreJoinEntry>(new ExtendedQueryTagNotFoundException("Tag doesn't exist")));
 
             await Assert.ThrowsAsync<ExtendedQueryTagNotFoundException>(() => _extendedQueryTagService.DeleteExtendedQueryTagAsync(path));
 
@@ -52,7 +52,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.ChangeFeed
         {
             DicomTag tag = DicomTag.DeviceSerialNumber;
             string tagPath = tag.GetPath();
-            ExtendedQueryTagStoreEntry entry = tag.BuildExtendedQueryTagStoreEntry();
+            var entry = new ExtendedQueryTagStoreJoinEntry(tag.BuildExtendedQueryTagStoreEntry());
             _extendedQueryTagStore.GetExtendedQueryTagAsync(tagPath, default).Returns(entry);
             await _extendedQueryTagService.DeleteExtendedQueryTagAsync(tagPath);
             await _extendedQueryTagStore.Received(1).DeleteExtendedQueryTagAsync(tagPath, entry.VR);

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/QueryTagServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ExtendedQueryTag/QueryTagServiceTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.ExtendedQueryTag
         public async Task GivenValidInput_WhenGetExtendedQueryTagsIsCalledMultipleTimes_ThenExtendedQueryTagStoreIsCalledOnce()
         {
             _extendedQueryTagStore.GetExtendedQueryTagsAsync(int.MaxValue, 0, Arg.Any<CancellationToken>())
-                  .Returns(Array.Empty<ExtendedQueryTagStoreEntry>());
+                  .Returns(Array.Empty<ExtendedQueryTagStoreJoinEntry>());
 
             await _queryTagService.GetQueryTagsAsync();
             await _queryTagService.GetQueryTagsAsync();

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/ExtendedQueryTagStoreEntry.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/ExtendedQueryTagStoreEntry.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using EnsureThat;
-using Microsoft.Health.Dicom.Core.Features.Routing;
 
 namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
 {
@@ -49,25 +48,5 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         /// Error count on this tag.
         /// </summary>
         public int ErrorCount { get; }
-
-        /// <summary>
-        /// Convert to  <see cref="GetExtendedQueryTagEntry"/>.
-        /// </summary>
-        /// <param name="resolver">An optional <see cref="IUrlResolver"/> for resolving resource paths.</param>
-        /// <returns>The extended query tag entry.</returns>
-        public GetExtendedQueryTagEntry ToExtendedQueryTagEntry(IUrlResolver resolver = null)
-        {
-            return new GetExtendedQueryTagEntry
-            {
-                Path = Path,
-                VR = VR,
-                PrivateCreator = PrivateCreator,
-                Level = Level,
-                Status = Status,
-                Errors = ErrorCount > 0 && resolver != null
-                    ? new ExtendedQueryTagErrorReference(ErrorCount, resolver.ResolveQueryTagErrorsUri(Path))
-                    : null,
-            };
-        }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/ExtendedQueryTagStoreJoinEntry.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/ExtendedQueryTagStoreJoinEntry.cs
@@ -1,0 +1,76 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+using Microsoft.Health.Dicom.Core.Features.Routing;
+using Microsoft.Health.Dicom.Core.Models.Operations;
+
+namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
+{
+    /// <summary>
+    /// Represent an extended query tag entry has retrieved from the store that has been
+    /// joined with its corresponding optional operation.
+    /// </summary>
+    public class ExtendedQueryTagStoreJoinEntry : ExtendedQueryTagStoreEntry
+    {
+        public ExtendedQueryTagStoreJoinEntry(ExtendedQueryTagStoreEntry storeEntry, Guid? operationId = null)
+            : base(
+                EnsureArg.IsNotNull(storeEntry, nameof(storeEntry)).Key,
+                storeEntry.Path,
+                storeEntry.VR,
+                storeEntry.PrivateCreator,
+                storeEntry.Level,
+                storeEntry.Status,
+                storeEntry.QueryStatus,
+                storeEntry.ErrorCount)
+        {
+            OperationId = operationId;
+        }
+
+        public ExtendedQueryTagStoreJoinEntry(
+            int key,
+            string path,
+            string vr,
+            string privateCreator,
+            QueryTagLevel level,
+            ExtendedQueryTagStatus status,
+            QueryStatus queryStatus,
+            int errorCount,
+            Guid? operationId = null)
+            : base(key, path, vr, privateCreator, level, status, queryStatus, errorCount)
+        {
+            OperationId = operationId;
+        }
+
+        /// <summary>
+        /// The optional ID for the long-running operation acted upon the tag.
+        /// </summary>
+        public Guid? OperationId { get; }
+
+        /// <summary>
+        /// Convert to  <see cref="GetExtendedQueryTagEntry"/>.
+        /// </summary>
+        /// <param name="resolver">An optional <see cref="IUrlResolver"/> for resolving resource paths.</param>
+        /// <returns>The extended query tag entry.</returns>
+        public GetExtendedQueryTagEntry ToExtendedQueryTagEntry(IUrlResolver resolver = null)
+        {
+            return new GetExtendedQueryTagEntry
+            {
+                Path = Path,
+                VR = VR,
+                PrivateCreator = PrivateCreator,
+                Level = Level,
+                Status = Status,
+                Errors = ErrorCount > 0 && resolver != null
+                    ? new ExtendedQueryTagErrorReference(ErrorCount, resolver.ResolveQueryTagErrorsUri(Path))
+                    : null,
+                Operation = OperationId.HasValue && resolver != null
+                    ? new OperationReference(OperationId.GetValueOrDefault(), resolver.ResolveOperationStatusUri(OperationId.GetValueOrDefault()))
+                    : null,
+            };
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/GetExtendedQueryTagEntry.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/GetExtendedQueryTagEntry.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Microsoft.Health.Dicom.Core.Models.Operations;
+
 namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
 {
     /// <summary>
@@ -25,9 +27,14 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         /// </summary>
         public ExtendedQueryTagErrorReference Errors { get; set; }
 
+        /// <summary>
+        /// Optional reference to the operation acted upon the act.
+        /// </summary>
+        public OperationReference Operation { get; set; }
+
         public override string ToString()
         {
-            return $"Path: {Path}, VR:{VR}, PrivateCreator:{PrivateCreator}, Level:{Level}, Status:{Status}, Errors: {Errors?.Count ?? 0}";
+            return $"Path: {Path}, VR:{VR}, PrivateCreator:{PrivateCreator}, Level:{Level}, Status:{Status}, Errors: {Errors?.Count ?? 0}, OperationId: {Operation?.Id}";
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/GetExtendedQueryTagsService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/GetExtendedQueryTagsService.cs
@@ -52,13 +52,13 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
                 throw new InvalidExtendedQueryTagPathException(string.Format(DicomCoreResource.InvalidExtendedQueryTag, tagPath ?? string.Empty));
             }
 
-            ExtendedQueryTagStoreEntry extendedQueryTag = await _extendedQueryTagStore.GetExtendedQueryTagAsync(numericalTagPath, cancellationToken);
+            ExtendedQueryTagStoreJoinEntry extendedQueryTag = await _extendedQueryTagStore.GetExtendedQueryTagAsync(numericalTagPath, cancellationToken);
             return new GetExtendedQueryTagResponse(extendedQueryTag.ToExtendedQueryTagEntry(_urlResolver));
         }
 
         public async Task<GetExtendedQueryTagsResponse> GetExtendedQueryTagsAsync(int limit, int offset = 0, CancellationToken cancellationToken = default)
         {
-            IReadOnlyList<ExtendedQueryTagStoreEntry> extendedQueryTags = await _extendedQueryTagStore.GetExtendedQueryTagsAsync(limit, offset, cancellationToken);
+            IReadOnlyList<ExtendedQueryTagStoreJoinEntry> extendedQueryTags = await _extendedQueryTagStore.GetExtendedQueryTagsAsync(limit, offset, cancellationToken);
             return new GetExtendedQueryTagsResponse(extendedQueryTags.Select(x => x.ToExtendedQueryTagEntry(_urlResolver)));
         }
     }

--- a/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/IExtendedQueryTagStore.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ExtendedQueryTag/IExtendedQueryTagStore.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         /// A task representing the asynchronous get operation. The value of its <see cref="Task{TResult}.Result"/>
         /// property contains the tag's information as found in storage.
         /// </returns>
-        Task<ExtendedQueryTagStoreEntry> GetExtendedQueryTagAsync(string tagPath, CancellationToken cancellationToken = default);
+        Task<ExtendedQueryTagStoreJoinEntry> GetExtendedQueryTagAsync(string tagPath, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get stored extended query tags from ExtendedQueryTagStore, if provided, by tagPath.
@@ -61,7 +61,7 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         /// <para>-or-</para>
         /// <para><paramref name="offset"/> is less than <c>0</c>.</para>
         /// </exception>
-        Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsAsync(int limit, int offset = 0, CancellationToken cancellationToken = default);
+        Task<IReadOnlyList<ExtendedQueryTagStoreJoinEntry>> GetExtendedQueryTagsAsync(int limit, int offset = 0, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Asynchronously gets extended query tags by keys.
@@ -69,7 +69,7 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         /// <param name="queryTagKeys">The tag keys.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The task.</returns>
-        Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsAsync(IReadOnlyList<int> queryTagKeys, CancellationToken cancellationToken = default);
+        Task<IReadOnlyList<ExtendedQueryTagStoreJoinEntry>> GetExtendedQueryTagsAsync(IReadOnlyList<int> queryTagKeys, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Update QueryStatus of extended query tag.
@@ -78,7 +78,7 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         /// <param name="queryStatus">The query status.</param>
         /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The updated extended query tag.</returns>
-        Task<ExtendedQueryTagStoreEntry> UpdateQueryStatusAsync(string tagPath, QueryStatus queryStatus, CancellationToken cancellationToken = default);
+        Task<ExtendedQueryTagStoreJoinEntry> UpdateQueryStatusAsync(string tagPath, QueryStatus queryStatus, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Asynchronously gets extended query tags assigned to the <paramref name="operationId"/>.
@@ -88,12 +88,12 @@ namespace Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag
         /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.
         /// </param>
         /// <returns>
-        /// A task representing the <see cref="GetExtendedQueryTagsByOperationAsync"/> operation.
+        /// A task representing the <see cref="GetExtendedQueryTagsAsync(Guid, CancellationToken)"/> operation.
         /// The value of its <see cref="Task{TResult}.Result"/> property contains the set of query tags assigned
         /// to the <paramref name="operationId"/>.
         /// </returns>
         /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
-        Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsByOperationAsync(Guid operationId, CancellationToken cancellationToken = default);
+        Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsAsync(Guid operationId, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Asynchronously deletes extended query tag.

--- a/src/Microsoft.Health.Dicom.Functions.Client.UnitTests/DicomAzureFunctionsHttpClientTests.cs
+++ b/src/Microsoft.Health.Dicom.Functions.Client.UnitTests/DicomAzureFunctionsHttpClientTests.cs
@@ -157,10 +157,10 @@ namespace Microsoft.Health.Dicom.Functions.Client.UnitTests
                     Arg.Is<IReadOnlyList<int>>(x => x.SequenceEqual(new int[] { 1, 4 })),
                     source.Token)
                 .Returns(
-                    new List<ExtendedQueryTagStoreEntry>
+                    new List<ExtendedQueryTagStoreJoinEntry>
                     {
-                        new ExtendedQueryTagStoreEntry(1, "00101010", "AS", null, QueryTagLevel.Study, ExtendedQueryTagStatus.Adding, QueryStatus.Enabled, 0),
-                        new ExtendedQueryTagStoreEntry(4, "00104040", "DT", null, QueryTagLevel.Instance, ExtendedQueryTagStatus.Adding, QueryStatus.Enabled, 0),
+                        new ExtendedQueryTagStoreJoinEntry(1, "00101010", "AS", null, QueryTagLevel.Study, ExtendedQueryTagStatus.Adding, QueryStatus.Enabled, 0, id),
+                        new ExtendedQueryTagStoreJoinEntry(4, "00104040", "DT", null, QueryTagLevel.Instance, ExtendedQueryTagStatus.Adding, QueryStatus.Enabled, 0, id),
                     });
             handler.SendingAsync += (msg, token) => AssertExpectedStatusRequestAsync(msg, id);
 

--- a/src/Microsoft.Health.Dicom.Functions.UnitTests/Indexing/ReindexDurableFunctionTests.Activity.cs
+++ b/src/Microsoft.Health.Dicom.Functions.UnitTests/Indexing/ReindexDurableFunctionTests.Activity.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Health.Dicom.Functions.UnitTests.Indexing
             context.InstanceId.Returns(OperationId.ToString(operationId));
 
             _extendedQueryTagStore
-                .GetExtendedQueryTagsByOperationAsync(operationId, CancellationToken.None)
+                .GetExtendedQueryTagsAsync(operationId, CancellationToken.None)
                 .Returns(expectedOutput);
 
             // Call the activity
@@ -80,7 +80,7 @@ namespace Microsoft.Health.Dicom.Functions.UnitTests.Indexing
             Assert.Same(expectedOutput, actual);
             await _extendedQueryTagStore
                 .Received(1)
-                .GetExtendedQueryTagsByOperationAsync(operationId, CancellationToken.None);
+                .GetExtendedQueryTagsAsync(operationId, CancellationToken.None);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Dicom.Functions/Indexing/ReindexDurableFunction.Activity.cs
+++ b/src/Microsoft.Health.Dicom.Functions/Indexing/ReindexDurableFunction.Activity.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Health.Dicom.Functions.Indexing
                 "Fetching the extended query tags for operation ID '{OperationId}'.",
                 context.InstanceId);
 
-            return _extendedQueryTagStore.GetExtendedQueryTagsByOperationAsync(
+            return _extendedQueryTagStore.GetExtendedQueryTagsAsync(
                 context.GetInstanceGuid(),
                 cancellationToken: CancellationToken.None);
         }

--- a/src/Microsoft.Health.Dicom.SqlServer/Extensions/ColumnExtensions.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Extensions/ColumnExtensions.cs
@@ -1,0 +1,17 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.SqlServer.Features.Schema.Model;
+
+namespace Microsoft.Health.Dicom.SqlServer.Extensions
+{
+    internal static class ColumnExtensions
+    {
+        // TODO: Support additional types
+
+        public static NullableUniqueIdentifierColumn AsNullable(this UniqueIdentifierColumn column)
+            => new NullableUniqueIdentifierColumn(column.Metadata.Name);
+    }
+}

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/SqlExtendedQueryTagStore.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/SqlExtendedQueryTagStore.cs
@@ -44,32 +44,32 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
             await store.DeleteExtendedQueryTagAsync(tagPath, vr, cancellationToken);
         }
 
-        public async Task<ExtendedQueryTagStoreEntry> GetExtendedQueryTagAsync(string tagPath, CancellationToken cancellationToken = default)
+        public async Task<ExtendedQueryTagStoreJoinEntry> GetExtendedQueryTagAsync(string tagPath, CancellationToken cancellationToken = default)
         {
             ISqlExtendedQueryTagStore store = await _cache.GetAsync(cancellationToken: cancellationToken);
             return await store.GetExtendedQueryTagAsync(tagPath, cancellationToken);
         }
 
-        public async Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsAsync(int limit, int offset, CancellationToken cancellationToken = default)
+        public async Task<IReadOnlyList<ExtendedQueryTagStoreJoinEntry>> GetExtendedQueryTagsAsync(int limit, int offset, CancellationToken cancellationToken = default)
         {
             ISqlExtendedQueryTagStore store = await _cache.GetAsync(cancellationToken: cancellationToken);
             return await store.GetExtendedQueryTagsAsync(limit, offset, cancellationToken);
         }
 
-        public async Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsAsync(IReadOnlyList<int> queryTagKeys, CancellationToken cancellationToken = default)
+        public async Task<IReadOnlyList<ExtendedQueryTagStoreJoinEntry>> GetExtendedQueryTagsAsync(IReadOnlyList<int> queryTagKeys, CancellationToken cancellationToken = default)
         {
             ISqlExtendedQueryTagStore store = await _cache.GetAsync(cancellationToken: cancellationToken);
             return await store.GetExtendedQueryTagsAsync(queryTagKeys, cancellationToken);
         }
 
-        public async Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsByOperationAsync(Guid operationId, CancellationToken cancellationToken = default)
+        public async Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsAsync(Guid operationId, CancellationToken cancellationToken = default)
         {
             ISqlExtendedQueryTagStore store = await _cache.GetAsync(cancellationToken: cancellationToken);
-            return await store.GetExtendedQueryTagsByOperationAsync(operationId, cancellationToken);
+            return await store.GetExtendedQueryTagsAsync(operationId, cancellationToken);
         }
 
         ///<inheritdoc/>
-        public async Task<ExtendedQueryTagStoreEntry> UpdateQueryStatusAsync(string tagPath, QueryStatus queryStatus, CancellationToken cancellationToken = default)
+        public async Task<ExtendedQueryTagStoreJoinEntry> UpdateQueryStatusAsync(string tagPath, QueryStatus queryStatus, CancellationToken cancellationToken = default)
         {
             ISqlExtendedQueryTagStore store = await _cache.GetAsync(cancellationToken);
             return await store.UpdateQueryStatusAsync(tagPath, queryStatus, cancellationToken);

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/SqlExtendedQueryTagStoreV1.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/SqlExtendedQueryTagStoreV1.cs
@@ -26,17 +26,17 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
             throw new BadRequestException(DicomSqlServerResource.SchemaVersionNeedsToBeUpgraded);
         }
 
-        public virtual Task<ExtendedQueryTagStoreEntry> GetExtendedQueryTagAsync(string tagPath, CancellationToken cancellationToken = default)
+        public virtual Task<ExtendedQueryTagStoreJoinEntry> GetExtendedQueryTagAsync(string tagPath, CancellationToken cancellationToken = default)
         {
             throw new BadRequestException(DicomSqlServerResource.SchemaVersionNeedsToBeUpgraded);
         }
 
-        public virtual Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsAsync(int limit, int offset, CancellationToken cancellationToken = default)
+        public virtual Task<IReadOnlyList<ExtendedQueryTagStoreJoinEntry>> GetExtendedQueryTagsAsync(int limit, int offset, CancellationToken cancellationToken = default)
         {
             throw new BadRequestException(DicomSqlServerResource.SchemaVersionNeedsToBeUpgraded);
         }
 
-        public virtual Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsByOperationAsync(Guid operationId, CancellationToken cancellationToken = default)
+        public virtual Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsAsync(Guid operationId, CancellationToken cancellationToken = default)
         {
             throw new BadRequestException(DicomSqlServerResource.SchemaVersionNeedsToBeUpgraded);
         }
@@ -46,7 +46,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
             throw new BadRequestException(DicomSqlServerResource.SchemaVersionNeedsToBeUpgraded);
         }
 
-        public virtual Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsAsync(IReadOnlyList<int> queryTagKeys, CancellationToken cancellationToken = default)
+        public virtual Task<IReadOnlyList<ExtendedQueryTagStoreJoinEntry>> GetExtendedQueryTagsAsync(IReadOnlyList<int> queryTagKeys, CancellationToken cancellationToken = default)
         {
             throw new BadRequestException(DicomSqlServerResource.SchemaVersionNeedsToBeUpgraded);
         }
@@ -62,7 +62,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
         }
 
         ///<inheritdoc/>
-        public virtual Task<ExtendedQueryTagStoreEntry> UpdateQueryStatusAsync(string tagPath, QueryStatus queryStatus, CancellationToken cancellationToken)
+        public virtual Task<ExtendedQueryTagStoreJoinEntry> UpdateQueryStatusAsync(string tagPath, QueryStatus queryStatus, CancellationToken cancellationToken)
         {
             throw new BadRequestException(DicomSqlServerResource.SchemaVersionNeedsToBeUpgraded);
         }

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/SqlExtendedQueryTagStoreV2.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/ExtendedQueryTag/SqlExtendedQueryTagStoreV2.cs
@@ -80,22 +80,22 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
                 }
             }
         }
-        public override async Task<IReadOnlyList<ExtendedQueryTagStoreEntry>> GetExtendedQueryTagsAsync(int limit, int offset, CancellationToken cancellationToken = default)
+        public override async Task<IReadOnlyList<ExtendedQueryTagStoreJoinEntry>> GetExtendedQueryTagsAsync(int limit, int offset, CancellationToken cancellationToken = default)
         {
             EnsureArg.IsGte(offset, 0, nameof(offset));
-            EnsureArg.IsGte(limit, 0, nameof(limit));
+            EnsureArg.IsGte(limit, 1, nameof(limit));
 
             var tags = await GetAllExtendedQueryTagsAsync(cancellationToken);
             if (offset >= tags.Count)
             {
-                return Array.Empty<ExtendedQueryTagStoreEntry>();
+                return Array.Empty<ExtendedQueryTagStoreJoinEntry>();
             }
 
             tags.Sort((entry1, entry2) => entry1.Key - entry2.Key);
             return tags.GetRange(offset, Math.Min(limit, tags.Count - offset));
         }
 
-        public override async Task<ExtendedQueryTagStoreEntry> GetExtendedQueryTagAsync(string path, CancellationToken cancellationToken = default)
+        public override async Task<ExtendedQueryTagStoreJoinEntry> GetExtendedQueryTagAsync(string path, CancellationToken cancellationToken = default)
         {
             using (SqlConnectionWrapper sqlConnectionWrapper = await ConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken))
             using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateSqlCommand())
@@ -121,7 +121,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
                     executionTimeWatch.Stop();
                     Logger.LogInformation(executionTimeWatch.ElapsedMilliseconds.ToString());
 
-                    return new ExtendedQueryTagStoreEntry(tagKey, tagPath, tagVR, tagPrivateCreator, (QueryTagLevel)tagLevel, (ExtendedQueryTagStatus)tagStatus, QueryStatus.Enabled, 0);
+                    return new ExtendedQueryTagStoreJoinEntry(tagKey, tagPath, tagVR, tagPrivateCreator, (QueryTagLevel)tagLevel, (ExtendedQueryTagStatus)tagStatus, QueryStatus.Enabled, 0);
                 }
             }
         }
@@ -159,9 +159,9 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
             }
         }
 
-        private async Task<List<ExtendedQueryTagStoreEntry>> GetAllExtendedQueryTagsAsync(CancellationToken cancellationToken = default)
+        private async Task<List<ExtendedQueryTagStoreJoinEntry>> GetAllExtendedQueryTagsAsync(CancellationToken cancellationToken = default)
         {
-            List<ExtendedQueryTagStoreEntry> results = new List<ExtendedQueryTagStoreEntry>();
+            var results = new List<ExtendedQueryTagStoreJoinEntry>();
 
             using (SqlConnectionWrapper sqlConnectionWrapper = await ConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken))
             using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateSqlCommand())
@@ -182,7 +182,7 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.ExtendedQueryTag
                             V2.ExtendedQueryTag.TagLevel,
                             V2.ExtendedQueryTag.TagStatus);
 
-                        results.Add(new ExtendedQueryTagStoreEntry(tagKey, tagPath, tagVR, tagPrivateCreator, (QueryTagLevel)tagLevel, (ExtendedQueryTagStatus)tagStatus, QueryStatus.Enabled, 0));
+                        results.Add(new ExtendedQueryTagStoreJoinEntry(tagKey, tagPath, tagVR, tagPrivateCreator, (QueryTagLevel)tagLevel, (ExtendedQueryTagStatus)tagStatus, QueryStatus.Enabled, 0));
                     }
 
                     executionTimeWatch.Stop();

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.diff.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.diff.sql
@@ -373,9 +373,20 @@ CREATE OR ALTER PROCEDURE dbo.UpdateExtendedQueryTagQueryStatus
 AS
     SET NOCOUNT     ON
 
-    UPDATE dbo.ExtendedQueryTag
+    UPDATE XQT
     SET QueryStatus = @queryStatus
-    OUTPUT INSERTED.TagKey, INSERTED.TagPath, INSERTED.TagVR, INSERTED.TagPrivateCreator, INSERTED.TagLevel, INSERTED.TagStatus, INSERTED.QueryStatus, INSERTED.ErrorCount
+    OUTPUT
+        INSERTED.TagKey,
+        INSERTED.TagPath,
+        INSERTED.TagVR,
+        INSERTED.TagPrivateCreator,
+        INSERTED.TagLevel,
+        INSERTED.TagStatus,
+        INSERTED.QueryStatus,
+        INSERTED.ErrorCount,
+        XQTO.OperationId
+    FROM dbo.ExtendedQueryTag AS XQT
+    LEFT OUTER JOIN dbo.ExtendedQueryTagOperation AS XQTO ON XQT.TagKey = XQTO.TagKey
     WHERE TagPath = @tagPath
 GO
 
@@ -488,10 +499,11 @@ BEGIN
            TagLevel,
            TagStatus,
            QueryStatus,
-           ErrorCount
-    FROM dbo.ExtendedQueryTag AS XQT
-    INNER JOIN @extendedQueryTagKeys AS input
-    ON XQT.TagKey = input.TagKey
+           ErrorCount,
+           OperationId
+    FROM @extendedQueryTagKeys AS input
+    INNER JOIN dbo.ExtendedQueryTag AS XQT ON input.TagKey = XQT.TagKey
+    LEFT OUTER JOIN dbo.ExtendedQueryTagOperation AS XQTO ON XQT.TagKey = XQTO.TagKey
 END
 GO
 
@@ -1060,16 +1072,18 @@ BEGIN
     SET NOCOUNT     ON
     SET XACT_ABORT  ON
 
-    SELECT  TagKey,
-            TagPath,
-            TagVR,
-            TagPrivateCreator,
-            TagLevel,
-            TagStatus,
-            QueryStatus,
-            ErrorCount
-    FROM    dbo.ExtendedQueryTag
-    WHERE   TagPath = ISNULL(@tagPath, TagPath)
+    SELECT XQT.TagKey,
+           TagPath,
+           TagVR,
+           TagPrivateCreator,
+           TagLevel,
+           TagStatus,
+           QueryStatus,
+           ErrorCount,
+           OperationId
+    FROM dbo.ExtendedQueryTag AS XQT
+    LEFT OUTER JOIN dbo.ExtendedQueryTagOperation AS XQTO ON XQT.TagKey = XQTO.TagKey
+    WHERE TagPath = ISNULL(@tagPath, TagPath)
 END
 GO
 
@@ -1097,16 +1111,18 @@ BEGIN
     SET NOCOUNT     ON
     SET XACT_ABORT  ON
 
-    SELECT TagKey,
+    SELECT XQT.TagKey,
            TagPath,
            TagVR,
            TagPrivateCreator,
            TagLevel,
            TagStatus,
            QueryStatus,
-           ErrorCount
-    FROM dbo.ExtendedQueryTag
-    ORDER BY TagKey ASC
+           ErrorCount,
+           OperationId
+    FROM dbo.ExtendedQueryTag AS XQT
+    LEFT OUTER JOIN dbo.ExtendedQueryTagOperation AS XQTO ON XQT.TagKey = XQTO.TagKey
+    ORDER BY XQT.TagKey ASC
     OFFSET @offset ROWS
     FETCH NEXT @limit ROWS ONLY
 END

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.sql
@@ -1840,16 +1840,18 @@ BEGIN
     SET NOCOUNT     ON
     SET XACT_ABORT  ON
 
-    SELECT  TagKey,
-            TagPath,
-            TagVR,
-            TagPrivateCreator,
-            TagLevel,
-            TagStatus,
-            QueryStatus,
-            ErrorCount
-    FROM    dbo.ExtendedQueryTag
-    WHERE   TagPath = ISNULL(@tagPath, TagPath)
+    SELECT XQT.TagKey,
+           TagPath,
+           TagVR,
+           TagPrivateCreator,
+           TagLevel,
+           TagStatus,
+           QueryStatus,
+           ErrorCount,
+           OperationId
+    FROM dbo.ExtendedQueryTag AS XQT
+    LEFT OUTER JOIN dbo.ExtendedQueryTagOperation AS XQTO ON XQT.TagKey = XQTO.TagKey
+    WHERE TagPath = ISNULL(@tagPath, TagPath)
 END
 GO
 
@@ -1877,16 +1879,18 @@ BEGIN
     SET NOCOUNT     ON
     SET XACT_ABORT  ON
 
-    SELECT TagKey,
+    SELECT XQT.TagKey,
            TagPath,
            TagVR,
            TagPrivateCreator,
            TagLevel,
            TagStatus,
            QueryStatus,
-           ErrorCount
-    FROM dbo.ExtendedQueryTag
-    ORDER BY TagKey ASC
+           ErrorCount,
+           OperationId
+    FROM dbo.ExtendedQueryTag AS XQT
+    LEFT OUTER JOIN dbo.ExtendedQueryTagOperation AS XQTO ON XQT.TagKey = XQTO.TagKey
+    ORDER BY XQT.TagKey ASC
     OFFSET @offset ROWS
     FETCH NEXT @limit ROWS ONLY
 END
@@ -1919,10 +1923,11 @@ BEGIN
            TagLevel,
            TagStatus,
            QueryStatus,
-           ErrorCount
-    FROM dbo.ExtendedQueryTag AS XQT
-    INNER JOIN @extendedQueryTagKeys AS input
-    ON XQT.TagKey = input.TagKey
+           ErrorCount,
+           OperationId
+    FROM @extendedQueryTagKeys AS input
+    INNER JOIN dbo.ExtendedQueryTag AS XQT ON input.TagKey = XQT.TagKey
+    LEFT OUTER JOIN dbo.ExtendedQueryTagOperation AS XQTO ON XQT.TagKey = XQTO.TagKey
 END
 GO
 
@@ -2110,9 +2115,20 @@ CREATE OR ALTER PROCEDURE dbo.UpdateExtendedQueryTagQueryStatus
 AS
     SET NOCOUNT     ON
 
-    UPDATE dbo.ExtendedQueryTag
+    UPDATE XQT
     SET QueryStatus = @queryStatus
-    OUTPUT INSERTED.TagKey, INSERTED.TagPath, INSERTED.TagVR, INSERTED.TagPrivateCreator, INSERTED.TagLevel, INSERTED.TagStatus, INSERTED.QueryStatus, INSERTED.ErrorCount
+    OUTPUT
+        INSERTED.TagKey,
+        INSERTED.TagPath,
+        INSERTED.TagVR,
+        INSERTED.TagPrivateCreator,
+        INSERTED.TagLevel,
+        INSERTED.TagStatus,
+        INSERTED.QueryStatus,
+        INSERTED.ErrorCount,
+        XQTO.OperationId
+    FROM dbo.ExtendedQueryTag AS XQT
+    LEFT OUTER JOIN dbo.ExtendedQueryTagOperation AS XQTO ON XQT.TagKey = XQTO.TagKey
     WHERE TagPath = @tagPath
 GO
 


### PR DESCRIPTION
## Description
- Return `Operation` for the following APIs:
  - `GET /extendedquerytags`
  - `GET /extendedquerytags/{tagpath}`
  - `PATCH /extendedquerytags/{tagpath}`
- Rename `GetExtendedQueryTagsByOperationAsync` to `GetExtendedQueryTagsAsync`
- Add SQL change to support behavior before release is cut and SQL version bumped
- Include @pengchen0692's fix for build pipelines

## Related issues
[AB#85274](https://microsofthealth.visualstudio.com/Health/_workitems/edit/85274)

## Testing
Locally and via PR