### PR TITLE
Adds initial ability to create Observations from Structured Reports

### DIFF
--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Fhir/ImagingStudyIdentifierUtilityTests.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Fhir/ImagingStudyIdentifierUtilityTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Fhir
         [Fact]
         public void GivenStudyInstanceUid_WhenCreated_ThenCorrectIdentifierShouldBeCreated()
         {
-            var identifier = ImagingStudyIdentifierUtility.CreateIdentifier("123");
+            var identifier = IdentifierUtility.CreateIdentifier("123");
 
             Assert.NotNull(identifier);
             Assert.Equal("urn:dicom:uid", identifier.System);

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/FhirResourceBuilder.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/FhirResourceBuilder.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
                 study.Series.Add(series);
             }
 
-            study.Identifier.Add(ImagingStudyIdentifierUtility.CreateIdentifier(studyInstanceUid));
+            study.Identifier.Add(IdentifierUtility.CreateIdentifier(studyInstanceUid));
 
             return study;
         }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/FhirTransactionRequestResponsePropertyAccessorTests.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/FhirTransactionRequestResponsePropertyAccessorTests.cs
@@ -4,6 +4,8 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Hl7.Fhir.Model;
 using Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction;
 using Xunit;
@@ -19,7 +21,7 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
 
         public FhirTransactionRequestResponsePropertyAccessorTests()
         {
-            _patientPropertyAccessor = CreatePropertyAccesor();
+            _patientPropertyAccessor = CreatePropertyAccessor();
         }
 
         [Fact]
@@ -31,17 +33,16 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
 
             Assert.Same(
                 requestEntry,
-                _patientPropertyAccessor.RequestEntryGetter(_fhirTransactionRequest));
+                _patientPropertyAccessor.RequestEntryGetter(_fhirTransactionRequest).Single());
         }
 
         [Fact]
         public void GiveTheResponseEntryGetter_WhenInvoked_ThenCorrectValueShouldBeSet()
         {
-            var responseEntry = new FhirTransactionResponseEntry(
-                new Bundle.ResponseComponent(),
-                new Patient());
+            FhirTransactionResponseEntry responseEntry = new(new Bundle.ResponseComponent(), new Patient());
+            var responseEntryList = new List<FhirTransactionResponseEntry> { responseEntry };
 
-            _patientPropertyAccessor.ResponseEntrySetter(_fhirTransactionResponse, responseEntry);
+            _patientPropertyAccessor.ResponseEntrySetter(_fhirTransactionResponse, responseEntryList);
 
             Assert.Same(
                 responseEntry,
@@ -51,7 +52,7 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
         [Fact]
         public void GivenSamePropertyAccessor_WhenHashCodeIsComputed_ThenHashCodeShouldBeTheSame()
         {
-            FhirTransactionRequestResponsePropertyAccessor anotherPatientPropertyAccessor = CreatePropertyAccesor();
+            FhirTransactionRequestResponsePropertyAccessor anotherPatientPropertyAccessor = CreatePropertyAccessor();
 
             Assert.Equal(_patientPropertyAccessor.GetHashCode(), anotherPatientPropertyAccessor.GetHashCode());
         }
@@ -59,7 +60,7 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
         [Fact]
         public void GivenPropertyAccessorWithDifferentPropertyName_WhenHashCodeIsComputed_ThenHashCodeShouldBeDifferent()
         {
-            FhirTransactionRequestResponsePropertyAccessor anotherPatientPropertyAccessor = CreatePropertyAccesor(
+            FhirTransactionRequestResponsePropertyAccessor anotherPatientPropertyAccessor = CreatePropertyAccessor(
                 propertyName: "ImagingStudy");
 
             Assert.NotEqual(_patientPropertyAccessor.GetHashCode(), anotherPatientPropertyAccessor.GetHashCode());
@@ -68,8 +69,8 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
         [Fact]
         public void GivenPropertyAccessorWithDifferentRequestEntryGetter_WhenHashCodeIsComputed_ThenHashCodeShouldBeDifferent()
         {
-            FhirTransactionRequestResponsePropertyAccessor anotherPatientPropertyAccessor = CreatePropertyAccesor(
-                requestEntryGetter: request => request.ImagingStudy);
+            FhirTransactionRequestResponsePropertyAccessor anotherPatientPropertyAccessor = CreatePropertyAccessor(
+                requestEntryGetter: request => new[] { request.ImagingStudy });
 
             Assert.NotEqual(_patientPropertyAccessor.GetHashCode(), anotherPatientPropertyAccessor.GetHashCode());
         }
@@ -77,8 +78,8 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
         [Fact]
         public void GivenPropertyAccessorWithDifferentResponseEntrySetter_WhenHashCodeIsComputed_ThenHashCodeShouldBeDifferent()
         {
-            FhirTransactionRequestResponsePropertyAccessor anotherPatientPropertyAccessor = CreatePropertyAccesor(
-                responseEntrySetter: (response, responseEntry) => response.ImagingStudy = responseEntry);
+            FhirTransactionRequestResponsePropertyAccessor anotherPatientPropertyAccessor = CreatePropertyAccessor(
+                responseEntrySetter: (response, responseEntry) => response.ImagingStudy = responseEntry.Single());
 
             Assert.NotEqual(_patientPropertyAccessor.GetHashCode(), anotherPatientPropertyAccessor.GetHashCode());
         }
@@ -99,21 +100,21 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
         public void GivenAPropertyAccessor_WhenCheckingEqualToDifferentPropertyAccessorWhenPropertyNameIsDifferentUsingObjectEquals_ThenFalseShouldBeReturned()
         {
             Assert.False(_patientPropertyAccessor.Equals(
-                (object)CreatePropertyAccesor(propertyName: "ImagingStudy")));
+                (object)CreatePropertyAccessor(propertyName: "ImagingStudy")));
         }
 
         [Fact]
         public void GivenAPropertyAccessor_WhenCheckingEqualToDifferentPropertyAccessorWhenRequestEntryGetterIsDifferentUsingObjectEquals_ThenFalseShouldBeReturned()
         {
             Assert.False(_patientPropertyAccessor.Equals(
-                (object)CreatePropertyAccesor(requestEntryGetter: request => request.ImagingStudy)));
+                (object)CreatePropertyAccessor(requestEntryGetter: request => new[] { request.ImagingStudy })));
         }
 
         [Fact]
         public void GivenAPropertyAccessor_WhenCheckingEqualToDifferentPropertyAccessorWhenResponseEntrySetterIsDifferentUsingObjectEquals_ThenFalseShouldBeReturned()
         {
             Assert.False(_patientPropertyAccessor.Equals(
-                (object)CreatePropertyAccesor(responseEntrySetter: (response, responseEntry) => response.ImagingStudy = responseEntry)));
+                (object)CreatePropertyAccessor(responseEntrySetter: (response, responseEntry) => response.ImagingStudy = responseEntry.Single())));
         }
 
         [Fact]
@@ -132,21 +133,21 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
         public void GivenAPropertyAccessor_WhenCheckingEqualToDifferentPropertyAccessorWhenPropertyNameIsDifferentUsingEquatableEquals_ThenFalseShouldBeReturned()
         {
             Assert.False(_patientPropertyAccessor.Equals(
-                CreatePropertyAccesor(propertyName: "ImagingStudy")));
+                CreatePropertyAccessor(propertyName: "ImagingStudy")));
         }
 
         [Fact]
         public void GivenAPropertyAccessor_WhenCheckingEqualToDifferentPropertyAccessorWhenRequestEntryGetterIsDifferentUsingEquatableEquals_ThenFalseShouldBeReturned()
         {
             Assert.False(_patientPropertyAccessor.Equals(
-                CreatePropertyAccesor(requestEntryGetter: request => request.ImagingStudy)));
+                CreatePropertyAccessor(requestEntryGetter: request => new[] { request.ImagingStudy })));
         }
 
         [Fact]
         public void GivenAPropertyAccessor_WhenCheckingEqualToDifferentPropertyAccessorWhenResponseEntrySetterIsDifferentUsingEquatableEquals_ThenFalseShouldBeReturned()
         {
             Assert.False(_patientPropertyAccessor.Equals(
-                CreatePropertyAccesor(responseEntrySetter: (response, responseEntry) => response.ImagingStudy = responseEntry)));
+                CreatePropertyAccessor(responseEntrySetter: (response, responseEntry) => response.ImagingStudy = responseEntry.Single())));
         }
 
         [Fact]
@@ -167,21 +168,21 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
         public void GivenAPropertyAccessor_WhenCheckingEqualToDifferentPropertyAccessorWhenPropertyNameIsDifferentUsingEqualityOperator_ThenFalseShouldBeReturned()
         {
             Assert.False(_patientPropertyAccessor ==
-                CreatePropertyAccesor(propertyName: "ImagingStudy"));
+                CreatePropertyAccessor(propertyName: "ImagingStudy"));
         }
 
         [Fact]
         public void GivenAPropertyAccessor_WhenCheckingEqualToDifferentPropertyAccessorWhenRequestEntryGetterIsDifferentUsingEqualityOperator_ThenFalseShouldBeReturned()
         {
             Assert.False(_patientPropertyAccessor ==
-                CreatePropertyAccesor(requestEntryGetter: request => request.ImagingStudy));
+                CreatePropertyAccessor(requestEntryGetter: request => new[] { request.ImagingStudy }));
         }
 
         [Fact]
         public void GivenAPropertyAccessor_WhenCheckingEqualToDifferentPropertyAccessorWhenResponseEntrySetterIsDifferentUsingEqualityOperator_ThenFalseShouldBeReturned()
         {
             Assert.False(_patientPropertyAccessor ==
-                CreatePropertyAccesor(responseEntrySetter: (response, responseEntry) => response.ImagingStudy = responseEntry));
+                CreatePropertyAccessor(responseEntrySetter: (response, responseEntry) => response.ImagingStudy = responseEntry.Single()));
         }
 
         [Fact]
