### PR TITLE
Disable ExtendedQueryTag E2E tests when using InProc test server

### DIFF
--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/ExtendedQueryTagTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/ExtendedQueryTagTests.cs
@@ -68,7 +68,6 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             Assert.Contains(instances, instance => instance.ToInstanceIdentifier().Equals(instanceId));
         }
 
-
         [Theory]
         [MemberData(nameof(GetRequestBodyWithMissingProperty))]
         public async Task GivenMissingPropertyInRequestBody_WhenCallingPostAsync_ThenShouldThrowException(string requestBody, string missingProperty)

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/ExtendedQueryTagTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/ExtendedQueryTagTests.cs
@@ -26,12 +26,14 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
         private readonly IDicomWebClient _client;
         private readonly DicomTagsManager _tagManager;
         private readonly DicomInstancesManager _instanceManager;
+        private readonly bool _isUsingInProcTestServer;
 
         public ExtendedQueryTagTests(HttpIntegrationTestFixture<Startup> fixture)
         {
             EnsureArg.IsNotNull(fixture, nameof(fixture));
             EnsureArg.IsNotNull(fixture.Client, nameof(fixture.Client));
             _client = fixture.Client;
+            _isUsingInProcTestServer = fixture.IsUsingInProcTestServer;
             _tagManager = new DicomTagsManager(_client);
             _instanceManager = new DicomInstancesManager(_client);
         }
@@ -39,6 +41,12 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
         [Fact]
         public async Task GivenValidExtendedQueryTag_WhenGoThroughEndToEndScenario_ThenShouldSucceed()
         {
+            if (_isUsingInProcTestServer)
+            {
+                // AzureFunction doesn't have InProc test sever, skip this test.
+                return;
+            }
+
             DicomTag tag = DicomTag.SeriesNumber;
 
             // upload file


### PR DESCRIPTION
## Description
Disable ExtendedQueryTag E2E tests when using InProc test server.
Ideally we should mark it as skipped instead of pass, xunit does provide  such mechanism  through [`SkipException`](https://github.com/xunit/assert.xunit/blob/main/Sdk/Exceptions/SkipException.cs), but never released, don't know why.

## Related issues
Addresses [issue #].

## Testing
All tests pass
