### PR TITLE
Changes to the return of the GetInstanceResourceAsync method to add the Transfer Syntax into Content Type.

### DIFF
--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveResourceServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveResourceServiceTests.cs
@@ -253,7 +253,8 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Retrieve
             ValidateDicomRequestIsPopulated();
 
             // Validate content type
-            Assert.Equal(KnownContentTypes.ApplicationDicom, response.ContentType);
+            string contentTypePart = response.ContentType.Substring(0, response.ContentType.IndexOf(';'));
+            Assert.Equal(KnownContentTypes.ApplicationDicom, contentTypePart);
 
             // Dispose created streams.
             streamAndStoredFile.Value.Dispose();

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveResourceService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveResourceService.cs
@@ -63,6 +63,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Retrieve
             {
                 string transferSyntax = _retrieveTransferSyntaxHandler.GetTransferSyntax(message.ResourceType, message.AcceptHeaders, out AcceptHeaderDescriptor acceptHeaderDescriptor);
                 bool isOriginalTransferSyntaxRequested = DicomTransferSyntaxUids.IsOriginalTransferSyntaxRequested(transferSyntax);
+                string contentType = acceptHeaderDescriptor.MediaType + "; transfer-syntax=" + transferSyntax;
 
                 IEnumerable<VersionedInstanceIdentifier> retrieveInstances = await _instanceStore.GetInstancesToRetrieve(
                     message.ResourceType, message.StudyInstanceUid, message.SeriesInstanceUid, message.SopInstanceUid, cancellationToken);
@@ -84,7 +85,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Retrieve
                     return new RetrieveResourceResponse(
                         await _frameHandler.GetFramesResourceAsync(
                         resultStreams.Single(), message.Frames, isOriginalTransferSyntaxRequested, transferSyntax),
-                        acceptHeaderDescriptor.MediaType);
+                        contentType);
                 }
                 else
                 {
@@ -99,7 +100,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Retrieve
                             s => ResetDicomFileStream(s))).ToArray();
                 }
 
-                return new RetrieveResourceResponse(resultStreams, acceptHeaderDescriptor.MediaType);
+                return new RetrieveResourceResponse(resultStreams, contentType);
             }
             catch (DataStoreException e)
             {


### PR DESCRIPTION
## Description
- Creation of variable to store MediaType and the Transfer Syntax, and pass to the return of the method.
- A bit of workaround to avoid breaking the test GivenStoredInstances_WhenRetrieveRequestForInstance_ThenInstanceIsRetrievedSuccessfully, because I changed the return of GetInstanceResourceAsync method in the previous paragraph.

## Related issues
Addresses [#1071].

## Testing
I couldn't test using Postman, but I store and retrieved DCIM files successfully. I tested by running all the tests in Microsoft.Health.Dicom.Core.UnitTests solution, especially the tests related to the GetInstanceResourceAsync method.

For some reason of the 1061 tests, 123 failed, but none of them are related to this issue, are more SQL Server issues, despite I did all the requirements including installing SQL 19 with full-text search and the AzureStorageEmulator did create a database with many tables in SQL.