@@ -202,30 +203,30 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
         public void GivenAPropertyAccessor_WhenCheckingEqualToDifferentPropertyAccessorWhenPropertyNameIsDifferentUsingInequalityOperator_ThenFalseShouldBeReturned()
         {
             Assert.True(_patientPropertyAccessor !=
-                CreatePropertyAccesor(propertyName: "ImagingStudy"));
+                CreatePropertyAccessor(propertyName: "ImagingStudy"));
         }
 
         [Fact]
         public void GivenAPropertyAccessor_WhenCheckingEqualToDifferentPropertyAccessorWhenRequestEntryGetterIsDifferentUsingInequalityOperator_ThenFalseShouldBeReturned()
         {
             Assert.True(_patientPropertyAccessor !=
-                CreatePropertyAccesor(requestEntryGetter: request => request.ImagingStudy));
+                CreatePropertyAccessor(requestEntryGetter: request => new[] { request.ImagingStudy }));
         }
 
         [Fact]
         public void GivenAPropertyAccessor_WhenCheckingEqualToDifferentPropertyAccessorWhenResponseEntrySetterIsDifferentUsingInequalityOperator_ThenFalseShouldBeReturned()
         {
             Assert.True(_patientPropertyAccessor !=
-                CreatePropertyAccesor(responseEntrySetter: (response, responseEntry) => response.ImagingStudy = responseEntry));
+                CreatePropertyAccessor(responseEntrySetter: (response, responseEntry) => response.ImagingStudy = responseEntry.Single()));
         }
 
-        private FhirTransactionRequestResponsePropertyAccessor CreatePropertyAccesor(
+        private FhirTransactionRequestResponsePropertyAccessor CreatePropertyAccessor(
             string propertyName = "Patient",
-            Func<FhirTransactionRequest, FhirTransactionRequestEntry> requestEntryGetter = null,
-            Action<FhirTransactionResponse, FhirTransactionResponseEntry> responseEntrySetter = null)
+            Func<FhirTransactionRequest, IEnumerable<FhirTransactionRequestEntry>> requestEntryGetter = null,
+            Action<FhirTransactionResponse, IEnumerable<FhirTransactionResponseEntry>> responseEntrySetter = null)
         {
-            requestEntryGetter ??= request => request.Patient;
-            responseEntrySetter ??= (response, responseEntry) => response.Patient = responseEntry;
+            requestEntryGetter ??= request => new List<FhirTransactionRequestEntry> { request.Patient };
+            responseEntrySetter ??= (response, responseEntry) => response.Patient = responseEntry.Single();
 
             return new FhirTransactionRequestResponsePropertyAccessor(propertyName, requestEntryGetter, responseEntrySetter);
         }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/FhirTransactionRequestResponsePropertyAccessorsTests.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/FhirTransactionRequestResponsePropertyAccessorsTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
 using System.Linq;
 using Hl7.Fhir.Model;
 using Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction;
@@ -32,11 +33,12 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
         [Fact]
         public void GivenAPatientResponse_WhenPropertySetterIsUsed_ThenCorrectValueShouldBeSet()
         {
-            FhirTransactionResponseEntry expectedResponse = ExecutePropertySetter(nameof(FhirTransactionRequest.Patient));
+            IEnumerable<FhirTransactionResponseEntry> expectedResponse = ExecutePropertySetter(nameof(FhirTransactionRequest.Patient));
 
-            Assert.Same(_fhirTransactionResponse.Patient, expectedResponse);
+            Assert.Same(_fhirTransactionResponse.Patient, expectedResponse.Single());
             Assert.Null(_fhirTransactionResponse.ImagingStudy);
             Assert.Null(_fhirTransactionResponse.Endpoint);
+            Assert.Null(_fhirTransactionResponse.Observation);
         }
 
         [Fact]
@@ -48,9 +50,9 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
         [Fact]
         public void GivenAnImagingStudyResponse_WhenPropertySetterIsUsed_ThenCorrectValueShouldBeSet()
         {
-            FhirTransactionResponseEntry expectedResponse = ExecutePropertySetter(nameof(FhirTransactionRequest.ImagingStudy));
+            IEnumerable<FhirTransactionResponseEntry> expectedResponse = ExecutePropertySetter(nameof(FhirTransactionRequest.ImagingStudy));
 
-            Assert.Same(_fhirTransactionResponse.ImagingStudy, expectedResponse);
+            Assert.Same(_fhirTransactionResponse.ImagingStudy, expectedResponse.Single());
         }
 
         [Fact]
@@ -62,25 +64,25 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
         [Fact]
         public void GivenAnEndpointResponse_WhenPropertySetterIsUsed_ThenCorrectValueShouldBeSet()
         {
-            FhirTransactionResponseEntry expectedResponse = ExecutePropertySetter(nameof(FhirTransactionRequest.Endpoint));
+            IEnumerable<FhirTransactionResponseEntry> expectedResponse = ExecutePropertySetter(nameof(FhirTransactionRequest.Endpoint));
 
-            Assert.Same(_fhirTransactionResponse.Endpoint, expectedResponse);
+            Assert.Same(_fhirTransactionResponse.Endpoint, expectedResponse.Single());
         }
 
         private void ExecuteAndValidatePropertyGetter(string propertyName, FhirTransactionRequestEntry expectedEntry)
         {
             FhirTransactionRequestResponsePropertyAccessor propertyAccessor = GetPropertyAccessor(propertyName);
 
-            FhirTransactionRequestEntry requestEntry = propertyAccessor.RequestEntryGetter(_fhirTransactionRequest);
+            IEnumerable<FhirTransactionRequestEntry> requestEntry = propertyAccessor.RequestEntryGetter(_fhirTransactionRequest);
 
-            Assert.Same(expectedEntry, requestEntry);
+            Assert.Same(expectedEntry, requestEntry.Single());
         }
 
