### PR TITLE
Add test to validate if stored procedure in new Sql schema compatible with old one

### DIFF
--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlDataStoreTestsFixture.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlDataStoreTestsFixture.cs
@@ -37,13 +37,17 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
         private const string LocalConnectionString = "server=(local);Integrated Security=true";
 
         private readonly string _masterConnectionString;
-        private readonly string _databaseName;
         private readonly SchemaInitializer _schemaInitializer;
 
-        // Only 1 public constructor is allowed for test fixture.
-        internal SqlDataStoreTestsFixture(string databaseName)
+        internal SqlDataStoreTestsFixture(string databaseName) : this(databaseName, new SchemaInformation(SchemaVersionConstants.Min, SchemaVersionConstants.Max))
         {
-            _databaseName = EnsureArg.IsNotNullOrEmpty(databaseName, nameof(databaseName));
+
+        }
+        // Only 1 public constructor is allowed for test fixture.
+        internal SqlDataStoreTestsFixture(string databaseName, SchemaInformation schemaInformation)
+        {
+            DatabaseName = EnsureArg.IsNotNullOrEmpty(databaseName, nameof(databaseName));
+            SchemaInformation = EnsureArg.IsNotNull(schemaInformation, nameof(schemaInformation));
 
             IConfiguration environment = new ConfigurationBuilder()
                 .AddEnvironmentVariables()
@@ -51,7 +55,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
 
             string initialConnectionString = environment["SqlServer:ConnectionString"] ?? LocalConnectionString;
             _masterConnectionString = new SqlConnectionStringBuilder(initialConnectionString) { InitialCatalog = "master" }.ToString();
-            TestConnectionString = new SqlConnectionStringBuilder(initialConnectionString) { InitialCatalog = _databaseName }.ToString();
+            TestConnectionString = new SqlConnectionStringBuilder(initialConnectionString) { InitialCatalog = DatabaseName }.ToString();
 
             var config = new SqlServerDataStoreConfiguration
             {
@@ -78,8 +82,6 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             var schemaManagerDataStore = new SchemaManagerDataStore(sqlConnectionFactory);
 
             SchemaUpgradeRunner = new SchemaUpgradeRunner(scriptProvider, baseScriptProvider, NullLogger<SchemaUpgradeRunner>.Instance, sqlConnectionFactory, schemaManagerDataStore);
-
-            SchemaInformation = new SchemaInformation(SchemaVersionConstants.Min, SchemaVersionConstants.Max);
 
             _schemaInitializer = new SchemaInitializer(configOptions, schemaManagerDataStore, SchemaUpgradeRunner, SchemaInformation, sqlConnectionFactory, sqlConnectionStringProvider, mediator, NullLogger<SchemaInitializer>.Instance);
 
@@ -166,6 +168,8 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             return $"{prefix}{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}_{BigInteger.Abs(new BigInteger(Guid.NewGuid().ToByteArray()))}";
         }
 
+        public string DatabaseName { get; }
+
         public async Task InitializeAsync(bool forceIncrementalSchemaUpgrade)
         {
             // Create the database
@@ -176,7 +180,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
                 using (SqlCommand command = sqlConnection.CreateCommand())
                 {
                     command.CommandTimeout = 600;
-                    command.CommandText = $"CREATE DATABASE {_databaseName}";
+                    command.CommandText = $"CREATE DATABASE {DatabaseName}";
                     await command.ExecuteNonQueryAsync();
                 }
             }
@@ -217,7 +221,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
                 using (SqlCommand sqlCommand = sqlConnection.CreateCommand())
                 {
                     sqlCommand.CommandTimeout = 600;
-                    sqlCommand.CommandText = $"DROP DATABASE IF EXISTS {_databaseName}";
+                    sqlCommand.CommandText = $"DROP DATABASE IF EXISTS {DatabaseName}";
                     await sqlCommand.ExecuteNonQueryAsync();
                 }
             }

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlDataStoreTestsFixture.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlDataStoreTestsFixture.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
         {
 
         }
-        // Only 1 public constructor is allowed for test fixture.
+
         internal SqlDataStoreTestsFixture(string databaseName, SchemaInformation schemaInformation)
         {
             DatabaseName = EnsureArg.IsNotNullOrEmpty(databaseName, nameof(databaseName));
@@ -135,6 +135,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             ExtendedQueryTagErrorStoreTestHelper = new ExtendedQueryTagErrorStoreTestHelper(TestConnectionString);
         }
 
