### PR TITLE
Fix SQL Snapshot Scripts to be Idempotent

### DIFF
--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/4.sql
@@ -1909,7 +1909,7 @@ GO
 -- RETURN VALUE
 --     The corresponding extended query tags, if any.
 /***************************************************************************************/
-CREATE PROCEDURE dbo.GetExtendedQueryTagsByKey
+CREATE OR ALTER PROCEDURE dbo.GetExtendedQueryTagsByKey
     @extendedQueryTagKeys dbo.ExtendedQueryTagKeyTableType_1 READONLY
 AS
 BEGIN
@@ -2284,7 +2284,7 @@ GO
 -- RETURN VALUE
 --     None
 /***************************************************************************************/
-CREATE PROCEDURE dbo.IndexInstance
+CREATE OR ALTER PROCEDURE dbo.IndexInstance
     @watermark                                                                   BIGINT,
     @stringExtendedQueryTags dbo.InsertStringExtendedQueryTagTableType_1         READONLY,
     @longExtendedQueryTags dbo.InsertLongExtendedQueryTagTableType_1             READONLY,

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
@@ -55,6 +55,28 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
             await snapshotFixture.DisposeAsync();
         }
 
-        public static IEnumerable<object[]> SchemaDiffVersions = new List<object[]>(Enumerable.Range(start: SchemaVersionConstants.Min + 1, count: SchemaVersionConstants.Max - SchemaVersionConstants.Min).Select(x => new object[] { x }));
+        [Theory]
+        [MemberData(nameof(SchemaSnapshotVersions))]
+        public async Task GivenASchemaVersion_WhenApplyingSnapshotTwice_ShouldSucceed(int schemaVersion)
+        {
+            SqlDataStoreTestsFixture snapshotFixture = new SqlDataStoreTestsFixture(SqlDataStoreTestsFixture.GenerateDatabaseName("SNAPSHOT"));
+            snapshotFixture.SchemaInformation = new SchemaInformation(SchemaVersionConstants.Min, schemaVersion);
+
+            await snapshotFixture.InitializeAsync(forceIncrementalSchemaUpgrade: false);
+            await snapshotFixture.SchemaUpgradeRunner.ApplySchemaAsync(schemaVersion, applyFullSchemaSnapshot: true, CancellationToken.None);
+
+            // cleanup if succeeds
+            await snapshotFixture.DisposeAsync();
+        }
+
+        public static IEnumerable<object[]> SchemaDiffVersions = Enumerable
+            .Range(start: SchemaVersionConstants.Min + 1, count: SchemaVersionConstants.Max - SchemaVersionConstants.Min)
+            .Select(x => new object[] { x })
+            .ToList();
+
+        public static IEnumerable<object[]> SchemaSnapshotVersions = Enumerable
+            .Range(start: SchemaVersionConstants.Min, count: SchemaVersionConstants.Max - SchemaVersionConstants.Min + 1)
+            .Select(x => new object[] { x })
+            .ToList();
     }
 }


### PR DESCRIPTION
## Description
- Fix 4.sql to be idempotent
- Enforce idempotency through new integration test

## Related issues
[AB#85322](https://microsofthealth.visualstudio.com/Health/_workitems/edit/85322)

## Testing
Tested via pipeline