-        private FhirTransactionResponseEntry ExecutePropertySetter(string propertyName)
+        private IEnumerable<FhirTransactionResponseEntry> ExecutePropertySetter(string propertyName)
         {
             FhirTransactionRequestResponsePropertyAccessor propertyAccessor = GetPropertyAccessor(propertyName);
 
-            var expectedResponse = new FhirTransactionResponseEntry(new Bundle.ResponseComponent(), new Patient());
+            var expectedResponse = new[] { new FhirTransactionResponseEntry(new Bundle.ResponseComponent(), new Patient()) };
 
             propertyAccessor.ResponseEntrySetter(_fhirTransactionResponse, expectedResponse);
 

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/Observation/ObservationParserTests.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/Observation/ObservationParserTests.cs
@@ -1,0 +1,254 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Linq;
+using Dicom;
+using Dicom.StructuredReport;
+using Hl7.Fhir.Model;
+using Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction;
+using Xunit;
+
+namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransaction
+{
+    public class ObservationParserTests
+    {
+        private readonly ObservationParser _observationParser;
+
+        public ObservationParserTests()
+        {
+            _observationParser = new ObservationParser();
+        }
+
+        [Fact]
+        public void RadiationEventWithAllSupportedAttributes()
+        {
+            const string randomIrradiationEventUid = "1.2.3.4.5.6.123123";
+            const decimal randomDecimalNumber = (decimal)0.10;
+            var randomRadiationMeasurementCodeItem = new DicomCodeItem("mGy", "UCUM", "mGy");
+            var report = new DicomStructuredReport(
+                ObservationConstants.IrradiationEventXRayData,
+                new DicomContentItem(
+                    ObservationConstants.IrradiationEventUid,
+                    DicomRelationship.Contains,
+                    new DicomUID(randomIrradiationEventUid, "", DicomUidType.Unknown)),
+                new DicomContentItem(
+                    ObservationConstants.MeanCtdIvol,
+                    DicomRelationship.Contains,
+                    new DicomMeasuredValue(randomDecimalNumber,
+                        randomRadiationMeasurementCodeItem)),
+                new DicomContentItem(
+                    ObservationConstants.Dlp,
+                    DicomRelationship.Contains,
+                    new DicomMeasuredValue(randomDecimalNumber,
+                        randomRadiationMeasurementCodeItem)),
+                new DicomContentItem(
+                    ObservationConstants.CtdIwPhantomType,
+                    DicomRelationship.Contains,
+                    new DicomCodeItem("113691", "DCM", "IEC Body Dosimetry Phantom")));
+
+            var observations = _observationParser.Parse(report.Dataset, new ResourceReference(), new ResourceReference());
+            Assert.Single(observations);
+
+            Observation radiationEvent = observations.First();
+            Assert.Single(radiationEvent.Identifier);
+            Assert.Equal(randomIrradiationEventUid, radiationEvent.Identifier[0].Value);
+            Assert.Equal(2,
+                radiationEvent.Component
+                    .Count(component => component.Value is Quantity));
+            Assert.Equal(1,
+                radiationEvent.Component
+                    .Count(component => component.Value is CodeableConcept));
+        }
+
+        [Fact]
+        public void DoseSummaryWithAllSupportedAttributes()
+        {
+            const string studyInstanceUid = "1.3.12.2.123.5.4.5.123123.123123";
+            const string accessionNumber = "random-accession";
+            const decimal randomDecimalNumber = (decimal)0.10;
+            var randomRadiationMeasurementCodeItem = new DicomCodeItem("mGy", "UCUM", "mGy");
+
+            var report = new DicomStructuredReport(
+                ObservationConstants.RadiopharmaceuticalRadiationDoseReport,
+                // identifiers
+                new DicomContentItem(
+                    ObservationConstants.StudyInstanceUid,
+                    DicomRelationship.HasProperties,
+                    new DicomUID(studyInstanceUid, "", DicomUidType.Unknown)),
+                new DicomContentItem(
+                    ObservationConstants.AccessionNumber,
+                    DicomRelationship.HasProperties,
+                    DicomValueType.Text,
+                    accessionNumber),
+
+                // attributes
+                new DicomContentItem(
+                    ObservationConstants.DoseRpTotal,
+                    DicomRelationship.Contains,
+                    new DicomMeasuredValue(randomDecimalNumber,
+                        randomRadiationMeasurementCodeItem)),
+                new DicomContentItem(
+                    ObservationConstants.AccumulatedAverageGlandularDose,
+                    DicomRelationship.Contains,
+                    new DicomMeasuredValue(randomDecimalNumber,
+                        randomRadiationMeasurementCodeItem)),
+                new DicomContentItem(
+                    ObservationConstants.DoseAreaProductTotal,
+                    DicomRelationship.Contains,
+                    new DicomMeasuredValue(randomDecimalNumber,
+                        randomRadiationMeasurementCodeItem)),
+                new DicomContentItem(
+                    ObservationConstants.FluoroDoseAreaProductTotal,
+                    DicomRelationship.Contains,
+                    new DicomMeasuredValue(randomDecimalNumber,
+                        randomRadiationMeasurementCodeItem)),
+                new DicomContentItem(
+                    ObservationConstants.AcquisitionDoseAreaProductTotal,
+                    DicomRelationship.Contains,
+                    new DicomMeasuredValue(randomDecimalNumber,
+                        randomRadiationMeasurementCodeItem)),
+                new DicomContentItem(
+                    ObservationConstants.TotalFluoroTime,
+                    DicomRelationship.Contains,
+                    new DicomMeasuredValue(randomDecimalNumber,
+                        randomRadiationMeasurementCodeItem)),
+                new DicomContentItem(
+                    ObservationConstants.TotalNumberOfRadiographicFrames,
+                    DicomRelationship.Contains,
+                    new DicomMeasuredValue(10,
+                        new DicomCodeItem("1", "UCUM", "No units"))),
+                new DicomContentItem(
+                    ObservationConstants.AdministeredActivity,
+                    DicomRelationship.Contains,
+                    new DicomMeasuredValue(randomDecimalNumber,
+                        randomRadiationMeasurementCodeItem)),
+                new DicomContentItem(
+                    ObservationConstants.CtDoseLengthProductTotal,
+                    DicomRelationship.Contains,
+                    new DicomMeasuredValue(randomDecimalNumber,
+                        randomRadiationMeasurementCodeItem)),
+                new DicomContentItem(
+                    ObservationConstants.TotalNumberOfIrradiationEvents,
+                    DicomRelationship.Contains,
+                    new DicomMeasuredValue(10,
+                        new DicomCodeItem("1", "UCUM", "No units"))),
+                new DicomContentItem(
+                    ObservationConstants.MeanCtdIvol,
+                    DicomRelationship.Contains,
+                    new DicomMeasuredValue(randomDecimalNumber,
+                        randomRadiationMeasurementCodeItem)),
+                new DicomContentItem(
+                    ObservationConstants.RadiopharmaceuticalAgent,
+                    DicomRelationship.Contains,
+                    DicomValueType.Text,
+                    "Uranium"),
+                new DicomContentItem(
+                    ObservationConstants.Radionuclide,
+                    DicomRelationship.Contains,
+                    DicomValueType.Text,
+                    "Uranium"),
+                new DicomContentItem(
+                    ObservationConstants.RadiopharmaceuticalVolume,
+                    DicomRelationship.Contains,
+                    new DicomMeasuredValue(randomDecimalNumber,
+                        randomRadiationMeasurementCodeItem)),
+                new DicomContentItem(
+                    ObservationConstants.RouteOfAdministration,
+                    DicomRelationship.Contains,
+                    new DicomCodeItem("needle", "random-scheme", "this is made up"))
+            );
+
+            var observations = _observationParser.Parse(
+                report.Dataset,
+                new ResourceReference(),
+                new ResourceReference());
+            Assert.Single(observations);
+
+            Observation doseSummary = observations.First();
+            Assert.Equal(2, doseSummary.Identifier.Count);
+            Assert.Equal("urn:oid:" + studyInstanceUid,
+                doseSummary.Identifier[0].Value);
+            Assert.Equal(accessionNumber,
+                doseSummary.Identifier[1].Value);
+            Assert.Equal(10,
+                doseSummary.Component
+                    .Count(component => component.Value is Quantity));
+            Assert.Equal(2,
+                doseSummary.Component
+                    .Count(component => component.Value is Integer));
+            Assert.Equal(2,
+                doseSummary.Component
+                    .Count(component => component.Value is FhirString));
+            Assert.Equal(1,
+                doseSummary.Component
+                    .Count(component => component.Value is CodeableConcept));
+        }
+
+        [Fact]
+        public void DoseSummaryWithStudyInstanceUidInTag()
+        {
+            var report = new DicomStructuredReport(
+                ObservationConstants.XRayRadiationDoseReport);
+            report.Dataset
+                .Add(DicomTag.StudyInstanceUID, "12345")
+                .Add(DicomTag.AccessionNumber, "12345");
+
+            var observations = _observationParser.Parse(
+                report.Dataset,
+                new ResourceReference(),
+                new ResourceReference());
+            Assert.Single(observations);
+        }
+
+
+        [Fact]
+        public void DoseSummaryWithStudyInstanceUidInReport()
+        {
+            var report = new DicomStructuredReport(
+                ObservationConstants.XRayRadiationDoseReport,
+                new DicomContentItem(
+                    ObservationConstants.StudyInstanceUid,
+                    DicomRelationship.HasProperties,
+                    new DicomUID("1.3.12.2.123.5.4.5.123123.123123", "", DicomUidType.Unknown)));
+
+            var observations = _observationParser.Parse(
+                report.Dataset,
+                new ResourceReference(),
+                new ResourceReference());
+            Assert.Single(observations);
+        }
+
+        [Fact]
+        public void RadiationEventWithIrradiationEventUid()
+        {
+            var report = new DicomStructuredReport(
+                ObservationConstants.IrradiationEventXRayData,
+                new DicomContentItem(
+                    ObservationConstants.IrradiationEventUid,
+                    DicomRelationship.Contains,
+                    new DicomUID("1.3.12.2.1234.5.4.5.123123.3000000111", "foobar", DicomUidType.Unknown)
+                ));
+
+            var observations = _observationParser.Parse(
+                report.Dataset,
+                new ResourceReference(),
+                new ResourceReference());
+            Assert.Single(observations);
+        }
+
+        [Fact]
+        public void RadiationEventWithoutIrradiationEventUid()
+        {
+            var report = new DicomStructuredReport(
+                ObservationConstants.IrradiationEventXRayData);
+
+            var observations = _observationParser.Parse(
+                report.Dataset,
+                new ResourceReference(),
+                new ResourceReference());
+            Assert.Empty(observations);
+        }
+    }
+}

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/Observation/ObservationParserTests.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/Observation/ObservationParserTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Dicom;
 using Dicom.StructuredReport;
 using Hl7.Fhir.Model;
+using Microsoft.Health.DicomCast.Core.Features.Fhir;
 using Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction;
 using Xunit;
 
@@ -48,12 +49,16 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
                     DicomRelationship.Contains,
                     new DicomCodeItem("113691", "DCM", "IEC Body Dosimetry Phantom")));
 
-            var observations = _observationParser.Parse(report.Dataset, new ResourceReference(), new ResourceReference());
+            var observations = _observationParser.Parse(
+                report.Dataset,
+                new ResourceReference(),
+                new ResourceReference(),
+                IdentifierUtility.CreateIdentifier(randomIrradiationEventUid));
             Assert.Single(observations);
 
             Observation radiationEvent = observations.First();
             Assert.Single(radiationEvent.Identifier);
-            Assert.Equal(randomIrradiationEventUid, radiationEvent.Identifier[0].Value);
+            Assert.Equal("urn:oid:" + randomIrradiationEventUid, radiationEvent.Identifier[0].Value);
             Assert.Equal(2,
                 radiationEvent.Component
                     .Count(component => component.Value is Quantity));
@@ -163,7 +168,9 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
             var observations = _observationParser.Parse(
                 report.Dataset,
                 new ResourceReference(),
-                new ResourceReference());
+                new ResourceReference(),
+                IdentifierUtility.CreateIdentifier(studyInstanceUid));
+
             Assert.Single(observations);
 
             Observation doseSummary = observations.First();
@@ -198,7 +205,8 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
             var observations = _observationParser.Parse(
                 report.Dataset,
                 new ResourceReference(),
-                new ResourceReference());
+                new ResourceReference(),
+                new Identifier());
             Assert.Single(observations);
         }
 
@@ -216,7 +224,8 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
             var observations = _observationParser.Parse(
                 report.Dataset,
                 new ResourceReference(),
-                new ResourceReference());
+                new ResourceReference(),
+                new Identifier());
             Assert.Single(observations);
         }
 
@@ -234,7 +243,8 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
             var observations = _observationParser.Parse(
                 report.Dataset,
                 new ResourceReference(),
-                new ResourceReference());
+                new ResourceReference(),
+                new Identifier());
             Assert.Single(observations);
         }
 
@@ -247,7 +257,8 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
             var observations = _observationParser.Parse(
                 report.Dataset,
                 new ResourceReference(),
-                new ResourceReference());
+                new ResourceReference(),
+                new Identifier());
             Assert.Empty(observations);
         }
     }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/ValidationUtility.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/FhirTransaction/ValidationUtility.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Health.DicomCast.Core.UnitTests.Features.Worker.FhirTransact
 
         public static ImagingStudy ValidateImagingStudyUpdate(string studyInstanceUid, string patientResourceId, FhirTransactionRequestEntry entry, bool hasAccessionNumber = true)
         {
-            Identifier expectedIdentifier = ImagingStudyIdentifierUtility.CreateIdentifier(studyInstanceUid);
+            Identifier expectedIdentifier = IdentifierUtility.CreateIdentifier(studyInstanceUid);
             string expectedRequestUrl = $"ImagingStudy/{entry.Resource.Id}";
 
             ValidateRequestEntryMinimumRequirementForWithChange(FhirTransactionRequestMode.Update, expectedRequestUrl, Bundle.HTTPVerb.PUT, actualEntry: entry);

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Configurations/FeatureConfiguration.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Configurations/FeatureConfiguration.cs
@@ -11,5 +11,10 @@ namespace Microsoft.Health.DicomCast.Core.Configurations
         /// Do not sync values that are invalid and are not required
         /// </summary>
         public bool EnforceValidationOfTagValues { get; set; }
+
+        /// <summary>
+        /// Generate observations from dcm
+        /// </summary>
+        public bool GenerateObservations { get; set; }
     }
 }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Fhir/FhirService.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Fhir/FhirService.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Fhir
         public async Task<Endpoint> RetrieveEndpointAsync(string queryParameter, CancellationToken cancellationToken)
             => (await SearchByQueryParameterAsync<Endpoint>(queryParameter, 1, cancellationToken)).FirstOrDefault();
 
+        /// <inheritdoc/>
         public async Task<IEnumerable<Observation>> RetrieveObservationsAsync(Identifier identifier, CancellationToken cancellationToken = default)
             => await SearchByIdentifierMultipleAsync<Observation>(identifier, cancellationToken);
 
@@ -123,8 +124,6 @@ namespace Microsoft.Health.DicomCast.Core.Features.Fhir
                     throw new MultipleMatchingResourcesException(typeof(TResource).Name);
                 }
 
-                // There was only one match but because the server could return empty continuation token
-                // with more results, we need to follow the links to make sure there are no additional matching resources.
                 results.AddRange(bundle.Entry.Select(x => (TResource)x.Resource));
 
                 if (bundle.NextLink != null)

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Fhir/FhirService.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Fhir/FhirService.cs
@@ -39,20 +39,20 @@ namespace Microsoft.Health.DicomCast.Core.Features.Fhir
         }
 
         /// <inheritdoc/>
-        public async Task<Patient> RetrievePatientAsync(Identifier identifier, CancellationToken cancellationToken)
-            => await SearchByIdentifierAsync<Patient>(identifier, cancellationToken);
+        public Task<Patient> RetrievePatientAsync(Identifier identifier, CancellationToken cancellationToken)
+            => SearchByIdentifierAsync<Patient>(identifier, cancellationToken);
 
         /// <inheritdoc/>