+        // Only 1 public constructor is allowed for test fixture.
         public SqlDataStoreTestsFixture()
             : this(GenerateDatabaseName())
         {

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
@@ -53,12 +53,12 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             // Create Sql store at old schema version
             SqlDataStoreTestsFixture oldSqlStore = new SqlDataStoreTestsFixture(SqlDataStoreTestsFixture.GenerateDatabaseName($"COMPATIBLE_{oldSchemaVersion}_"), new SchemaInformation(oldSchemaVersion, oldSchemaVersion));
             await oldSqlStore.InitializeAsync(forceIncrementalSchemaUpgrade: false);
-            var oldProcedures = await SqlTestUtils.GetStoredProceduresAsync(oldSqlStore);
+            var oldProcedures = SqlTestUtils.GetStoredProcedures(oldSqlStore);
 
             // Create Sql store at new schema version
             SqlDataStoreTestsFixture newSqlStore = new SqlDataStoreTestsFixture(SqlDataStoreTestsFixture.GenerateDatabaseName($"COMPATIBLE_{schemaVersion}_"), new SchemaInformation(schemaVersion, schemaVersion));
             await newSqlStore.InitializeAsync(forceIncrementalSchemaUpgrade: false);
-            var newProcedures = await SqlTestUtils.GetStoredProceduresAsync(newSqlStore);
+            var newProcedures = SqlTestUtils.GetStoredProcedures(newSqlStore);
 
             // Validate if stored procedures are compatible
             StoredProcedureCompatibleValidator.Validate(newProcedures, oldProcedures);

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             await newSqlStore.InitializeAsync(forceIncrementalSchemaUpgrade: false);
             var newProcedures = await SqlTestUtils.GetStoredProceduresAsync(newSqlStore);
 
-            // Validate if stored prodcedures are compatible
+            // Validate if stored procedures are compatible
             StoredProcedureCompatibleValidator.Validate(newProcedures, oldProcedures);
 
             // Dispose if not exist

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
@@ -51,9 +51,9 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
         {
             int oldSchemaVersion = schemaVersion - 1;
             // Create Sql store at old schema version
-            SqlDataStoreTestsFixture minSqlStore = new SqlDataStoreTestsFixture(SqlDataStoreTestsFixture.GenerateDatabaseName($"COMPATIBLE_{oldSchemaVersion}_"), new SchemaInformation(oldSchemaVersion, oldSchemaVersion));
-            await minSqlStore.InitializeAsync(forceIncrementalSchemaUpgrade: false);
-            var oldProcedures = await SqlTestUtils.GetStoredProceduresAsync(minSqlStore);
+            SqlDataStoreTestsFixture oldSqlStore = new SqlDataStoreTestsFixture(SqlDataStoreTestsFixture.GenerateDatabaseName($"COMPATIBLE_{oldSchemaVersion}_"), new SchemaInformation(oldSchemaVersion, oldSchemaVersion));
+            await oldSqlStore.InitializeAsync(forceIncrementalSchemaUpgrade: false);
+            var oldProcedures = await SqlTestUtils.GetStoredProceduresAsync(oldSqlStore);
 
             // Create Sql store at new schema version
             SqlDataStoreTestsFixture newSqlStore = new SqlDataStoreTestsFixture(SqlDataStoreTestsFixture.GenerateDatabaseName($"COMPATIBLE_{schemaVersion}_"), new SchemaInformation(schemaVersion, schemaVersion));
@@ -63,8 +63,8 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             // Validate if stored procedures are compatible
             StoredProcedureCompatibleValidator.Validate(newProcedures, oldProcedures);
 
-            // Dispose if not exist
-            await minSqlStore.DisposeAsync();
+            // Dispose if pass
+            await oldSqlStore.DisposeAsync();
             await newSqlStore.DisposeAsync();
         }
 

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlTestUtils.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlTestUtils.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
         }
 
         /// <summary>
-        /// Get StoredProcedures in SqlDataaStore
+        /// Get StoredProcedures in SqlDataStore
         /// </summary>
         /// <param name="sqlDataStore">The Sql data store</param>
         /// <param name="cancellationToken">The cancellation token</param>
