### PR TITLE
Update middleware to add transcode and egress data for billing

### DIFF
--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Features/ByteCounter/ByteCountingStreamTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Features/ByteCounter/ByteCountingStreamTests.cs
@@ -1,0 +1,139 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Health.Dicom.Api.Features.ByteCounter;
+using Xunit;
+
+namespace Microsoft.Health.Dicom.Api.UnitTests.Features.ByteCounter
+{
+    public class ByteCountingStreamTests
+    {
+        [Fact]
+        public void BillingResponseLogMiddleware_ByteCountingStream_PropertiesCheck()
+        {
+            var memoryStream = new MemoryStream();
+            using (var byteCountingStream = new ByteCountingStream(memoryStream))
+            {
+                byteCountingStream.Write(new byte[123]);
+                Assert.Equal(memoryStream.CanRead, byteCountingStream.CanRead);
+                Assert.Equal(memoryStream.CanSeek, byteCountingStream.CanSeek);
+                Assert.Equal(memoryStream.CanWrite, byteCountingStream.CanWrite);
+                Assert.Equal(memoryStream.CanTimeout, byteCountingStream.CanTimeout);
+                Assert.Equal(memoryStream.Length, byteCountingStream.Length);
+                Assert.Equal(memoryStream.Position, byteCountingStream.Position);
+            }
+        }
+
+        [Fact]
+        public void BillingResponseLogMiddleware_ByteCountingStream_ReadWrite()
+        {
+            var memoryStream = new MemoryStream();
+            using (var byteCountingStream = new ByteCountingStream(memoryStream))
+            {
+                byte[] bytes = Encoding.UTF8.GetBytes("This is a string");
+                byteCountingStream.Write(bytes);
+                Assert.Equal(bytes.Length, byteCountingStream.WrittenByteCount);
+                Assert.Equal(bytes.Length, memoryStream.Length);
+
+                byteCountingStream.Flush();
+                byteCountingStream.Seek(0, 0);
+                int bytesRead = byteCountingStream.Read(new byte[bytes.Length], 0, bytes.Length);
+                Assert.Equal(bytes.Length, bytesRead);
+            }
+        }
+
+        [Fact]
+        public async Task BillingResponseLogMiddleware_ByteCountingStream_WriteAsync()
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes("This is a string");
+            using (var byteCountingStream = new ByteCountingStream(new MemoryStream()))
+            {
+                await byteCountingStream.WriteAsync(bytes);
+                Assert.Equal(bytes.Length, byteCountingStream.WrittenByteCount);
+            }
+
+            using (var byteCountingStream = new ByteCountingStream(new MemoryStream()))
+            {
+                await byteCountingStream.WriteAsync(bytes, 0, bytes.Length);
+                Assert.Equal(bytes.Length, byteCountingStream.WrittenByteCount);
+            }
+
+            using (var byteCountingStream = new ByteCountingStream(new MemoryStream()))
+            {
+                await byteCountingStream.WriteAsync(bytes.AsMemory(0, bytes.Length), CancellationToken.None);
+                Assert.Equal(bytes.Length, byteCountingStream.WrittenByteCount);
+            }
+
+            using (var byteCountingStream = new ByteCountingStream(new MemoryStream()))
+            {
+                IAsyncResult asyncResult = byteCountingStream.BeginWrite(bytes, 0, bytes.Length, null, new object());
+                Assert.Equal(bytes.Length, byteCountingStream.WrittenByteCount);
+            }
+        }
+
+        [Fact]
+        public void BillingResponseLogMiddleware_ByteCountingStream_WriteByte()
+        {
+            using (var byteCountingStream = new ByteCountingStream(new MemoryStream()))
+            {
+                byteCountingStream.WriteByte(0);
+                Assert.Equal(1, byteCountingStream.WrittenByteCount);
+                Assert.Equal(1, byteCountingStream.Length);
+            }
+        }
+
+        [Fact]
+        public void BillingResponseLogMiddleware_ByteCountingStream_WriteVaryingCounts()
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes("This is a string");
+
+            using (var byteCountingStream = new ByteCountingStream(new MemoryStream()))
+            {
+                // Specified count is the same as the byte array length
+                byteCountingStream.Write(bytes, 0, bytes.Length);
+                Assert.Equal(bytes.Length, byteCountingStream.WrittenByteCount);
+                Assert.Equal(bytes.Length, byteCountingStream.Length);
+            }
+
+            using (var byteCountingStream = new ByteCountingStream(new MemoryStream()))
+            {
+                // Specified count is less than the byte array length
+                int count = bytes.Length / 2;
+                byteCountingStream.Write(bytes, 0, count);
+                Assert.Equal(count, byteCountingStream.WrittenByteCount);
+                Assert.Equal(count, byteCountingStream.Length);
+            }
+        }
+
+        [Fact]
+        public void BillingResponseLogMiddleware_ByteCountingStream_NullBaseStreamThrows()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ByteCountingStream(null));
+        }
+
+        [Fact]
+        public void BillingResponseLogMiddleware_ByteCountingStream_IsDisposed()
+        {
+            var memoryStream = new MemoryStream();
+            var byteCountingStream = new ByteCountingStream(memoryStream);
+            byte[] bytes = Encoding.UTF8.GetBytes("This is a string");
+            byteCountingStream.Write(bytes);
+
+            byteCountingStream.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => { byteCountingStream.WriteByte(1); });
+            Assert.Throws<ObjectDisposedException>(() => { memoryStream.WriteByte(1); });
+        }
+
+        private async Task WriteToStream(Stream stream, byte[] bytes)
+        {
+            await stream.WriteAsync(bytes);
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Context/DefaultDicomRequestContext.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Context/DefaultDicomRequestContext.cs
@@ -19,6 +19,10 @@ namespace Microsoft.Health.Dicom.Api.UnitTests.Features.Context
 
         public string SopInstanceUid { get; set; }
 
+        public bool IsTranscodeRequested { get; set; }
+
+        public long BytesTranscoded { get; set; }
+
         public string Method { get; set; }
 
         public Uri BaseUri { get; set; }

--- a/src/Microsoft.Health.Dicom.Api/Features/ByteCounter/ByteCountingStream.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/ByteCounter/ByteCountingStream.cs
@@ -1,0 +1,134 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+
+namespace Microsoft.Health.Dicom.Api.Features.ByteCounter
+{
+    /// <summary>
+    /// A stream to wrap an underlying stream and counts the number of bytes passed while operating with it.
+    /// </summary>
+    public class ByteCountingStream : Stream
+    {
+        private readonly Stream _stream;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ByteCountingStream"/> class.
+        /// </summary>
+        /// <param name="stream">An underlying stream.</param>
+        public ByteCountingStream(Stream stream)
+        {
+            EnsureArg.IsNotNull(stream, nameof(stream));
+
+            _stream = stream;
+        }
+
+        /// <inheritdoc />
+        public override bool CanRead => _stream.CanRead;
+
+        /// <inheritdoc />
+        public override bool CanSeek => _stream.CanSeek;
+
+        /// <inheritdoc />
+        public override bool CanWrite => _stream.CanWrite;
+
+        /// <inheritdoc />
+        public override long Length => _stream.Length;
+
+        /// <inheritdoc />
+        public override long Position
+        {
+            get { return _stream.Position; }
+            set { _stream.Position = value; }
+        }
+
+        /// <summary>
+        /// The number of bytes that have been written.
+        /// </summary>
+        public long WrittenByteCount { get; private set; }
+
+        /// <inheritdoc />
+        public override void Flush()
+        {
+            _stream.Flush();
+        }
+
+        /// <inheritdoc />
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return _stream.FlushAsync(cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return _stream.Read(buffer, offset, count);
+        }
+
+        /// <inheritdoc />
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return _stream.Seek(offset, origin);
+        }
+
+        /// <inheritdoc />
+        public override void SetLength(long value)
+        {
+            _stream.SetLength(value);
+        }
+
+        /// <inheritdoc />
+        public override void WriteByte(byte value)
+        {
+            _stream.WriteByte(value);
+            WrittenByteCount++;
+        }
+
+        /// <inheritdoc />
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            _stream.Write(buffer, offset, count);
+            WrittenByteCount += count;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a sequence of bytes to the current stream and advances the current position within this stream by the number of bytes written.
+        /// </summary>
+        /// <param name="buffer">The buffer to write data from.</param>
+        /// <param name="offset">The zero-based byte offset in buffer from which to begin copying bytes to the stream.</param>
+        /// <param name="count">The maximum number of bytes to write.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        public new Task WriteAsync(byte[] buffer, int offset, int count)
+        {
+            WrittenByteCount += count;
+            return _stream.WriteAsync(buffer, offset, count);
+        }
+
+        /// <inheritdoc />
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            WrittenByteCount += count;
+            return _stream.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            WrittenByteCount += count;
+            return _stream.BeginWrite(buffer, offset, count, callback, state);
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            _stream.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Api/Features/ByteCounter/ByteCountingStreamResponseLogStreamFactory.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/ByteCounter/ByteCountingStreamResponseLogStreamFactory.cs
@@ -1,0 +1,18 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.IO;
+
+namespace Microsoft.Health.Dicom.Api.Features.ByteCounter
+{
+    public class ByteCountingStreamResponseLogStreamFactory : IResponseLogStreamFactory
+    {
+        /// <inheritdoc/>
+        public ByteCountingStream CreateByteCountingResponseLogStream(Stream stream)
+        {
+            return new ByteCountingStream(stream);
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Api/Features/ByteCounter/HeaderUtility.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/ByteCounter/HeaderUtility.cs
@@ -1,0 +1,41 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Text;
+using EnsureThat;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.Health.Dicom.Api.Features.ByteCounter
+{
+    public static class HeaderUtility
+    {
+        private static readonly Encoding HeaderEncoding = Encoding.UTF8;
+        private static readonly int HeaderDelimiterByteCount = HeaderEncoding.GetByteCount(": ");
+        private static readonly int HeaderEndOfLineCharactersByteCount = HeaderEncoding.GetByteCount("\r\n");
+
+        public static int GetTotalHeaderLength(IHeaderDictionary headers)
+        {
+            // Per https://en.wikipedia.org/wiki/List_of_HTTP_header_fields, each header will be of the form
+            // headerKey: headerValues, and terminated by an end-of-line character sequence. The list of headers
+            // will be terminated by another end-of-line character sequence.
+            EnsureArg.IsNotNull(headers, nameof(headers));
+
+            int headerLength = 0;
+            foreach (KeyValuePair<string, StringValues> header in headers)
+            {
+                headerLength += HeaderEncoding.GetByteCount(header.Key)
+                    + HeaderDelimiterByteCount
+                    + HeaderEncoding.GetByteCount(header.Value.ToString())
+                    + HeaderEndOfLineCharactersByteCount;
+            }
+
+            headerLength += HeaderEndOfLineCharactersByteCount;
+
+            return headerLength;
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Api/Features/ByteCounter/IResponseLogStreamFactory.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/ByteCounter/IResponseLogStreamFactory.cs
@@ -1,0 +1,19 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.IO;
+
+namespace Microsoft.Health.Dicom.Api.Features.ByteCounter
+{
+    public interface IResponseLogStreamFactory
+    {
+        /// <summary>
+        /// Creates a <see cref="ByteCountingStream"/>
+        /// </summary>
+        /// <param name="stream">An underlying stream.</param>
+        /// <returns>A byte counting stream that wraps the specified underlying stream.</returns>
+        ByteCountingStream CreateByteCountingResponseLogStream(Stream stream);
+    }
+}

--- a/src/Microsoft.Health.Dicom.Api/Features/Context/DicomRequestContextMiddleware.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Context/DicomRequestContextMiddleware.cs
@@ -4,10 +4,14 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.Text;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Health.Dicom.Api.Features.ByteCounter;
 using Microsoft.Health.Dicom.Core.Features.Context;
 
 namespace Microsoft.Health.Dicom.Api.Features.Context
@@ -15,12 +19,21 @@ namespace Microsoft.Health.Dicom.Api.Features.Context
     public class DicomRequestContextMiddleware
     {
         private readonly RequestDelegate _next;
+        private readonly IResponseLogStreamFactory _responseLogStreamFactory;
 
-        public DicomRequestContextMiddleware(RequestDelegate next)
+        private static readonly Encoding HeaderEncoding = Encoding.UTF8;
+        private static readonly int HeaderDelimiterByteCount = HeaderEncoding.GetByteCount(": ");
+        private static readonly int HeaderEndOfLineCharactersByteCount = HeaderEncoding.GetByteCount("\r\n");
+
+        public DicomRequestContextMiddleware(
+            RequestDelegate next,
+            IResponseLogStreamFactory responseLogStreamFactory)
         {
             EnsureArg.IsNotNull(next, nameof(next));
+            EnsureArg.IsNotNull(responseLogStreamFactory, nameof(responseLogStreamFactory));
 
             _next = next;
+            _responseLogStreamFactory = responseLogStreamFactory;
         }
 
         public async Task Invoke(HttpContext context, IDicomRequestContextAccessor dicomRequestContextAccessor)
@@ -51,8 +64,45 @@ namespace Microsoft.Health.Dicom.Api.Features.Context
 
             dicomRequestContextAccessor.RequestContext = dicomRequestContext;
 
-            // Call the next delegate/middleware in the pipeline
-            await _next(context);
+            ByteCountingStream byteCountingStream = _responseLogStreamFactory.CreateByteCountingResponseLogStream(context.Response.Body);
+            context.Response.Body = byteCountingStream;
+
+            try
+            {
+                // Call the next delegate/middleware in the pipeline
+                await _next(context);
+            }
+            finally
+            {
+                context.Items["TranscodedSize"] = dicomRequestContextAccessor.RequestContext.BytesTranscoded;
+                context.Items["IsTranscodeRequested"] = dicomRequestContextAccessor.RequestContext.IsTranscodeRequested;
+
+                long responseBodySize = byteCountingStream.WrittenByteCount;
+                long responseHeaderSize = GetTotalHeaderLength(context.Response.Headers);
+                long totalResponseSize = responseBodySize + responseHeaderSize;
+                context.Items["ResponseSize"] = totalResponseSize;
+            }
+        }
+
+        private static long GetTotalHeaderLength(IHeaderDictionary headers)
+        {
+            // Per https://en.wikipedia.org/wiki/List_of_HTTP_header_fields, each header will be of the form
+            // headerKey: headerValues, and terminated by an end-of-line character sequence. The list of headers
+            // will be terminated by another end-of-line character sequence.
+            EnsureArg.IsNotNull(headers, nameof(headers));
+
+            int headerLength = 0;
+            foreach (KeyValuePair<string, StringValues> header in headers)
+            {
+                headerLength += HeaderEncoding.GetByteCount(header.Key)
+                    + HeaderDelimiterByteCount
+                    + HeaderEncoding.GetByteCount(header.Value.ToString())
+                    + HeaderEndOfLineCharactersByteCount;
+            }
+
+            headerLength += HeaderEndOfLineCharactersByteCount;
+
+            return headerLength;
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Api/Features/Context/DicomRequestContextMiddleware.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Context/DicomRequestContextMiddleware.cs
@@ -4,13 +4,10 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
-using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Dicom.Api.Features.ByteCounter;
 using Microsoft.Health.Dicom.Core.Features.Context;
 
@@ -20,10 +17,6 @@ namespace Microsoft.Health.Dicom.Api.Features.Context
     {
         private readonly RequestDelegate _next;
         private readonly IResponseLogStreamFactory _responseLogStreamFactory;
-
-        private static readonly Encoding HeaderEncoding = Encoding.UTF8;
-        private static readonly int HeaderDelimiterByteCount = HeaderEncoding.GetByteCount(": ");
-        private static readonly int HeaderEndOfLineCharactersByteCount = HeaderEncoding.GetByteCount("\r\n");
 
         public DicomRequestContextMiddleware(
             RequestDelegate next,
@@ -74,35 +67,14 @@ namespace Microsoft.Health.Dicom.Api.Features.Context
             }
             finally
             {
-                context.Items["TranscodedSize"] = dicomRequestContextAccessor.RequestContext.BytesTranscoded;
-                context.Items["IsTranscodeRequested"] = dicomRequestContextAccessor.RequestContext.IsTranscodeRequested;
-
                 long responseBodySize = byteCountingStream.WrittenByteCount;
-                long responseHeaderSize = GetTotalHeaderLength(context.Response.Headers);
+                long responseHeaderSize = HeaderUtility.GetTotalHeaderLength(context.Response.Headers);
                 long totalResponseSize = responseBodySize + responseHeaderSize;
                 context.Items["ResponseSize"] = totalResponseSize;
+
+                context.Items["TranscodedSize"] = dicomRequestContextAccessor.RequestContext.BytesTranscoded;
+                context.Items["IsTranscodeRequested"] = dicomRequestContextAccessor.RequestContext.IsTranscodeRequested;
             }
-        }
-
-        private static long GetTotalHeaderLength(IHeaderDictionary headers)
-        {
-            // Per https://en.wikipedia.org/wiki/List_of_HTTP_header_fields, each header will be of the form
-            // headerKey: headerValues, and terminated by an end-of-line character sequence. The list of headers
-            // will be terminated by another end-of-line character sequence.
-            EnsureArg.IsNotNull(headers, nameof(headers));
-
-            int headerLength = 0;
-            foreach (KeyValuePair<string, StringValues> header in headers)
-            {
-                headerLength += HeaderEncoding.GetByteCount(header.Key)
-                    + HeaderDelimiterByteCount
-                    + HeaderEncoding.GetByteCount(header.Value.ToString())
-                    + HeaderEndOfLineCharactersByteCount;
-            }
-
-            headerLength += HeaderEndOfLineCharactersByteCount;
-
-            return headerLength;
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Api/Features/Context/DicomRequestContextMiddlewareExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Context/DicomRequestContextMiddlewareExtensions.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Health.Dicom.Api.Features.Context
             this IApplicationBuilder builder)
         {
             EnsureArg.IsNotNull(builder, nameof(builder));
-
             return builder.UseMiddleware<DicomRequestContextMiddleware>();
         }
     }

--- a/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ using Microsoft.Health.Api.Features.Headers;
 using Microsoft.Health.Api.Modules;
 using Microsoft.Health.Dicom.Api.Configs;
 using Microsoft.Health.Dicom.Api.Features.BackgroundServices;
+using Microsoft.Health.Dicom.Api.Features.ByteCounter;
 using Microsoft.Health.Dicom.Api.Features.Context;
 using Microsoft.Health.Dicom.Api.Features.Formatters;
 using Microsoft.Health.Dicom.Api.Features.Routing;
@@ -120,6 +121,7 @@ namespace Microsoft.AspNetCore.Builder
             services.AddSwaggerGenNewtonsoftSupport();
 
             services.AddSingleton<IUrlResolver, UrlResolver>();
+            services.AddSingleton<IResponseLogStreamFactory, ByteCountingStreamResponseLogStreamFactory>();
 
             services.RegisterAssemblyModules(typeof(DicomMediatorExtensions).Assembly, dicomServerConfiguration.Features, dicomServerConfiguration.Services);
             services.AddTransient<IStartupFilter, DicomServerStartupFilter>();

--- a/src/Microsoft.Health.Dicom.Core/Features/Context/DicomRequestContext.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Context/DicomRequestContext.cs
@@ -65,6 +65,10 @@ namespace Microsoft.Health.Dicom.Core.Features.Context
 
         public string SopInstanceUid { get; set; }
 
+        public bool IsTranscodeRequested { get; set; }
+
+        public long BytesTranscoded { get; set; }
+
         public ClaimsPrincipal Principal { get; set; }
 
         public IDictionary<string, StringValues> RequestHeaders { get; }

--- a/src/Microsoft.Health.Dicom.Core/Features/Context/IDicomRequestContext.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Context/IDicomRequestContext.cs
@@ -14,5 +14,9 @@ namespace Microsoft.Health.Dicom.Core.Features.Context
         string SeriesInstanceUid { get; set; }
 
         string SopInstanceUid { get; set; }
+
+        bool IsTranscodeRequested { get; set; }
+
+        long BytesTranscoded { get; set; }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveResourceService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveResourceService.cs
@@ -12,6 +12,7 @@ using EnsureThat;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Dicom.Core.Exceptions;
 using Microsoft.Health.Dicom.Core.Features.Common;
+using Microsoft.Health.Dicom.Core.Features.Context;
 using Microsoft.Health.Dicom.Core.Features.Model;
 using Microsoft.Health.Dicom.Core.Messages;
 using Microsoft.Health.Dicom.Core.Messages.Retrieve;
@@ -25,6 +26,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Retrieve
         private readonly ITranscoder _transcoder;
         private readonly IFrameHandler _frameHandler;
         private readonly IRetrieveTransferSyntaxHandler _retrieveTransferSyntaxHandler;
+        private readonly IDicomRequestContextAccessor _dicomRequestContextAccessor;
         private readonly ILogger<RetrieveResourceService> _logger;
 
         public RetrieveResourceService(
@@ -33,6 +35,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Retrieve
             ITranscoder transcoder,
             IFrameHandler frameHandler,
             IRetrieveTransferSyntaxHandler retrieveTransferSyntaxHandler,
+            IDicomRequestContextAccessor dicomRequestContextAccessor,
             ILogger<RetrieveResourceService> logger)
         {
             EnsureArg.IsNotNull(instanceStore, nameof(instanceStore));
@@ -40,6 +43,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Retrieve
             EnsureArg.IsNotNull(transcoder, nameof(transcoder));
             EnsureArg.IsNotNull(frameHandler, nameof(frameHandler));
             EnsureArg.IsNotNull(retrieveTransferSyntaxHandler, nameof(retrieveTransferSyntaxHandler));
+            EnsureArg.IsNotNull(dicomRequestContextAccessor, nameof(dicomRequestContextAccessor));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             _instanceStore = instanceStore;
@@ -47,6 +51,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Retrieve
             _transcoder = transcoder;
             _frameHandler = frameHandler;
             _retrieveTransferSyntaxHandler = retrieveTransferSyntaxHandler;
+            _dicomRequestContextAccessor = dicomRequestContextAccessor;
             _logger = logger;
         }
 
@@ -69,6 +74,10 @@ namespace Microsoft.Health.Dicom.Core.Features.Retrieve
 
                 Stream[] resultStreams = await Task.WhenAll(
                     retrieveInstances.Select(x => _blobDataStore.GetFileAsync(x, cancellationToken)));
+
+                var lengthOfResultStreams = resultStreams.Sum(stream => stream.Length);
+                _dicomRequestContextAccessor.RequestContext.IsTranscodeRequested = !isOriginalTransferSyntaxRequested;
+                _dicomRequestContextAccessor.RequestContext.BytesTranscoded = isOriginalTransferSyntaxRequested ? 0 : lengthOfResultStreams;
 
                 if (message.ResourceType == ResourceType.Frames)
                 {

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveResourceService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveResourceService.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Retrieve
                 Stream[] resultStreams = await Task.WhenAll(
                     retrieveInstances.Select(x => _blobDataStore.GetFileAsync(x, cancellationToken)));
 
-                var lengthOfResultStreams = resultStreams.Sum(stream => stream.Length);
+                long lengthOfResultStreams = resultStreams.Sum(stream => stream.Length);
                 _dicomRequestContextAccessor.RequestContext.IsTranscodeRequested = !isOriginalTransferSyntaxRequested;
                 _dicomRequestContextAccessor.RequestContext.BytesTranscoded = isOriginalTransferSyntaxRequested ? 0 : lengthOfResultStreams;
 


### PR DESCRIPTION
## Description
We are responsible for calculating billing charges for: # api requests, bytes transcoded, and egress.

I've updated the middleware to add the necessary data to the response, so it can be used for billing in another middleware in workspace platform.

Code under Api/Features/ByteCounter is from health-pass, and is used by FHIR to calculate their egress. I don't know if there's a better way to consume that code other than copying it.

## Related issues
Addresses 85307

## Testing
Ran project locally & unit tested