-        public async Task<ImagingStudy> RetrieveImagingStudyAsync(Identifier identifier, CancellationToken cancellationToken)
-            => await SearchByIdentifierAsync<ImagingStudy>(identifier, cancellationToken);
+        public Task<ImagingStudy> RetrieveImagingStudyAsync(Identifier identifier, CancellationToken cancellationToken)
+            => SearchByIdentifierAsync<ImagingStudy>(identifier, cancellationToken);
 
         /// <inheritdoc/>
         public async Task<Endpoint> RetrieveEndpointAsync(string queryParameter, CancellationToken cancellationToken)
             => (await SearchByQueryParameterAsync<Endpoint>(queryParameter, 1, cancellationToken)).FirstOrDefault();
 
         /// <inheritdoc/>
-        public async Task<IEnumerable<Observation>> RetrieveObservationsAsync(Identifier identifier, CancellationToken cancellationToken = default)
-            => await SearchByIdentifierMultipleAsync<Observation>(identifier, cancellationToken);
+        public Task<IEnumerable<Observation>> RetrieveObservationsAsync(Identifier identifier, CancellationToken cancellationToken)
+            => SearchByIdentifierMultipleAsync<Observation>(identifier, cancellationToken);
 
         /// <inheritdoc/>
         public async Task CheckFhirServiceCapability(CancellationToken cancellationToken)
@@ -86,15 +86,15 @@ namespace Microsoft.Health.DicomCast.Core.Features.Fhir
             return (await SearchByQueryParameterAsync<TResource>(identifier.ToSearchQueryParameter(), 1, cancellationToken)).FirstOrDefault();
         }
 
-        private async Task<List<TResource>> SearchByIdentifierMultipleAsync<TResource>(Identifier identifier, CancellationToken cancellationToken)
+        private Task<IEnumerable<TResource>> SearchByIdentifierMultipleAsync<TResource>(Identifier identifier, CancellationToken cancellationToken)
             where TResource : Resource, new()
         {
             EnsureArg.IsNotNull(identifier, nameof(identifier));
 
-            return await SearchByQueryParameterAsync<TResource>(identifier.ToSearchQueryParameter(), null, cancellationToken);
+            return SearchByQueryParameterAsync<TResource>(identifier.ToSearchQueryParameter(), null, cancellationToken);
         }
 
