### PR TITLE
Update sdkpackageversion to 5.0.9 to solve governance alert.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,7 +19,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Product>Microsoft Health</Product>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <SdkPackageVersion>5.0.0</SdkPackageVersion>
+    <SdkPackageVersion>5.0.9</SdkPackageVersion>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />


### PR DESCRIPTION
## Description
Update sdkpackageversion to 5.0.9 to solve governance alert.

## Related issues
Addresses [AB#85404](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/85404)

## Testing
All tests passed