@@ -62,16 +62,13 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             foreach (DataRow row in storedProcedureTable.Rows)
             {
                 string schema = (string)row["Schema"];
-                if (schema == "sys" || schema == "INFORMATION_SCHEMA")
+                if (schema == "sys")
                 {
                     continue;
                 }
 
                 StoredProcedure sp = (StoredProcedure)server.GetSmoObject(new Urn((string)row["Urn"]));
-                if (!sp.IsSystemObject)
-                {
-                    result.Add(sp);
-                }
+                result.Add(sp);
             }
             return result;
         }

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlTestUtils.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlTestUtils.cs
@@ -3,9 +3,16 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+using System.Data;
+using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Data.SqlClient;
+using Microsoft.SqlServer.Management.Common;
+using Microsoft.SqlServer.Management.Sdk.Sfc;
+using Microsoft.SqlServer.Management.Smo;
+using StoredProcedure = Microsoft.SqlServer.Management.Smo.StoredProcedure;
 
 namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
 {
@@ -34,6 +41,31 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
                     await sqlCommand.ExecuteNonQueryAsync();
                 }
             }
+        }
+
+        public static async Task<System.Collections.Generic.IReadOnlyList<StoredProcedure>> GetStoredProceduresAsync(SqlDataStoreTestsFixture sqlStore, CancellationToken cancellationToken = default)
+        {
+            EnsureArg.IsNotNull(sqlStore, nameof(sqlStore));
+            using var connectionWraper = await sqlStore.SqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken);
+            ServerConnection connection = new ServerConnection(connectionWraper.SqlConnection);
+            Server server = new Server(connection);
+            Database db = server.Databases[sqlStore.DatabaseName];
+            List<StoredProcedure> result = new List<StoredProcedure>();
+            DataTable dataTable = db.EnumObjects(DatabaseObjectTypes.StoredProcedure);
+            foreach (DataRow row in dataTable.Rows)
+            {
+                string schema = (string)row["Schema"];
+                if (schema == "sys" || schema == "INFORMATION_SCHEMA")
+                {
+                    continue;
+                }
+                StoredProcedure sp = (StoredProcedure)server.GetSmoObject(new Urn((string)row["Urn"]));
+                if (!sp.IsSystemObject)
+                {
+                    result.Add(sp);
+                }
+            }
+            return result;
         }
     }
 }

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlTestUtils.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlTestUtils.cs
@@ -5,7 +5,6 @@
 
 using System.Collections.Generic;
 using System.Data;
-using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Data.SqlClient;
@@ -47,13 +46,12 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
         /// Get StoredProcedures in SqlDataStore
         /// </summary>
         /// <param name="sqlDataStore">The Sql data store</param>
