### PR TITLE
Set Http/Https connectTimeout to 2 seconds for Blob connections

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <FhirServerPackageVersion>2.0.55</FhirServerPackageVersion>
     <FoDicomVersion>4.0.8</FoDicomVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <HealthcareSharedPackageVersion>3.2.6</HealthcareSharedPackageVersion>
+    <HealthcareSharedPackageVersion>3.2.7</HealthcareSharedPackageVersion>
     <HighEntropyVA>true</HighEntropyVA>
     <Hl7FhirPackageVersion>3.3.0</Hl7FhirPackageVersion>
     <LangVersion>Latest</LangVersion>

--- a/src/Microsoft.Health.Dicom.Web/appsettings.json
+++ b/src/Microsoft.Health.Dicom.Web/appsettings.json
@@ -94,6 +94,9 @@
       "MaxRetries": 6,
       "Mode": "Exponential",
       "NetworkTimeout": "00:02:00"
+    },
+    "TransportOverride": {
+      "ConnectTimeout": "00:00:02"
     }
   },
   "SqlServer": {


### PR DESCRIPTION

## Description
Set the Blob httpClient ConnectTimeout to 2 seconds read from appSettings.

## Related issues
[AB#85137](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/85137)

## Testing
SocketHandler ConnectTimeout is set correct.
Zeiss will help test the QIDO performance
