### PR TITLE
Purging key vault during cleanup

### DIFF
--- a/build/cleanup.yml
+++ b/build/cleanup.yml
@@ -19,7 +19,10 @@ jobs:
       azurePowerShellVersion: latestVersion
       ScriptType: InlineScript
       Inline: |
-        Get-AzKeyVault -VaultName $(deploymentName) -Location $(resourceGroupRegion) -InRemovedState | Remove-AzKeyVault -VaultName $(deploymentName) -InRemovedState -Location $(resourceGroupRegion) -Force
+        if (Get-AzKeyVault -VaultName $(deploymentName) -Location $(resourceGroupRegion) -InRemovedState)
+        {
+            Remove-AzKeyVault -VaultName $(deploymentName) -InRemovedState -Location $(resourceGroupRegion) -Force
+        }
 
 - job: cleanupAad
   displayName: 'Cleanup Azure Active Directory'


### PR DESCRIPTION
There are two key vaults created during PR tests: one named `<webapp>` and one named `<webapp>-ts`. The `-ts` key vault is used to hold AAD identity secrets, is created via PowerShell commandlet, and is soft-deleted [here](https://github.com/microsoft/dicom-server/blob/9d7a5d845e833493a4de35e6ec71b318bb7b74e7/build/add-aad-test-environment.yml#L36). The other key vault is used for Function App secrets, is created via ARM template, and needs to be purged after the resource group is deleted, which causes future provisioning attempts to fail. 

https://docs.microsoft.com/azure/key-vault/key-vault-ovw-soft-delete

## Related issues
Addresses [issue #].

## Testing
Tested by triggering PR build twice.
