### PR TITLE
Enabling Test Impact Analysis for PR builds

### DIFF
--- a/build/ci-variables.yml
+++ b/build/ci-variables.yml
@@ -17,3 +17,4 @@ variables:
   dicomCastComposeLocation: 'converter/dicom-cast/build/docker/docker-compose.yaml'
   deleteDataOnStartup: 'false'
   skipNugetSecurityAnalysis: 'true' # NuGet config contains multiple feeds but meets exception criteria
+  runOnlyImpactedTests: 'false'

--- a/build/pr-variables.yml
+++ b/build/pr-variables.yml
@@ -14,3 +14,4 @@ variables:
   buildConfiguration: 'Release'
   deleteDataOnStartup: 'true'
   skipNugetSecurityAnalysis: 'true' # NuGet config contains multiple feeds but meets exception criteria
+  runOnlyImpactedTests: 'true'

--- a/build/run-e2e-tests.yml
+++ b/build/run-e2e-tests.yml
@@ -44,3 +44,4 @@ jobs:
     inputs:
       testAssemblyVer2: '**\*Tests.E2E*.dll'
       searchFolder: '$(System.ArtifactsDirectory)'
+      runOnlyImpactedTests: '$(runOnlyImpactedTests)'

--- a/build/run-integration-tests.yml
+++ b/build/run-integration-tests.yml
@@ -36,4 +36,5 @@ jobs:
       testAssemblyVer2: '**\*Tests.Integration.dll'
       searchFolder: '$(System.ArtifactsDirectory)'
       runInParallel: true
+      runOnlyImpactedTests: '$(runOnlyImpactedTests)'
 


### PR DESCRIPTION
## Description
This PR enables TIA for PR builds **only** to run only tests that are affected by the code changes in the PR. The feature has solid fallback behavior such as defaulting to running all tests if it's not able to determine which tests are affected by a change.

"[Test Impact Analysis](https://docs.microsoft.com/en-us/azure/devops/pipelines/test/test-impact-analysis?view=azure-devops) performs incremental validation by automatic test selection. It will automatically select only the subset of tests required to validate the code being committed. For a given code commit entering the CI/CD pipeline, TIA will select and run only the relevant tests required to validate that commit."

## Related issues
[AB#83141](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/83141)

## Testing
PR pipeline run: you can see the behavior [here](https://microsofthealthoss.visualstudio.com/DicomServer/_build/results?buildId=15666&view=logs&j=2df0ed39-f730-5c6f-8da1-968a19311a63&t=03233812-5060-510b-ec4f-079ee82a3f9e&l=54) - since this PR updated only YAML, the tool was not able to decide which tests would be affected, so ran all tests.