### PR TITLE
Update IDicomWebClient for Extended Query Tags + Errors

### DIFF
--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Controllers/ExtendedQueryTagControllerTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Controllers/ExtendedQueryTagControllerTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Health.Dicom.Api.UnitTests.Extensions
 
             var actual = response as ObjectResult;
             Assert.Equal((int)HttpStatusCode.OK, actual.StatusCode);
-            Assert.Same(expected, actual.Value);
+            Assert.Same(expected.ExtendedQueryTagErrors, actual.Value);
 
             await mediator.Received(1).Send(
                 Arg.Is<GetExtendedQueryTagErrorsRequest>(x => x.Path == path),

--- a/src/Microsoft.Health.Dicom.Api/Controllers/ExtendedQueryTagController.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/ExtendedQueryTagController.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Health.Dicom.Api.Controllers
         /// </returns>
         [HttpGet]
         [Produces(KnownContentTypes.ApplicationJson)]
-        [ProducesResponseType(typeof(GetExtendedQueryTagErrorsResponse), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(IEnumerable<ExtendedQueryTagError>), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
         [VersionedRoute(KnownRoutes.GetExtendedQueryTagErrorsRoute, Name = KnownRouteNames.VersionedGetExtendedQueryTagErrors)]
@@ -176,7 +176,7 @@ namespace Microsoft.Health.Dicom.Api.Controllers
             EnsureFeatureIsEnabled();
             GetExtendedQueryTagErrorsResponse response = await _mediator.GetExtendedQueryTagErrorsAsync(tagPath, limit, offset, HttpContext.RequestAborted);
 
-            return StatusCode((int)HttpStatusCode.OK, response);
+            return StatusCode((int)HttpStatusCode.OK, response.ExtendedQueryTagErrors);
         }
 
         private void EnsureFeatureIsEnabled()

--- a/src/Microsoft.Health.Dicom.Client/DicomWebConstants.cs
+++ b/src/Microsoft.Health.Dicom.Client/DicomWebConstants.cs
@@ -29,6 +29,10 @@ namespace Microsoft.Health.Dicom.Client
         public const string QuerySeriesInstancUriFormat = SeriesUriString + "/{0}" + InstancesUriString;
         public const string BaseExtendedQueryTagUri = "/extendedquerytags";
         public const string BaseOperationUri = "/operations";
+        public const string BaseErrorsUriFormat = BaseExtendedQueryTagUri + "/{0}/errors";
+
+        public const string LimitParameter = "limit";
+        public const string OffsetParameter = "offset";
 
         public const string OriginalDicomTransferSyntax = "*";
 

--- a/src/Microsoft.Health.Dicom.Client/IDicomWebClient.ExtendedQueryTag.cs
+++ b/src/Microsoft.Health.Dicom.Client/IDicomWebClient.ExtendedQueryTag.cs
@@ -13,8 +13,13 @@ namespace Microsoft.Health.Dicom.Client
     public partial interface IDicomWebClient
     {
         Task<DicomWebResponse<OperationReference>> AddExtendedQueryTagAsync(IEnumerable<AddExtendedQueryTagEntry> tagEntries, CancellationToken cancellationToken = default);
+
         Task<DicomWebResponse> DeleteExtendedQueryTagAsync(string tagPath, CancellationToken cancellationToken = default);
+
         Task<DicomWebResponse<GetExtendedQueryTagEntry>> GetExtendedQueryTagAsync(string tagPath, CancellationToken cancellationToken = default);
-        Task<DicomWebResponse<IEnumerable<GetExtendedQueryTagEntry>>> GetExtendedQueryTagsAsync(CancellationToken cancellationToken = default);
+
+        Task<DicomWebResponse<IEnumerable<GetExtendedQueryTagEntry>>> GetExtendedQueryTagsAsync(int limit, int offset = 0, CancellationToken cancellationToken = default);
+
+        Task<DicomWebResponse<IEnumerable<ExtendedQueryTagError>>> GetExtendedQueryTagErrorsAsync(string tagPath, int limit, int offset = 0, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.Health.Dicom.Client/IDicomWebClient.ExtendedQueryTag.cs
+++ b/src/Microsoft.Health.Dicom.Client/IDicomWebClient.ExtendedQueryTag.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Health.Dicom.Client
 
         Task<DicomWebResponse<GetExtendedQueryTagEntry>> GetExtendedQueryTagAsync(string tagPath, CancellationToken cancellationToken = default);
 
-        Task<DicomWebResponse<IEnumerable<GetExtendedQueryTagEntry>>> GetExtendedQueryTagsAsync(int limit, int offset = 0, CancellationToken cancellationToken = default);
+        Task<DicomWebResponse<IEnumerable<GetExtendedQueryTagEntry>>> GetExtendedQueryTagsAsync(int limit = 100, int offset = 0, CancellationToken cancellationToken = default);
 
-        Task<DicomWebResponse<IEnumerable<ExtendedQueryTagError>>> GetExtendedQueryTagErrorsAsync(string tagPath, int limit, int offset = 0, CancellationToken cancellationToken = default);
+        Task<DicomWebResponse<IEnumerable<ExtendedQueryTagError>>> GetExtendedQueryTagErrorsAsync(string tagPath, int limit = 100, int offset = 0, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.Health.Dicom.Client/Models/ExtendedQueryTagError.cs
+++ b/src/Microsoft.Health.Dicom.Client/Models/ExtendedQueryTagError.cs
@@ -1,0 +1,40 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Health.Dicom.Client.Models
+{
+    /// <summary>
+    /// Represents a problem that arose when re-indexing the given DICOM instance.
+    /// </summary>
+    public class ExtendedQueryTagError
+    {
+        /// <summary>
+        /// Gets or sets the DICOM study instance UID.
+        /// </summary>
+        public string StudyInstanceUid { get; set; }
+
+        /// <summary>
+        /// Gets or sets the DICOM series instance UID.
+        /// </summary>
+        public string SeriesInstanceUid { get; set; }
+
+        /// <summary>
+        /// Gets or sets the DICOM SOP instance UID.
+        /// </summary>
+        public string SopInstanceUid { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date and time when the error was found.
+        /// </summary>
+        public DateTime CreatedTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the localized error message.
+        /// </summary>
+        public string ErrorMessage { get; set; }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Client/Models/ExtendedQueryTagErrorReference.cs
+++ b/src/Microsoft.Health.Dicom.Client/Models/ExtendedQueryTagErrorReference.cs
@@ -1,0 +1,27 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Health.Dicom.Client.Models
+{
+    /// <summary>
+    /// Represents a reference to a one or more extended query tag errors.
+    /// </summary>
+    public class ExtendedQueryTagErrorReference
+    {
+        /// <summary>
+        /// Gets or sets the number of errors.
+        /// </summary>
+        /// <value>The positive number of errors found at the <see cref="Href"/>.</value>
+        public int Count { get; set; }
+
+        /// <summary>
+        /// Gets or sets the resource reference for the errors.
+        /// </summary>
+        /// <value>The unique resource URL for the extended query tag errors.</value>
+        public Uri Href { get; set; }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Client/Models/GetExtendedQueryTagEntry.cs
+++ b/src/Microsoft.Health.Dicom.Client/Models/GetExtendedQueryTagEntry.cs
@@ -35,5 +35,15 @@ namespace Microsoft.Health.Dicom.Client.Models
         /// Identification code of private tag implementer.
         /// </summary>
         public string PrivateCreator { get; set; }
+
+        /// <summary>
+        /// Optional errors associated with the query tag.
+        /// </summary>
+        public ExtendedQueryTagErrorReference Errors { get; set; }
+
+        /// <summary>
+        /// Optional reference to the operation acted upon the act.
+        /// </summary>
+        public OperationReference Operation { get; set; }
     }
 }

--- a/src/Microsoft.Health.Dicom.Functions/host.json
+++ b/src/Microsoft.Health.Dicom.Functions/host.json
@@ -1,10 +1,16 @@
 ﻿{
   "version": "2.0",
-  "logging": {
-    "applicationInsights": {
-      "samplingSettings": {
-        "isEnabled": true,
-        "excludedTypes": "Request"
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Warning"
+    },
+    "ApplicationInsights": {
+      "LogLevel": {
+        "Default": "Information",
+        "Microsoft.Health": "Information",
+        "Microsoft": "Warning",
+        "System": "Warning"
       }
     }
   },

--- a/src/Microsoft.Health.Dicom.SqlServer/Registration/DicomSqlServerRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Registration/DicomSqlServerRegistrationExtensions.cs
@@ -53,7 +53,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddSqlIndexDataStores()
                 .AddSqlQueryStore()
                 .AddSqlInstanceStores()
-                .AddSqlExtendedQueryTagStores();
+                .AddSqlExtendedQueryTagStores()
+                .AddSqlExtendedQueryTagErrorStores();
 
             return dicomServerBuilder;
         }

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/InstanceStoreTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/InstanceStoreTests.cs
@@ -74,11 +74,11 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             DicomDataset dataset2 = Samples.CreateRandomInstanceDataset(studyUid);
             dataset2.Add(tag, tagValue2);
             DicomDataset dataset3 = Samples.CreateRandomInstanceDataset(studyUid);
-            dataset2.Add(tag, tagValue3);
+            dataset3.Add(tag, tagValue3);
 
             Instance instance1 = await CreateInstanceIndexAsync(dataset1);
             Instance instance2 = await CreateInstanceIndexAsync(dataset2);
-            Instance instance3 = await CreateInstanceIndexAsync(dataset2);
+            Instance instance3 = await CreateInstanceIndexAsync(dataset3);
 
             var tagStoreEntry = await AddExtendedQueryTagAsync(tag.BuildAddExtendedQueryTagEntry(level: QueryTagLevel.Study));
             QueryTag queryTag = new QueryTag(tagStoreEntry);

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/InstanceStoreTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/InstanceStoreTests.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             DicomTag tag = DicomTag.DeviceSerialNumber;
             string tagValue1 = "test1";
             string tagValue2 = "test2";
+            string tagValue3 = "test3";
 
             string studyUid = TestUidGenerator.Generate();
 
@@ -72,17 +73,29 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             dataset1.Add(tag, tagValue1);
             DicomDataset dataset2 = Samples.CreateRandomInstanceDataset(studyUid);
             dataset2.Add(tag, tagValue2);
+            DicomDataset dataset3 = Samples.CreateRandomInstanceDataset(studyUid);
+            dataset2.Add(tag, tagValue3);
+
             Instance instance1 = await CreateInstanceIndexAsync(dataset1);
             Instance instance2 = await CreateInstanceIndexAsync(dataset2);
+            Instance instance3 = await CreateInstanceIndexAsync(dataset2);
 
             var tagStoreEntry = await AddExtendedQueryTagAsync(tag.BuildAddExtendedQueryTagEntry(level: QueryTagLevel.Study));
             QueryTag queryTag = new QueryTag(tagStoreEntry);
 
-            await _indexDataStore.ReindexInstanceAsync(dataset1, instance1.Watermark, new[] { queryTag });
+            // Simulate re-indexing, which may re-index an instance which may re-index
+            // the instances for a particular study or series out-of-order
             await _indexDataStore.ReindexInstanceAsync(dataset2, instance2.Watermark, new[] { queryTag });
+            ExtendedQueryTagDataRow row = (await _extendedQueryTagStoreTestHelper.GetExtendedQueryTagDataAsync(ExtendedQueryTagDataType.StringData, tagStoreEntry.Key, instance1.StudyKey, null, null)).Single();
+            Assert.Equal(tagValue2, row.TagValue); // Added
 
-            var row = (await _extendedQueryTagStoreTestHelper.GetExtendedQueryTagDataAsync(ExtendedQueryTagDataType.StringData, tagStoreEntry.Key, instance1.StudyKey, null, null)).First();
-            Assert.Equal(tagValue2, row.TagValue);
+            await _indexDataStore.ReindexInstanceAsync(dataset3, instance3.Watermark, new[] { queryTag });
+            row = (await _extendedQueryTagStoreTestHelper.GetExtendedQueryTagDataAsync(ExtendedQueryTagDataType.StringData, tagStoreEntry.Key, instance1.StudyKey, null, null)).Single();
+            Assert.Equal(tagValue3, row.TagValue); // Overwrite
+
+            await _indexDataStore.ReindexInstanceAsync(dataset1, instance1.Watermark, new[] { queryTag });
+            row = (await _extendedQueryTagStoreTestHelper.GetExtendedQueryTagDataAsync(ExtendedQueryTagDataType.StringData, tagStoreEntry.Key, instance1.StudyKey, null, null)).Single();
+            Assert.Equal(tagValue3, row.TagValue); // Do not overwrite
         }
 
         [Fact]

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Common/DicomTagsManager.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Common/DicomTagsManager.cs
@@ -57,14 +57,38 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Common
             }
 
             var operation = await response.GetValueAsync();
-
-            var operationStatus = await GetOperationStatusRetryPolicy.ExecuteAsync(async () =>
+            return await GetOperationStatusRetryPolicy.ExecuteAsync(async () =>
             {
                 var operationStatus = await _dicomWebClient.GetOperationStatusAsync(operation.Id);
                 return await operationStatus.GetValueAsync();
             });
-            return operationStatus;
         }
 
+        public async Task<GetExtendedQueryTagEntry> GetTagAsync(string tagPath, CancellationToken cancellationToken = default)
+        {
+            EnsureArg.IsNotNull(tagPath, nameof(tagPath));
+
+            var response = await _dicomWebClient.GetExtendedQueryTagAsync(tagPath, cancellationToken);
+            return await response.GetValueAsync();
+        }
+
+        public async Task<IEnumerable<GetExtendedQueryTagEntry>> GetTagsAsync(int limit, int offset, CancellationToken cancellationToken = default)
+        {
+            EnsureArg.IsGte(limit, 1, nameof(limit));
+            EnsureArg.IsGte(offset, 0, nameof(offset));
+
+            var response = await _dicomWebClient.GetExtendedQueryTagsAsync(limit, offset, cancellationToken);
+            return await response.GetValueAsync();
+        }
+
+        public async Task<IEnumerable<ExtendedQueryTagError>> GetTagErrorsAsync(string tagPath, int limit, int offset, CancellationToken cancellationToken = default)
+        {
+            EnsureArg.IsNotNull(tagPath, nameof(tagPath));
+            EnsureArg.IsGte(limit, 1, nameof(limit));
+            EnsureArg.IsGte(offset, 0, nameof(offset));
+
+            var response = await _dicomWebClient.GetExtendedQueryTagErrorsAsync(tagPath, limit, offset, cancellationToken);
+            return await response.GetValueAsync();
+        }
     }
 }

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Common/DicomTagsManager.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Common/DicomTagsManager.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -72,23 +73,23 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Common
             return await response.GetValueAsync();
         }
 
-        public async Task<IEnumerable<GetExtendedQueryTagEntry>> GetTagsAsync(int limit, int offset, CancellationToken cancellationToken = default)
+        public async Task<IReadOnlyList<GetExtendedQueryTagEntry>> GetTagsAsync(int limit, int offset, CancellationToken cancellationToken = default)
         {
             EnsureArg.IsGte(limit, 1, nameof(limit));
             EnsureArg.IsGte(offset, 0, nameof(offset));
 
             var response = await _dicomWebClient.GetExtendedQueryTagsAsync(limit, offset, cancellationToken);
-            return await response.GetValueAsync();
+            return (await response.GetValueAsync()).ToList();
         }
 
-        public async Task<IEnumerable<ExtendedQueryTagError>> GetTagErrorsAsync(string tagPath, int limit, int offset, CancellationToken cancellationToken = default)
+        public async Task<IReadOnlyList<ExtendedQueryTagError>> GetTagErrorsAsync(string tagPath, int limit, int offset, CancellationToken cancellationToken = default)
         {
             EnsureArg.IsNotNull(tagPath, nameof(tagPath));
             EnsureArg.IsGte(limit, 1, nameof(limit));
             EnsureArg.IsGte(offset, 0, nameof(offset));
 
             var response = await _dicomWebClient.GetExtendedQueryTagErrorsAsync(tagPath, limit, offset, cancellationToken);
-            return await response.GetValueAsync();
+            return (await response.GetValueAsync()).ToList();
         }
     }
 }

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/ExtendedQueryTagTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/ExtendedQueryTagTests.cs
@@ -56,9 +56,15 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             DicomDataset instance3 = Samples.CreateRandomInstanceDataset();
 
             // Annotate files
+            // (Disable Auto-validate)
             instance1.Add(patientWeightTag, 68.0M);
             instance2.Add(patientWeightTag, 50.0M);
             instance3.Add(patientWeightTag, 81.0M);
+
+#pragma warning disable CS0618
+            instance1.AutoValidate = false;
+            instance2.AutoValidate = false;
+#pragma warning restore CS0618
 
             instance1.Add(patientAgeTag, "foobar");
             instance2.Add(patientAgeTag, "invalid");


### PR DESCRIPTION
## Description
- Update `IDicomWebClient` with new paginated APIs for getting extended query tags and their errors
- Update data models to incorporate references to operation and errors
- Fix errors return type and DI
- Update E2E test

## Related issues
N/A

## Testing
Via local client testing