-        private async Task<List<TResource>> SearchByQueryParameterAsync<TResource>(string queryParameter, int? maxCount, CancellationToken cancellationToken)
+        private async Task<IEnumerable<TResource>> SearchByQueryParameterAsync<TResource>(string queryParameter, int? maxCount, CancellationToken cancellationToken)
             where TResource : Resource, new()
         {
             EnsureArg.IsNotNullOrEmpty(queryParameter, nameof(queryParameter));

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Fhir/IFhirService.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Fhir/IFhirService.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Hl7.Fhir.Model;
@@ -38,6 +39,8 @@ namespace Microsoft.Health.DicomCast.Core.Features.Fhir
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A task representing the retrieving operation.</returns>
         Task<Endpoint> RetrieveEndpointAsync(string queryParameter, CancellationToken cancellationToken = default);
+
+        Task<IEnumerable<Observation>> RetrieveObservationsAsync(Identifier identifier, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Validates that FHIR server is right version and supports transactions.

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Fhir/IFhirService.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Fhir/IFhirService.cs
@@ -40,6 +40,12 @@ namespace Microsoft.Health.DicomCast.Core.Features.Fhir
         /// <returns>A task representing the retrieving operation.</returns>
         Task<Endpoint> RetrieveEndpointAsync(string queryParameter, CancellationToken cancellationToken = default);
 
+        /// <summary>
+        /// Asynchronously retrieves multiple <see cref="Observation"/> resources from FHIR server matching the <paramref name="identifier"/>.
+        /// </summary>
+        /// <param name="identifier">The identifier of the study.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A task representing the retrieving operation.</returns>
         Task<IEnumerable<Observation>> RetrieveObservationsAsync(Identifier identifier, CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Fhir/IdentifierUtility.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Fhir/IdentifierUtility.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Fhir
     /// <summary>
     /// Utility for creating an identifier for <see cref="ImagingStudy"/>.
     /// </summary>
-    public static class ImagingStudyIdentifierUtility
+    public static class IdentifierUtility
     {
         private const string DicomIdentifierSystem = "urn:dicom:uid";
 

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/ChangeFeedProcessor.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/ChangeFeedProcessor.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker
                         if (!(changeFeedEntry.Action == ChangeFeedAction.Create && changeFeedEntry.State == ChangeFeedState.Deleted))
                         {
                             await _fhirTransactionPipeline.ProcessAsync(changeFeedEntry, cancellationToken);
-                            _logger.LogInformation("Successfully process DICOM event with SequenceID: {sequenceId}", changeFeedEntry.Sequence);
+                            _logger.LogInformation("Successfully processed DICOM event with SequenceID: {sequenceId}", changeFeedEntry.Sequence);
                         }
                         else
                         {

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/ChangeFeedProcessor.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/ChangeFeedProcessor.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker
                         if (!(changeFeedEntry.Action == ChangeFeedAction.Create && changeFeedEntry.State == ChangeFeedState.Deleted))
                         {
                             await _fhirTransactionPipeline.ProcessAsync(changeFeedEntry, cancellationToken);
-                            _logger.LogInformation("Succesfully process DICOM event with SequenceID: {sequenceId}", changeFeedEntry.Sequence);
+                            _logger.LogInformation("Successfully process DICOM event with SequenceID: {sequenceId}", changeFeedEntry.Sequence);
                         }
                         else
                         {

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/FhirTransactionPipeline.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/FhirTransactionPipeline.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
                 usedPropertyAccessors.Add((propertyAccessor, useCount));
             }
 
-            if (!bundle.Entry.Any())
+            if (bundle.Entry.Count == 0)
             {
                 // Nothing to update.
                 return;
@@ -97,7 +97,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
             Bundle responseBundle = await _fhirTransactionExecutor.ExecuteTransactionAsync(bundle, cancellationToken);
 
             // Process the response.
-            int processesResponseItems = 0;
+            int processedResponseItems = 0;
 
             foreach ((FhirTransactionRequestResponsePropertyAccessor accessor, int count) in
                 usedPropertyAccessors.Where(x => x.Count > 0))
@@ -105,11 +105,11 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
                 var responseEntries = new List<FhirTransactionResponseEntry>();
                 for (int j = 0; j < count; j++)
                 {
-                    FhirTransactionResponseEntry responseEntry = CreateResponseEntry(responseBundle.Entry[processesResponseItems + j]);
+                    FhirTransactionResponseEntry responseEntry = CreateResponseEntry(responseBundle.Entry[processedResponseItems + j]);
                     responseEntries.Add(responseEntry);
                 }
 
-                processesResponseItems += count;
+                processedResponseItems += count;
                 accessor.ResponseEntrySetter(context.Response, responseEntries);
             }
 

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/FhirTransactionPipeline.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/FhirTransactionPipeline.cs
@@ -63,9 +63,9 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
 
             foreach (FhirTransactionRequestResponsePropertyAccessor propertyAccessor in _requestResponsePropertyAccessors)
             {
-                List<FhirTransactionRequestEntry> requestEntries = propertyAccessor.RequestEntryGetter(context.Request).ToList();
+                List<FhirTransactionRequestEntry> requestEntries = propertyAccessor.RequestEntryGetter(context.Request)?.ToList();
 
-                if (!requestEntries.Any())
+                if (requestEntries == null || !requestEntries.Any())
                 {
                     continue;
                 }
@@ -101,6 +101,11 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
             for (int i = 0; i < usedPropertyAccessors.Count; i++)
             {
                 int bundleCount = usedPropertyAccessors[i].Item2;
+
+                if (bundleCount == 0)
+                {
+                    continue;
+                }
                 var responseEntries = new List<FhirTransactionResponseEntry>();
                 for (int j = 0; j < bundleCount; j++)
                 {

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/FhirTransactionRequest.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/FhirTransactionRequest.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+
 namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
 {
     /// <summary>
@@ -18,5 +20,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
 
         /// <inheritdoc/>
         public FhirTransactionRequestEntry ImagingStudy { get; set; }
+
+        public IEnumerable<FhirTransactionRequestEntry> Observation { get; set; }
     }
 }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/FhirTransactionRequestResponsePropertyAccessor.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/FhirTransactionRequestResponsePropertyAccessor.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using EnsureThat;
 
 namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
@@ -15,8 +16,8 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
     {
         public FhirTransactionRequestResponsePropertyAccessor(
             string propertyName,
-            Func<FhirTransactionRequest, FhirTransactionRequestEntry> requestEntryGetter,
-            Action<FhirTransactionResponse, FhirTransactionResponseEntry> responseEntrySetter)
+            Func<FhirTransactionRequest, IEnumerable<FhirTransactionRequestEntry>> requestEntryGetter,
+            Action<FhirTransactionResponse, IEnumerable<FhirTransactionResponseEntry>> responseEntrySetter)
         {
             EnsureArg.IsNotNullOrWhiteSpace(propertyName, nameof(propertyName));
             EnsureArg.IsNotNull(requestEntryGetter, nameof(requestEntryGetter));
@@ -35,12 +36,12 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
         /// <summary>
         /// Gets the property getter for <see cref="FhirTransactionRequestEntry"/>.
         /// </summary>
-        public Func<FhirTransactionRequest, FhirTransactionRequestEntry> RequestEntryGetter { get; }
+        public Func<FhirTransactionRequest, IEnumerable<FhirTransactionRequestEntry>> RequestEntryGetter { get; }
 
         /// <summary>
         /// Gets the property setter for <see cref="FhirTransactionResponseEntry"/>.
         /// </summary>
-        public Action<FhirTransactionResponse, FhirTransactionResponseEntry> ResponseEntrySetter { get; }
+        public Action<FhirTransactionResponse, IEnumerable<FhirTransactionResponseEntry>> ResponseEntrySetter { get; }
 
         public static bool operator ==(FhirTransactionRequestResponsePropertyAccessor left, FhirTransactionRequestResponsePropertyAccessor right)
         {

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/FhirTransactionRequestResponsePropertyAccessors.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/FhirTransactionRequestResponsePropertyAccessors.cs
@@ -50,7 +50,6 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
             }
             else
             {
-                // TODO: Do these need to be cast to IEnumerable<FhirTransactionRequestEntry> or can expr tree handle it?
                 bodyExpression = Expression.NewArrayInit(typeof(FhirTransactionRequestEntry), propertyExpression);
             }
 

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/FhirTransactionResponse.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/FhirTransactionResponse.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+
 namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
 {
     /// <summary>
@@ -18,5 +20,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
 
         /// <inheritdoc/>
         public FhirTransactionResponseEntry ImagingStudy { get; set; }
+
+        public IEnumerable<FhirTransactionResponseEntry> Observation { get; set; }
     }
 }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/IFhirTransactionRequestResponse.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/IFhirTransactionRequestResponse.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+
 namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
 {
     /// <summary>
@@ -25,5 +27,10 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
         /// Gets or sets the imaging study.
         /// </summary>
         T ImagingStudy { get; set; }
+
+        /// <summary>
+        /// Gets or sets the observation
+        /// </summary>
+        IEnumerable<T> Observation { get; set; }
     }
 }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/ImagingStudy/IImagingStudyUpsertHandler.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/ImagingStudy/IImagingStudyUpsertHandler.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
     public interface IImagingStudyUpsertHandler
     {
         /// <summary>
-        /// Builds a request for creating or udpating the <see cref="ImagingStudy"/> resource..
+        /// Builds a request for creating or updating the <see cref="ImagingStudy"/> resource..
         /// </summary>
         /// <param name="context">The transaction context.</param>
         /// <param name="cancellationToken">The cancellation token.</param>

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyDeleteHandler.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyDeleteHandler.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
 
             ChangeFeedEntry changeFeedEntry = context.ChangeFeedEntry;
 
-            Identifier imagingStudyIdentifier = ImagingStudyIdentifierUtility.CreateIdentifier(changeFeedEntry.StudyInstanceUid);
+            Identifier imagingStudyIdentifier = IdentifierUtility.CreateIdentifier(changeFeedEntry.StudyInstanceUid);
             ImagingStudy imagingStudy = await _fhirService.RetrieveImagingStudyAsync(imagingStudyIdentifier, cancellationToken);
 
             // Returns null if imagingStudy does not exists for given studyInstanceUid

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyUpsertHandler.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/ImagingStudy/ImagingStudyUpsertHandler.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
 
             ChangeFeedEntry changeFeedEntry = context.ChangeFeedEntry;
 
-            Identifier imagingStudyIdentifier = ImagingStudyIdentifierUtility.CreateIdentifier(changeFeedEntry.StudyInstanceUid);
+            Identifier imagingStudyIdentifier = IdentifierUtility.CreateIdentifier(changeFeedEntry.StudyInstanceUid);
 
             ImagingStudy existingImagingStudy = await _fhirService.RetrieveImagingStudyAsync(imagingStudyIdentifier, cancellationToken);
             ImagingStudy imagingStudy = (ImagingStudy)existingImagingStudy?.DeepCopy();

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/IObservationDeleteHandler.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/IObservationDeleteHandler.cs
@@ -1,0 +1,16 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
+{
+    public interface IObservationDeleteHandler
+    {
+        Task<IEnumerable<FhirTransactionRequestEntry>> BuildAsync(FhirTransactionContext context, CancellationToken cancellationToken);
+    }
+}

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/IObservationUpsertHandler.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/IObservationUpsertHandler.cs
@@ -1,0 +1,16 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
+{
+    public interface IObservationUpsertHandler
+    {
+        Task<IEnumerable<FhirTransactionRequestEntry>> BuildAsync(FhirTransactionContext context, CancellationToken cancellationToken);
+    }
+}

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationConstants.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationConstants.cs
@@ -1,0 +1,102 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.ObjectModel;
+using Dicom.StructuredReport;
+
+namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
+{
+    /// <summary>
+    /// Dicom structured report codes used by FHIR Observation profiles
+    /// </summary>
+    public static class ObservationConstants
+    {
+        // https://www.hl7.org/fhir/terminologies-systems.html
+        public const string SctSystem = "http://snomed.info/sct";
+        public const string DcmSystem = "http://dicom.nema.org/resources/ontology/DCM";
+
+        public const string Dcm = "DCM";
+        public const string Sct = "Sct";
+        public const string Ln = "LN";
+
+        //------------------------------------------------------------
+        // Report codes
+        // - When you encounter these codes in a structured report, it means to create a new "Does Summary" Observation
+        //------------------------------------------------------------
+        public static readonly DicomCodeItem RadiopharmaceuticalRadiationDoseReport = new("113500", Dcm, "Radiopharmaceutical Radiation Dose Report");
+        public static readonly DicomCodeItem XRayRadiationDoseReport = new("113701", Dcm, "X-Ray Radiation Dose Report");
+
+
+        //------------------------------------------------------------
+        // Irradiation Event Codes
+        // - When you encounter these code in a structured report, it means to create a new "Irradiation Event" Observation
+        //------------------------------------------------------------
+        public static readonly DicomCodeItem IrradiationEventXRayData = new("113706", Dcm, "Irradiation Event X-Ray Data");
+        public static readonly DicomCodeItem CtAcquisition = new("113819", Dcm, "CT Acquisition");
+        public static readonly DicomCodeItem RadiopharmaceuticalAdministration = new("113502", Dcm, "Radiopharmaceutical Administration");
+
+
+        //------------------------------------------------------------
+        // Dicom Codes (attribute)
+        // - These are report values which map to non component observation attributes.
+        //------------------------------------------------------------
+        public static readonly DicomCodeItem IrradiationAuthorizingPerson = new("113850", Dcm, "Irradiation Authorizing");
+        public static readonly DicomCodeItem PregnancyObservation = new("364320009", Sct, "Pregnancy observable");
+        public static readonly DicomCodeItem IndicationObservation = new("18785-6", Ln, "Indications for Procedure");
+        public static readonly DicomCodeItem IrradiatingDevice = new("113859", Dcm, "Irradiating Device");
+
+        public static readonly DicomCodeItem IrradiationEventUid = new("113769", Dcm, "Irradiation Event UID");
+        public static readonly DicomCodeItem StudyInstanceUid = new("110180", Dcm, "Study Instance UID");
+        public static readonly DicomCodeItem AccessionNumber = new("121022", Dcm, "Accession Number");
+        public static readonly DicomCodeItem StartOfXrayIrradiation = new("113809", Dcm, "Start of X-Ray Irradiation”)");
+
+        //------------------------------------------------------------
+        // Dicom codes (component)
+        // - These are report values which map to Observation.component values
+        //------------------------------------------------------------
+        // Study
+        public static readonly DicomCodeItem DoseRpTotal = new("113725", Dcm, "Dose (RP) Total");
+        public static readonly DicomCodeItem EntranceExposureAtRp = new("111636", Dcm, "Entrance Exposure at RP");
+        public static readonly DicomCodeItem AccumulatedAverageGlandularDose = new("111637", Dcm, "Accumulated Average Glandular Dose");
+        public static readonly DicomCodeItem DoseAreaProductTotal = new("113722", Dcm, "Dose Area Product Total");
+        public static readonly DicomCodeItem FluoroDoseAreaProductTotal = new("113726", Dcm, "Fluoro Dose Area Product Total");
+        public static readonly DicomCodeItem AcquisitionDoseAreaProductTotal = new("113727", Dcm, "Acquisition Dose Area Product Total");
+        public static readonly DicomCodeItem TotalFluoroTime = new("113730", Dcm, "Total Fluoro Time");
+        public static readonly DicomCodeItem TotalNumberOfRadiographicFrames = new("113731", Dcm, "Total Number of Radiographic Frames");
+        public static readonly DicomCodeItem AdministeredActivity = new("113507", Dcm, "Administered activity");
+        public static readonly DicomCodeItem CtDoseLengthProductTotal = new("113813", Dcm, "CT Dose Length Product Total");
+        public static readonly DicomCodeItem TotalNumberOfIrradiationEvents = new("113812", Dcm, "");
+        public static readonly DicomCodeItem RadiopharmaceuticalAgent = new("349358000", Sct, "Radiopharmaceutical agent");
+        public static readonly DicomCodeItem Radionuclide = new("89457008", Sct, "Radionuclide");
+        public static readonly DicomCodeItem RadiopharmaceuticalVolume = new("123005", Dcm, "Radiopharmaceutical Volume");
+        public static readonly DicomCodeItem RouteOfAdministration = new("410675002", Sct, "Route of administration");
+
+        // (Ir)radiation Event
+        // uses MeanCtdIvol as well
+        public static readonly DicomCodeItem MeanCtdIvol = new("113830", Dcm, "Mean CTDIvol");
+        public static readonly DicomCodeItem Dlp = new("113838", Dcm, "DLP");
+        public static readonly DicomCodeItem TargetRegion = new("123014", Dcm, "Target Region");
+        public static readonly DicomCodeItem CtdIwPhantomType = new("113835", Dcm, "CTDIw Phantom Type");
+
+        /// <summary>
+        /// DicomStructuredReport codes which mean the start of a Dose Summary
+        /// </summary>
+        public static readonly Collection<DicomCodeItem> DoseSummaryReportCodes = new()
+        {
+            RadiopharmaceuticalRadiationDoseReport,
+            XRayRadiationDoseReport,
+        };
+
+        /// <summary>
+        /// DicomStructuredReport codes which mean the start of an Irradiation Event
+        /// </summary>
+        public static readonly Collection<DicomCodeItem> IrradiationEventCodes = new()
+        {
+            IrradiationEventXRayData,
+            CtAcquisition,
+            RadiopharmaceuticalAdministration
+        };
+    }
+}

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationConstants.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationConstants.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using Dicom.StructuredReport;
 using Hl7.Fhir.Model;
 
@@ -84,17 +84,13 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
         public static readonly CodeableConcept AccessionCodeableConcept = new CodeableConcept("http://terminology.hl7.org/CodeSystem/v2-0203", "ACSN");
         public static readonly CodeableConcept IrradiationEventCodeableConcept = new CodeableConcept("http://dicom.nema.org/resources/ontology/DCM", "113852", "Irradiation Event");
 
-        public static readonly HashSet<DicomCodeItem> IrradiationEvents = new()
-        {
+        public static readonly ImmutableHashSet<DicomCodeItem> IrradiationEvents = ImmutableHashSet.Create(
             IrradiationEventXRayData,
             CtAcquisition,
-            RadiopharmaceuticalAdministration,
-        };
+            RadiopharmaceuticalAdministration);
 
-        public static readonly HashSet<DicomCodeItem> DoseSummaryReportCodes = new()
-        {
+        public static readonly ImmutableHashSet<DicomCodeItem> DoseSummaryReportCodes = ImmutableHashSet.Create(
             RadiopharmaceuticalRadiationDoseReport,
-            XRayRadiationDoseReport,
-        };
+            XRayRadiationDoseReport);
     }
 }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationConstants.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationConstants.cs
@@ -3,8 +3,9 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using Dicom.StructuredReport;
+using Hl7.Fhir.Model;
 
 namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
 {
@@ -28,7 +29,6 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
         public static readonly DicomCodeItem RadiopharmaceuticalRadiationDoseReport = new("113500", Dcm, "Radiopharmaceutical Radiation Dose Report");
         public static readonly DicomCodeItem XRayRadiationDoseReport = new("113701", Dcm, "X-Ray Radiation Dose Report");
 
-
         //------------------------------------------------------------
         // Irradiation Event Codes
         // - When you encounter these code in a structured report, it means to create a new "Irradiation Event" Observation
@@ -36,7 +36,6 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
         public static readonly DicomCodeItem IrradiationEventXRayData = new("113706", Dcm, "Irradiation Event X-Ray Data");
         public static readonly DicomCodeItem CtAcquisition = new("113819", Dcm, "CT Acquisition");
         public static readonly DicomCodeItem RadiopharmaceuticalAdministration = new("113502", Dcm, "Radiopharmaceutical Administration");
-
 
         //------------------------------------------------------------
         // Dicom Codes (attribute)
@@ -80,23 +79,22 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
         public static readonly DicomCodeItem TargetRegion = new("123014", Dcm, "Target Region");
         public static readonly DicomCodeItem CtdIwPhantomType = new("113835", Dcm, "CTDIw Phantom Type");
 
-        /// <summary>
-        /// DicomStructuredReport codes which mean the start of a Dose Summary
-        /// </summary>
-        public static readonly Collection<DicomCodeItem> DoseSummaryReportCodes = new()
-        {
-            RadiopharmaceuticalRadiationDoseReport,
-            XRayRadiationDoseReport,
-        };
+        // FHIR CodeableConcepts
+        public static readonly CodeableConcept RadiationExposureCodeableConcept = new CodeableConcept("http://loinc.org", "73569-6", "Radiation exposure and protection information");
+        public static readonly CodeableConcept AccessionCodeableConcept = new CodeableConcept("http://terminology.hl7.org/CodeSystem/v2-0203", "ACSN");
+        public static readonly CodeableConcept IrradiationEventCodeableConcept = new CodeableConcept("http://dicom.nema.org/resources/ontology/DCM", "113852", "Irradiation Event");
 
-        /// <summary>
-        /// DicomStructuredReport codes which mean the start of an Irradiation Event
-        /// </summary>
-        public static readonly Collection<DicomCodeItem> IrradiationEventCodes = new()
+        public static readonly HashSet<DicomCodeItem> IrradiationEvents = new()
         {
             IrradiationEventXRayData,
             CtAcquisition,
-            RadiopharmaceuticalAdministration
+            RadiopharmaceuticalAdministration,
+        };
+
+        public static readonly HashSet<DicomCodeItem> DoseSummaryReportCodes = new()
+        {
+            RadiopharmaceuticalRadiationDoseReport,
+            XRayRadiationDoseReport,
         };
     }
 }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationDeleteHandler.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationDeleteHandler.cs
@@ -29,11 +29,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
             EnsureArg.IsNotNull(context, nameof(context));
             EnsureArg.IsNotNull(context.ChangeFeedEntry, nameof(context.ChangeFeedEntry));
 
-            // operate on the pre-condition that their _should_ only be one DoseSummary per ImagingStudy.
-            // If multiple observations are found; just use the first one.
-            // TODO current codebase only supports single resource per FhirTransactionRequest. Will need to refactor to support multiple.
-            // TODO currently only supports deleting a single matched resource.
-            Identifier identifier = ImagingStudyIdentifierUtility.CreateIdentifier(context.ChangeFeedEntry.StudyInstanceUid);
+            Identifier identifier = IdentifierUtility.CreateIdentifier(context.ChangeFeedEntry.StudyInstanceUid);
             IEnumerable<Observation> matchingObservationsAsync = await _fhirService.RetrieveObservationsAsync(identifier, cancellationToken);
             var matchingObservations = matchingObservationsAsync.ToList();
 

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationDeleteHandler.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationDeleteHandler.cs
@@ -30,11 +30,10 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
             EnsureArg.IsNotNull(context.ChangeFeedEntry, nameof(context.ChangeFeedEntry));
 
             Identifier identifier = IdentifierUtility.CreateIdentifier(context.ChangeFeedEntry.StudyInstanceUid);
-            IEnumerable<Observation> matchingObservationsAsync = await _fhirService.RetrieveObservationsAsync(identifier, cancellationToken);
-            var matchingObservations = matchingObservationsAsync.ToList();
+            List<Observation> matchingObservations = (await _fhirService.RetrieveObservationsAsync(identifier, cancellationToken)).ToList();
 
             // terminate early if no observation found
-            if (!matchingObservations.Any())
+            if (matchingObservations.Count == 0)
             {
                 return null;
             }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationDeleteHandler.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationDeleteHandler.cs
@@ -1,0 +1,65 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Utility;
+using Microsoft.Health.DicomCast.Core.Extensions;
+using Microsoft.Health.DicomCast.Core.Features.Fhir;
+
+namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
+{
+    public class ObservationDeleteHandler : IObservationDeleteHandler
+    {
+        private readonly IFhirService _fhirService;
+
+        public ObservationDeleteHandler(IFhirService fhirService)
+        {
+            _fhirService = EnsureArg.IsNotNull(fhirService, nameof(fhirService));
+        }
+
+        public async Task<IEnumerable<FhirTransactionRequestEntry>> BuildAsync(FhirTransactionContext context, CancellationToken cancellationToken)
+        {
+            EnsureArg.IsNotNull(context, nameof(context));
+            EnsureArg.IsNotNull(context.ChangeFeedEntry, nameof(context.ChangeFeedEntry));
+
+            // operate on the pre-condition that their _should_ only be one DoseSummary per ImagingStudy.
+            // If multiple observations are found; just use the first one.
+            // TODO current codebase only supports single resource per FhirTransactionRequest. Will need to refactor to support multiple.
+            // TODO currently only supports deleting a single matched resource.
+            Identifier identifier = ImagingStudyIdentifierUtility.CreateIdentifier(context.ChangeFeedEntry.StudyInstanceUid);
+            IEnumerable<Observation> matchingObservationsAsync = await _fhirService.RetrieveObservationsAsync(identifier, cancellationToken);
+            var matchingObservations = matchingObservationsAsync.ToList();
+
+            // terminate early if no observation found
+            if (!matchingObservations.Any())
+            {
+                return null;
+            }
+
+            var requests = new List<FhirTransactionRequestEntry>();
+            foreach (Observation observation in matchingObservations)
+            {
+                Bundle.RequestComponent request = new Bundle.RequestComponent()
+                {
+                    Method = Bundle.HTTPVerb.DELETE,
+                    Url = $"{ResourceType.Observation.GetLiteral()}/{observation.Id}"
+                };
+
+                requests.Add(new FhirTransactionRequestEntry(
+                    FhirTransactionRequestMode.Delete,
+                    request,
+                    observation.ToServerResourceId(),
+                    observation));
+            }
+
+            return requests;
+        }
+    }
+}

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationParser.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationParser.cs
@@ -1,0 +1,327 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Dicom;
+using Dicom.StructuredReport;
+using EnsureThat;
+using Hl7.Fhir.Model;
+using Microsoft.Health.DicomCast.Core.Features.Fhir;
+
+namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
+{
+    public class ObservationParser
+    {
+        public const string SctSystem = "http://snomed.info/sct";
+        public const string DcmSystem = "http://dicom.nema.org/resources/ontology/DCM";
+
+        public const string Dcm = "DCM";
+        public const string Sct = "Sct";
+        public const string Ln = "LN";
+
+        private static readonly DicomCodeItem StudyInstanceUid = new("110180", Dcm, "Study Instance UID");
+        private static readonly DicomCodeItem AccessionNumber = new("121022", Dcm, "Accession Number");
+        private static readonly DicomCodeItem TargetRegion = new("123014", Dcm, "Target Region");
+
+        private readonly HashSet<DicomCodeItem> _irradiationEvents = new HashSet<DicomCodeItem>
+        {
+            ObservationConstants.IrradiationEventXRayData,
+            ObservationConstants.CtAcquisition,
+            ObservationConstants.RadiopharmaceuticalAdministration,
+        };
+
+        private readonly HashSet<DicomCodeItem> _doseSummaryReportCodes = new HashSet<DicomCodeItem>
+        {
+            ObservationConstants.RadiopharmaceuticalRadiationDoseReport,
+            ObservationConstants.XRayRadiationDoseReport,
+        };
+
+        public IEnumerable<Observation> Parse(DicomDataset dataset, ResourceReference patientReference, ResourceReference imagingStudyReference)
+        {
+            EnsureArg.IsNotNull(dataset, nameof(dataset));
+            EnsureArg.IsNotNull(patientReference, nameof(patientReference));
+            EnsureArg.IsNotNull(imagingStudyReference, nameof(imagingStudyReference));
+
+            var observations = new List<Observation>();
+            ParseDicomDataset(dataset, patientReference, imagingStudyReference, observations);
+
+            return observations;
+        }
+
+        private void ParseDicomDataset(DicomDataset dataset, ResourceReference patientReference, ResourceReference imagingStudyReference, List<Observation> observations)
+        {
+            var structuredReport = new DicomStructuredReport(dataset);
+
+            try
+            {
+
+                if (_irradiationEvents.Contains(structuredReport.Code))
+                {
+                    observations.Add(CreateIrradiationEvent(dataset, patientReference));
+                }
+
+                if (_doseSummaryReportCodes.Contains(structuredReport.Code))
+                {
+                    observations.Add(CreateDoseSummary(dataset, imagingStudyReference, patientReference));
+                }
+            }
+            catch (DicomDataException)
+            {
+                // Ignore, this occurs when the report has no content sequence and we attempt to access report.Code; i.e and empty report
+            }
+            catch (MissingMemberException)
+            {
+                // Occurs when a required attribute is unable to be extracted from a dataset.
+                // Ignore and move onto the next one.
+            }
+
+            // Recursively iterate through every child in the document checking for nested observations.
+            // Return the final aggregated list of observations.
+            foreach (DicomContentItem childItem in structuredReport.Children())
+            {
+                ParseDicomDataset(childItem.Dataset, patientReference, imagingStudyReference, observations);
+            }
+        }
+
+        private static Observation CreateDoseSummary(
+            DicomDataset dataset,
+            ResourceReference imagingStudyReference,
+            ResourceReference patientReference)
+        {
+            // Create the observation
+            var observation = new Observation
+            {
+                // Set the code.coding
+                Code = new CodeableConcept("http://loinc.org", "73569-6", "Radiation exposure and protection information"),
+                // Add Patient reference
+                Subject = patientReference
+            };
+            // Add ImagingStudy reference
+            observation.PartOf.Add(imagingStudyReference);
+
+            // Set identifiers
+            // Attempt to get the StudyInstanceUid from the report; if it is not there fallback to the Tag value in the dataset
+            var report = new DicomStructuredReport(dataset);
+            var studyInstanceUid = report.Get<string>(
+                StudyInstanceUid,
+                string.Empty);
+            if (string.IsNullOrEmpty(studyInstanceUid))
+            {
+                if (!dataset.TryGetSingleValue(DicomTag.StudyInstanceUID, out studyInstanceUid))
+                {
+                    throw new MissingMemberException($"Unable to {nameof(DicomTag.StudyInstanceUID)} from dose summary observation dataset");
+                }
+            }
+
+            Identifier studyInstanceIdentifier = ImagingStudyIdentifierUtility.CreateIdentifier(studyInstanceUid);
+            observation.Identifier.Add(studyInstanceIdentifier);
+
+            // Try to get accession number from report first then tag; ignore if it is not present it is not a required identifier.
+            var accessionNumber = report.Get<string>(AccessionNumber, "");
+            if (string.IsNullOrEmpty(accessionNumber))
+            {
+                dataset.TryGetSingleValue(DicomTag.AccessionNumber, out accessionNumber);
+            }
+
+            if (!string.IsNullOrEmpty(accessionNumber))
+            {
+                var identifier = new Identifier
+                {
+                    Value = accessionNumber,
+                    Type = new CodeableConcept("http://terminology.hl7.org/CodeSystem/v2-0203", "ACSN")
+                };
+                observation.Identifier.Add(identifier);
+            }
+
+            // Add all structured report information
+            ApplyDicomTransforms(observation, dataset, new Collection<DicomCodeItem>()
+            {
+                ObservationConstants.DoseRpTotal,
+                ObservationConstants.AccumulatedAverageGlandularDose,
+                ObservationConstants.DoseAreaProductTotal,
+                ObservationConstants.FluoroDoseAreaProductTotal,
+                ObservationConstants.AcquisitionDoseAreaProductTotal,
+                ObservationConstants.TotalFluoroTime,
+                ObservationConstants.TotalNumberOfRadiographicFrames,
+                ObservationConstants.AdministeredActivity,
+                ObservationConstants.CtDoseLengthProductTotal,
+                ObservationConstants.TotalNumberOfIrradiationEvents,
+                ObservationConstants.MeanCtdIvol,
+                ObservationConstants.RadiopharmaceuticalAgent,
+                ObservationConstants.RadiopharmaceuticalVolume,
+                ObservationConstants.Radionuclide,
+                ObservationConstants.RouteOfAdministration,
+            });
+
+            return observation;
+        }
+
+        private static Observation CreateIrradiationEvent(DicomDataset dataset, ResourceReference patientRef)
+        {
+            var report = new DicomStructuredReport(dataset);
+            // create the observation
+            var observation = new Observation
+            {
+                Code = new CodeableConcept("http://dicom.nema.org/resources/ontology/DCM", "113852", "Irradiation Event"),
+                Subject = patientRef
+            };
+
+            // try to extract the event UID
+            DicomUID irradiationEventUidValue = report.Get<DicomUID>(ObservationConstants.IrradiationEventUid, null);
+            if (irradiationEventUidValue == null)
+            {
+                throw new MissingMemberException($"unable to extract {nameof(ObservationConstants.IrradiationEventUid)} from dataset");
+            }
+
+            var identifier = new Identifier(irradiationEventUidValue.Name, irradiationEventUidValue.UID);
+            observation.Identifier.Add(identifier);
+
+            DicomCodeItem bodySite = report.Get<DicomCodeItem>(TargetRegion, null);
+            if (bodySite != null)
+            {
+                observation.BodySite = new CodeableConcept(
+                    GetSystem(bodySite.Scheme),
+                    bodySite.Value,
+                    bodySite.Meaning);
+            }
+
+            // Extract the necessary information
+            ApplyDicomTransforms(observation, report.Dataset, new List<DicomCodeItem>()
+            {
+                ObservationConstants.MeanCtdIvol,
+                ObservationConstants.Dlp,
+                ObservationConstants.CtdIwPhantomType
+            });
+
+            return observation;
+        }
+
+        private static void ApplyDicomTransforms(Observation observation,
+            DicomDataset dataset,
+            IEnumerable<DicomCodeItem> reportCodesToParse)
+        {
+            var report = new DicomStructuredReport(dataset);
+            foreach (DicomCodeItem item in reportCodesToParse)
+            {
+                if (DicomComponentMutators.TryGetValue(item,
+                    out Action<Observation, DicomStructuredReport, DicomCodeItem> mutator))
+                {
+                    mutator(observation, report, item);
+                }
+            }
+
+            foreach (DicomContentItem dicomContentItem in report.Children())
+            {
+                ApplyDicomTransforms(observation, dicomContentItem.Dataset, reportCodesToParse);
+            }
+        }
+
+        /// <summary>
+        /// Lookup map of DicomCodeItem to Fhir Observation mutator
+        /// </summary>
+        private static readonly Dictionary<DicomCodeItem, Action<Observation, DicomStructuredReport, DicomCodeItem>> DicomComponentMutators = new()
+        {
+            [ObservationConstants.EntranceExposureAtRp] = AddComponentForDicomMeasuredValue,
+            [ObservationConstants.DoseRpTotal] = AddComponentForDicomMeasuredValue,
+            [ObservationConstants.AccumulatedAverageGlandularDose] = AddComponentForDicomMeasuredValue,
+            [ObservationConstants.DoseAreaProductTotal] = AddComponentForDicomMeasuredValue,
+            [ObservationConstants.FluoroDoseAreaProductTotal] = AddComponentForDicomMeasuredValue,
+            [ObservationConstants.AcquisitionDoseAreaProductTotal] = AddComponentForDicomMeasuredValue,
+            [ObservationConstants.TotalFluoroTime] = AddComponentForDicomMeasuredValue,
+            [ObservationConstants.TotalNumberOfRadiographicFrames] = AddComponentForDicomIntegerValue,
+            [ObservationConstants.AdministeredActivity] = AddComponentForDicomMeasuredValue,
+            [ObservationConstants.CtDoseLengthProductTotal] = AddComponentForDicomMeasuredValue,
+            [ObservationConstants.TotalNumberOfIrradiationEvents] = AddComponentForDicomIntegerValue,
+            [ObservationConstants.MeanCtdIvol] = AddComponentForDicomMeasuredValue,
+            [ObservationConstants.RadiopharmaceuticalAgent] = AddComponentForDicomTextValue,
+            [ObservationConstants.RadiopharmaceuticalVolume] = AddComponentForDicomMeasuredValue,
+            [ObservationConstants.Radionuclide] = AddComponentForDicomTextValue,
+            [ObservationConstants.RouteOfAdministration] = AddComponentForDicomCodeValue,
+            [ObservationConstants.Dlp] = AddComponentForDicomMeasuredValue,
+            [ObservationConstants.CtdIwPhantomType] = AddComponentForDicomCodeValue,
+        };
+
+        private static void AddComponentForDicomMeasuredValue(Observation observation,
+            DicomStructuredReport report,
+            DicomCodeItem codeItem)
+        {
+            var system = GetSystem(codeItem.Scheme);
+            var component = new Observation.ComponentComponent
+            {
+                Code = new CodeableConcept(system, codeItem.Value, codeItem.Meaning),
+            };
+            DicomMeasuredValue measuredValue = report.Get<DicomMeasuredValue>(codeItem, null);
+            if (measuredValue != null)
+            {
+                component.Value = new Quantity(measuredValue.Value, measuredValue.Code.Value);
+                observation.Component.Add(component);
+            }
+        }
+
+        private static void AddComponentForDicomTextValue(Observation observation,
+            DicomStructuredReport report,
+            DicomCodeItem codeItem)
+        {
+            var system = GetSystem(codeItem.Scheme);
+            var component = new Observation.ComponentComponent
+            {
+                Code = new CodeableConcept(system, codeItem.Value, codeItem.Meaning),
+            };
+            var value = report.Get<string>(codeItem, "");
+            if (!string.IsNullOrEmpty(value))
+            {
+                component.Value = new FhirString(value);
+                observation.Component.Add(component);
+            }
+        }
+
+
+        private static void AddComponentForDicomCodeValue(Observation observation,
+            DicomStructuredReport report,
+            DicomCodeItem codeItem)
+        {
+            var system = GetSystem(codeItem.Scheme);
+            var component = new Observation.ComponentComponent
+            {
+                Code = new CodeableConcept(system, codeItem.Value, codeItem.Meaning),
+            };
+            var value = report.Get<DicomCodeItem>(codeItem, null);
+            if (value != null)
+            {
+                component.Value = new CodeableConcept(system, value.Value, value.Meaning);
+                observation.Component.Add(component);
+            }
+        }
+
+        private static void AddComponentForDicomIntegerValue(Observation observation,
+            DicomStructuredReport report,
+            DicomCodeItem codeItem)
+        {
+            var system = GetSystem(codeItem.Scheme);
+            var component = new Observation.ComponentComponent
+            {
+                Code = new CodeableConcept(system, codeItem.Value, codeItem.Meaning),
+            };
+            var value = report.Get<int>(codeItem, 0);
+            if (value != 0)
+            {
+                component.Value = new Integer(value);
+                observation.Component.Add(component);
+            }
+        }
+
+        private static string GetSystem(string scheme)
+        {
+            return scheme switch
+            {
+                Dcm => DcmSystem,
+                Sct => SctSystem,
+                _ => scheme
+            };
+        }
+    }
+}

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationParser.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationParser.cs
@@ -58,7 +58,6 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
 
             try
             {
-
                 if (_irradiationEvents.Contains(structuredReport.Code))
                 {
                     observations.Add(CreateIrradiationEvent(dataset, patientReference));

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationParser.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationParser.cs
@@ -97,7 +97,8 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
                 // Set the code.coding
                 Code = new CodeableConcept("http://loinc.org", "73569-6", "Radiation exposure and protection information"),
                 // Add Patient reference
-                Subject = patientReference
+                Subject = patientReference,
+                Status = ObservationStatus.Preliminary,
             };
             // Add ImagingStudy reference
             observation.PartOf.Add(imagingStudyReference);
@@ -166,7 +167,8 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
             var observation = new Observation
             {
                 Code = new CodeableConcept("http://dicom.nema.org/resources/ontology/DCM", "113852", "Irradiation Event"),
-                Subject = patientRef
+                Subject = patientRef,
+                Status = ObservationStatus.Preliminary,
             };
 
             // try to extract the event UID

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationParser.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationParser.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
 {
     public class ObservationParser
     {
-        public IEnumerable<Observation> Parse(DicomDataset dataset, ResourceReference patientReference, ResourceReference imagingStudyReference, Identifier identifier)
+        public IReadOnlyCollection<Observation> Parse(DicomDataset dataset, ResourceReference patientReference, ResourceReference imagingStudyReference, Identifier identifier)
         {
             EnsureArg.IsNotNull(dataset, nameof(dataset));
             EnsureArg.IsNotNull(patientReference, nameof(patientReference));

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationPipelineStep.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationPipelineStep.cs
@@ -1,0 +1,58 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using Microsoft.Health.Dicom.Client.Models;
+
+namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
+{
+    public class ObservationPipelineStep : IFhirTransactionPipelineStep
+    {
+        private readonly IObservationDeleteHandler _observationDeleteHandler;
+        private readonly IObservationUpsertHandler _observationUpsertHandler;
+
+        public ObservationPipelineStep(IObservationDeleteHandler observationDeleteHandler, IObservationUpsertHandler observationUpsertHandler)
+        {
+            _observationDeleteHandler = EnsureArg.IsNotNull(observationDeleteHandler, nameof(observationDeleteHandler));
+            _observationUpsertHandler = EnsureArg.IsNotNull(observationUpsertHandler, nameof(observationUpsertHandler));
+        }
+
+        public async Task PrepareRequestAsync(FhirTransactionContext context, CancellationToken cancellationToken = default)
+        {
+            EnsureArg.IsNotNull(context, nameof(context));
+
+            ChangeFeedEntry changeFeedEntry = context.ChangeFeedEntry;
+            context.Request.Observation = changeFeedEntry.Action switch
+            {
+                ChangeFeedAction.Create => await _observationUpsertHandler.BuildAsync(context, cancellationToken),
+                ChangeFeedAction.Delete => await _observationDeleteHandler.BuildAsync(context, cancellationToken),
+                _ => throw new NotSupportedException(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        DicomCastCoreResource.NotSupportedChangeFeedAction,
+                        changeFeedEntry.Action))
+            };
+        }
+
+        public void ProcessResponse(FhirTransactionContext context)
+        {
+            EnsureArg.IsNotNull(context, nameof(context));
+            // if (context.Request?.Observation?.RequestMode != FhirTransactionRequestMode.Create)
+            // {
+            //     return;
+            // }
+            //
+            // HttpStatusCode statusCode = context.Response.Observation.Response.Annotation<HttpStatusCode>();
+            // if (statusCode == HttpStatusCode.OK)
+            // {
+            //     throw new ResourceConflictException();
+            // }
+        }
+    }
+}

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationUpsertHandler.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationUpsertHandler.cs
@@ -35,7 +35,9 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
             IResourceId imagingStudyId = context.Request.ImagingStudy.ResourceId;
             ChangeFeedEntry changeFeedEntry = context.ChangeFeedEntry;
 
-            IEnumerable<Observation> observations = _observationParser.Parse(changeFeedEntry.Metadata, patientId.ToResourceReference(), imagingStudyId.ToResourceReference());
+            Identifier identifier = IdentifierUtility.CreateIdentifier(changeFeedEntry.StudyInstanceUid);
+
+            IEnumerable<Observation> observations = _observationParser.Parse(changeFeedEntry.Metadata, patientId.ToResourceReference(), imagingStudyId.ToResourceReference(), identifier);
 
             if (!observations.Any())
             {

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationUpsertHandler.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationUpsertHandler.cs
@@ -37,9 +37,9 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
 
             Identifier identifier = IdentifierUtility.CreateIdentifier(changeFeedEntry.StudyInstanceUid);
 
-            IEnumerable<Observation> observations = _observationParser.Parse(changeFeedEntry.Metadata, patientId.ToResourceReference(), imagingStudyId.ToResourceReference(), identifier);
+            IReadOnlyCollection<Observation> observations = _observationParser.Parse(changeFeedEntry.Metadata, patientId.ToResourceReference(), imagingStudyId.ToResourceReference(), identifier);
 
-            if (!observations.Any())
+            if (observations.Count == 0)
             {
                 return Enumerable.Empty<FhirTransactionRequestEntry>();
             }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationUpsertHandler.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationUpsertHandler.cs
@@ -52,6 +52,8 @@ namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
                         cancellationToken)
                 : new List<Observation>();
 
+            // TODO: Figure out a way to match existing observations with newly created ones.
+
             List<FhirTransactionRequestEntry> fhirRequests = new List<FhirTransactionRequestEntry>();
             foreach (var observation in observations)
             {

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationUpsertHandler.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/FhirTransaction/Observation/ObservationUpsertHandler.cs
@@ -1,0 +1,70 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Utility;
+using Microsoft.Health.Dicom.Client.Models;
+using Microsoft.Health.DicomCast.Core.Features.Fhir;
+
+namespace Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction
+{
+    public class ObservationUpsertHandler : IObservationUpsertHandler
+    {
+        private readonly IFhirService _fhirService;
+        private readonly ObservationParser _observationParser;
+
+        public ObservationUpsertHandler(IFhirService fhirService, ObservationParser observationParser)
+        {
+            _fhirService = EnsureArg.IsNotNull(fhirService, nameof(fhirService));
+            _observationParser = EnsureArg.IsNotNull(observationParser, nameof(observationParser));
+        }
+
+        public async Task<IEnumerable<FhirTransactionRequestEntry>> BuildAsync(FhirTransactionContext context, CancellationToken cancellationToken)
+        {
+            EnsureArg.IsNotNull(context?.ChangeFeedEntry, nameof(context.ChangeFeedEntry));
+            EnsureArg.IsNotNull(context.Request, nameof(context.Request));
+
+            IResourceId patientId = context.Request.Patient.ResourceId;
+            IResourceId imagingStudyId = context.Request.ImagingStudy.ResourceId;
+            ChangeFeedEntry changeFeedEntry = context.ChangeFeedEntry;
+
+            IEnumerable<Observation> observations = _observationParser.Parse(changeFeedEntry.Metadata, patientId.ToResourceReference(), imagingStudyId.ToResourceReference());
+
+            if (!observations.Any())
+            {
+                return Enumerable.Empty<FhirTransactionRequestEntry>();
+            }
+
+            Identifier imagingStudyIdentifier = imagingStudyId.ToResourceReference().Identifier;
+            IEnumerable<Observation> existingDoseSummariesAsync = imagingStudyIdentifier != null
+                ? await _fhirService
+                    .RetrieveObservationsAsync(
+                        imagingStudyId.ToResourceReference().Identifier,
+                        cancellationToken)
+                : new List<Observation>();
+
+            List<FhirTransactionRequestEntry> fhirRequests = new List<FhirTransactionRequestEntry>();
+            foreach (var observation in observations)
+            {
+                fhirRequests.Add(new FhirTransactionRequestEntry(
+                    FhirTransactionRequestMode.Create,
+                    new Bundle.RequestComponent()
+                    {
+                        Method = Bundle.HTTPVerb.POST,
+                        Url = ResourceType.Observation.GetLiteral()
+                    },
+                    new ClientResourceId(),
+                    observation));
+            }
+
+            return fhirRequests;
+        }
+    }
+}

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Modules/FhirModule.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Modules/FhirModule.cs
@@ -67,6 +67,16 @@ namespace Microsoft.Health.DicomCast.Core.Modules
                 .Singleton()
                 .AsSelf()
                 .AsImplementedInterfaces();
+
+            services.Add<ObservationDeleteHandler>()
+                .Singleton()
+                .AsSelf()
+                .AsImplementedInterfaces();
+
+            services.Add<ObservationUpsertHandler>()
+                .Singleton()
+                .AsSelf()
+                .AsImplementedInterfaces();
         }
     }
 }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Modules/WorkerModule.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Modules/WorkerModule.cs
@@ -65,6 +65,8 @@ namespace Microsoft.Health.DicomCast.Core.Modules
                 .Singleton()
                 .AsSelf()
                 .AsImplementedInterfaces();
+
+            services.AddSingleton<ObservationParser>();
         }
 
         private static void RegisterPipeline(IServiceCollection services)
@@ -145,6 +147,11 @@ namespace Microsoft.Health.DicomCast.Core.Modules
                 .AsImplementedInterfaces();
 
             services.Add<ImagingStudyPipelineStep>()
+                .Singleton()
+                .AsSelf()
+                .AsImplementedInterfaces();
+
+            services.Add<ObservationPipelineStep>()
                 .Singleton()
                 .AsSelf()
                 .AsImplementedInterfaces();

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Hosting/appsettings.Development.json
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Hosting/appsettings.Development.json
@@ -25,5 +25,4 @@
     "DicomCastWorker": {
         "PollInterval": "00:00:05"
     }
-
 }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Hosting/appsettings.json
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Hosting/appsettings.json
@@ -34,7 +34,8 @@
     },
     "DicomCast": {
         "Features": {
-            "EnforceValidationOfTagValues": false
+            "EnforceValidationOfTagValues": false,
+            "GenerateObservations": true
         }
     },
     "RetryConfiguration": {

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.TableStorage/Registration/DicomCastTableRegistrationExtension.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.TableStorage/Registration/DicomCastTableRegistrationExtension.cs
@@ -17,7 +17,7 @@ using Microsoft.Health.Extensions.DependencyInjection;
 
 namespace Microsoft.Health.DicomCast.TableStorage
 {
-    public static class DiocmCastTableRegistrationExtension
+    public static class DicomCastTableRegistrationExtension
     {
         public const string TableStoreConfigurationSectionName = "TableStore";
 


### PR DESCRIPTION
## Description
This is a re-opening of the previous PR #763 which was abandoned. It extends that PR to allow multiple observations to be generated from a single study. 

It can currently find `dose summaries` and `irradiation events`. 

NOTE: There is a current edge case where if you re-process studies with the same structured reports, duplicate observations will be recorded.

## Related issues
Addresses [AB#86106](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/86106).

## Testing
Manual testing of mocked SR files, unit tests. 