-        /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The stored procedures.</returns>
-        public static async Task<System.Collections.Generic.IReadOnlyList<StoredProcedure>> GetStoredProceduresAsync(SqlDataStoreTestsFixture sqlDataStore, CancellationToken cancellationToken = default)
+        public static System.Collections.Generic.IReadOnlyList<StoredProcedure> GetStoredProcedures(SqlDataStoreTestsFixture sqlDataStore)
         {
             EnsureArg.IsNotNull(sqlDataStore, nameof(sqlDataStore));
-            using var connectionWraper = await sqlDataStore.SqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken);
-            ServerConnection connection = new ServerConnection(connectionWraper.SqlConnection);
+            using var sqlConnection = new SqlConnection(sqlDataStore.TestConnectionString);
+            ServerConnection connection = new ServerConnection(sqlConnection);
             Server server = new Server(connection);
             Database db = server.Databases[sqlDataStore.DatabaseName];
             DataTable storedProcedureTable = db.EnumObjects(DatabaseObjectTypes.StoredProcedure);

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/StoredProcedureCompatibleValidator.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/StoredProcedureCompatibleValidator.cs
@@ -49,17 +49,14 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
 
         private static List<Tuple<StoredProcedure, StoredProcedure>> GetComparisonProcedures(IReadOnlyCollection<StoredProcedure> newProcedures, IReadOnlyCollection<StoredProcedure> oldProcedures)
         {
-            // Return procedures keeping same name
             List<Tuple<StoredProcedure, StoredProcedure>> pairs = new List<Tuple<StoredProcedure, StoredProcedure>>();
             foreach (var oldOne in oldProcedures)
             {
+                // every procedure in old database must have match one in new
                 var newOne = newProcedures.FirstOrDefault(x => x.Name == oldOne.Name);
-                if (newOne != null)
-                {
-                    pairs.Add(new Tuple<StoredProcedure, StoredProcedure>(oldOne, newOne));
-                }
+                Assert.NotNull(newOne);
+                pairs.Add(new Tuple<StoredProcedure, StoredProcedure>(oldOne, newOne));
             }
-
             return pairs;
         }
 

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/StoredProcedureCompatibleValidator.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/StoredProcedureCompatibleValidator.cs
@@ -1,0 +1,76 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.SqlServer.Management.Smo;
+using Xunit;
+
+namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
+{
+    /// <summary>
+    /// Validate if new stored procedures compatible with old ones
+    /// </summary>
+    internal class StoredProcedureCompatibleValidator
+    {
+        public static void Validate(IReadOnlyCollection<StoredProcedure> newProcedures, IReadOnlyCollection<StoredProcedure> oldProcedures)
+        {
+            var pairs = GetComparisonProcedures(newProcedures, oldProcedures);
+
+            foreach (var pair in pairs)
+            {
+                var oldOne = pair.Item1;
+                var newOne = pair.Item2;
+
+                List<StoredProcedureParameter> oldList = ParameterCollectionToList(oldOne.Parameters);
+                List<StoredProcedureParameter> newList = ParameterCollectionToList(newOne.Parameters);
+
+                // any old parameter should be able to find a match
+                foreach (var paramOld in oldList)
+                {
+                    int iNewParam = newList.FindIndex(x => x.Name == paramOld.Name);
+                    Assert.NotEqual(-1, iNewParam);
+                    Assert.Equal(paramOld.DataType, newList[iNewParam].DataType);
+
+                    // remove from new list since having a match
+                    newList.RemoveAt(iNewParam);
+                }
+
+                // additional parameters must have default value
+                foreach (var item in newList)
+                {
+                    Assert.NotEqual(string.Empty, item.DefaultValue);
+                }
+            }
+        }
+
+        private static List<Tuple<StoredProcedure, StoredProcedure>> GetComparisonProcedures(IReadOnlyCollection<StoredProcedure> newProcedures, IReadOnlyCollection<StoredProcedure> oldProcedures)
+        {
+            // Return procedures keeping same name
+            List<Tuple<StoredProcedure, StoredProcedure>> pairs = new List<Tuple<StoredProcedure, StoredProcedure>>();
+            foreach (var oldOne in oldProcedures)
+            {
+                var newOne = newProcedures.FirstOrDefault(x => x.Name == oldOne.Name);
+                if (newOne != null)
+                {
+                    pairs.Add(new Tuple<StoredProcedure, StoredProcedure>(oldOne, newOne));
+                }
+            }
+
+            return pairs;
+        }
+
+        private static List<StoredProcedureParameter> ParameterCollectionToList(StoredProcedureParameterCollection collection)
+        {
+            List<StoredProcedureParameter> result = new List<StoredProcedureParameter>();
+            for (int i = 0; i < collection.Count; i++)
+            {
+                result.Add(collection[i]);
+            }
+            return result;
+        }
+    }
+}

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/StoredProcedureCompatibleValidator.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/StoredProcedureCompatibleValidator.cs
@@ -16,6 +16,11 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
     /// </summary>
     internal class StoredProcedureCompatibleValidator
     {
+        /// <summary>
+        /// Validate if newProcedures are compatible with old ones.
+        /// </summary>
+        /// <param name="newProcedures">The new procedures.</param>
+        /// <param name="oldProcedures">The old procedures.</param>
         public static void Validate(IReadOnlyCollection<StoredProcedure> newProcedures, IReadOnlyCollection<StoredProcedure> oldProcedures)
         {
             var pairs = GetComparisonProcedures(newProcedures, oldProcedures);
@@ -25,8 +30,8 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
                 var oldOne = pair.Item1;
                 var newOne = pair.Item2;
 
-                List<StoredProcedureParameter> oldList = ParameterCollectionToList(oldOne.Parameters);
-                List<StoredProcedureParameter> newList = ParameterCollectionToList(newOne.Parameters);
+                List<StoredProcedureParameter> oldList = oldOne.Parameters.Cast<StoredProcedureParameter>().ToList();
+                List<StoredProcedureParameter> newList = newOne.Parameters.Cast<StoredProcedureParameter>().ToList();
 
                 // any old parameter should be able to find a match
                 foreach (var paramOld in oldList)
@@ -52,22 +57,12 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             List<Tuple<StoredProcedure, StoredProcedure>> pairs = new List<Tuple<StoredProcedure, StoredProcedure>>();
             foreach (var oldOne in oldProcedures)
             {
-                // every procedure in old database must have match one in new
+                // every procedure in old database must have a match in new
                 var newOne = newProcedures.FirstOrDefault(x => x.Name == oldOne.Name);
                 Assert.NotNull(newOne);
                 pairs.Add(new Tuple<StoredProcedure, StoredProcedure>(oldOne, newOne));
             }
             return pairs;
-        }
-
-        private static List<StoredProcedureParameter> ParameterCollectionToList(StoredProcedureParameterCollection collection)
-        {
-            List<StoredProcedureParameter> result = new List<StoredProcedureParameter>();
-            for (int i = 0; i < collection.Count; i++)
-            {
-                result.Add(collection[i]);
-            }
-            return result;
         }
     }
 }

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/StoredProcedureCompatibleValidator.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/StoredProcedureCompatibleValidator.cs
@@ -27,25 +27,25 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
 
             foreach (var pair in pairs)
             {
-                var oldOne = pair.Item1;
-                var newOne = pair.Item2;
+                var oldProcedure = pair.Item1;
+                var newProcedure = pair.Item2;
 
-                List<StoredProcedureParameter> oldList = oldOne.Parameters.Cast<StoredProcedureParameter>().ToList();
-                List<StoredProcedureParameter> newList = newOne.Parameters.Cast<StoredProcedureParameter>().ToList();
+                List<StoredProcedureParameter> oldParams = oldProcedure.Parameters.Cast<StoredProcedureParameter>().ToList();
+                List<StoredProcedureParameter> newParams = newProcedure.Parameters.Cast<StoredProcedureParameter>().ToList();
 
                 // any old parameter should be able to find a match
-                foreach (var paramOld in oldList)
+                foreach (var oldParam in oldParams)
                 {
-                    int iNewParam = newList.FindIndex(x => x.Name == paramOld.Name);
+                    int iNewParam = newParams.FindIndex(x => x.Name == oldParam.Name);
                     Assert.NotEqual(-1, iNewParam);
-                    Assert.Equal(paramOld.DataType, newList[iNewParam].DataType);
+                    Assert.Equal(oldParam.DataType, newParams[iNewParam].DataType);
 
                     // remove from new list since having a match
-                    newList.RemoveAt(iNewParam);
+                    newParams.RemoveAt(iNewParam);
                 }
 
                 // additional parameters must have default value
-                foreach (var item in newList)
+                foreach (var item in newParams)
                 {
                     Assert.NotEqual(string.Empty, item.DefaultValue);
                 }
@@ -55,12 +55,12 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
         private static List<Tuple<StoredProcedure, StoredProcedure>> GetComparisonProcedures(IReadOnlyCollection<StoredProcedure> newProcedures, IReadOnlyCollection<StoredProcedure> oldProcedures)
         {
             List<Tuple<StoredProcedure, StoredProcedure>> pairs = new List<Tuple<StoredProcedure, StoredProcedure>>();
-            foreach (var oldOne in oldProcedures)
+            foreach (var oldProcedure in oldProcedures)
             {
                 // every procedure in old database must have a match in new
-                var newOne = newProcedures.FirstOrDefault(x => x.Name == oldOne.Name);
+                var newOne = newProcedures.FirstOrDefault(x => x.Name == oldProcedure.Name);
                 Assert.NotNull(newOne);
-                pairs.Add(new Tuple<StoredProcedure, StoredProcedure>(oldOne, newOne));
+                pairs.Add(new Tuple<StoredProcedure, StoredProcedure>(oldProcedure, newOne));
             }
             return pairs;
         }


### PR DESCRIPTION
## Description
There is small window where Sql schema is updated but not populated to web server, so the server still tries to call old stored procedure. This test validate it works by checking stored procedure compatiblity.

## Related issues
Addresses [AB#85211](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/85211).

## Testing
All tests pass
