### PR TITLE
Data partitions - Ensure feature cannot be disabled when data is partitioned

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Features/Partition/DataPartitionFeatureValidatorService.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Partition/DataPartitionFeatureValidatorService.cs
@@ -1,0 +1,60 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Dicom.Core.Configs;
+using Microsoft.Health.Dicom.Core.Exceptions;
+using Microsoft.Health.Dicom.Core.Features.Partition;
+
+namespace Microsoft.Health.Dicom.Api.Features.Partition
+{
+    /// <summary>
+    /// This hosted service performs the check at startup to ensure user cannot disable DataPartitions feature flag
+    /// if they already created partitioned data other than the default partition.
+    /// If a user created partitioned data other than the default partition, then an exception is thrown to block startup.
+    /// We will allow users to enable DataPartitions feature even if they have already created data,
+    /// it will be accessible by specifying Microsoft.Default partition name in the request.
+    /// </summary>
+    public class DataPartitionFeatureValidatorService : IHostedService
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly bool _isPartitionEnabled;
+
+        public DataPartitionFeatureValidatorService(
+            IServiceProvider serviceProvider,
+            IOptions<FeatureConfiguration> featureConfiguration)
+        {
+            _serviceProvider = serviceProvider;
+            EnsureArg.IsNotNull(featureConfiguration, nameof(featureConfiguration));
+            _isPartitionEnabled = featureConfiguration.Value.EnableDataPartitions;
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            if (!_isPartitionEnabled)
+            {
+                using (var scope = _serviceProvider.CreateScope())
+                {
+                    var partitionService = scope.ServiceProvider.GetRequiredService<IPartitionService>();
+
+                    var partitionEntries = await partitionService.GetPartitionsAsync(cancellationToken);
+
+                    if (partitionEntries.Entries.Count > 1)
+                    {
+                        throw new DataPartitionsFeatureCannotBeDisabledException();
+                    }
+                }
+            }
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/src/Microsoft.Health.Dicom.Api/Features/Partition/DataPartitionFeatureValidatorService.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Partition/DataPartitionFeatureValidatorService.cs
@@ -33,7 +33,8 @@ namespace Microsoft.Health.Dicom.Api.Features.Partition
             IOptions<FeatureConfiguration> featureConfiguration)
         {
             _serviceProvider = serviceProvider;
-            EnsureArg.IsNotNull(featureConfiguration, nameof(featureConfiguration));
+            EnsureArg.IsNotNull(featureConfiguration?.Value, nameof(featureConfiguration));
+
             _isPartitionEnabled = featureConfiguration.Value.EnableDataPartitions;
         }
 

--- a/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ using Microsoft.Health.Dicom.Api.Configs;
 using Microsoft.Health.Dicom.Api.Features.BackgroundServices;
 using Microsoft.Health.Dicom.Api.Features.Context;
 using Microsoft.Health.Dicom.Api.Features.Formatters;
+using Microsoft.Health.Dicom.Api.Features.Partition;
 using Microsoft.Health.Dicom.Api.Features.Routing;
 using Microsoft.Health.Dicom.Api.Features.Swagger;
 using Microsoft.Health.Dicom.Core.Extensions;
@@ -51,6 +52,18 @@ namespace Microsoft.AspNetCore.Builder
             EnsureArg.IsNotNull(serverBuilder, nameof(serverBuilder));
             serverBuilder.Services.AddScoped<DeletedInstanceCleanupWorker>();
             serverBuilder.Services.AddHostedService<DeletedInstanceCleanupBackgroundService>();
+            return serverBuilder;
+        }
+
+        /// <summary>
+        /// Add services for DICOM hosted services.
+        /// </summary>
+        /// <param name="serverBuilder">The DICOM server builder instance.</param>
+        /// <returns>The DICOM server builder instance.</returns>
+        public static IDicomServerBuilder AddHostedServices(this IDicomServerBuilder serverBuilder)
+        {
+            EnsureArg.IsNotNull(serverBuilder, nameof(serverBuilder));
+            serverBuilder.Services.AddHostedService<DataPartitionFeatureValidatorService>();
             return serverBuilder;
         }
 

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Partition/PartitionCacheTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Partition/PartitionCacheTests.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Dicom.Core.Configs;
-using Microsoft.Health.Dicom.Core.Features.ChangeFeed;
 using Microsoft.Health.Dicom.Core.Features.Partition;
 using NSubstitute;
 using Xunit;

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Health.Dicom.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Data partitions feature cannot be disabled when the service has existing data..
+        ///   Looks up a localized string similar to Data partitions feature cannot be disabled while existing data has already been partitioned..
         /// </summary>
         internal static string DataPartitionFeatureCannotBeDisabled {
             get {

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
@@ -97,6 +97,15 @@ namespace Microsoft.Health.Dicom.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Data partitions feature cannot be disabled when the service has existing data..
+        /// </summary>
+        internal static string DataPartitionFeatureCannotBeDisabled {
+            get {
+                return ResourceManager.GetString("DataPartitionFeatureCannotBeDisabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Specified PartitionName &apos;{0}&apos; does not exist..
         /// </summary>
         internal static string DataPartitionNotFound {

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
@@ -466,6 +466,6 @@ For details on valid range queries, please refer to Search Matching section in C
     <comment>{0} PartitionName value.</comment>
   </data>
   <data name="DataPartitionFeatureCannotBeDisabled" xml:space="preserve">
-    <value>Data partitions feature cannot be disabled while existing data has already been partitioned./value>
+    <value>Data partitions feature cannot be disabled while existing data has already been partitioned.</value>
   </data>
 </root>

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
@@ -465,4 +465,7 @@ For details on valid range queries, please refer to Search Matching section in C
     <value>Specified PartitionName '{0}' does not exist.</value>
     <comment>{0} PartitionName value.</comment>
   </data>
+  <data name="DataPartitionFeatureCannotBeDisabled" xml:space="preserve">
+    <value>Data partitions feature cannot be disabled when the service has existing data.</value>
+  </data>
 </root>

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
@@ -466,6 +466,6 @@ For details on valid range queries, please refer to Search Matching section in C
     <comment>{0} PartitionName value.</comment>
   </data>
   <data name="DataPartitionFeatureCannotBeDisabled" xml:space="preserve">
-    <value>Data partitions feature cannot be disabled when the service has existing data.</value>
+    <value>Data partitions feature cannot be disabled while existing data has already been partitioned./value>
   </data>
 </root>

--- a/src/Microsoft.Health.Dicom.Core/Exceptions/DataPartitionsFeatureCannotBeDisabledException.cs
+++ b/src/Microsoft.Health.Dicom.Core/Exceptions/DataPartitionsFeatureCannotBeDisabledException.cs
@@ -1,0 +1,20 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+
+namespace Microsoft.Health.Dicom.Core.Exceptions
+{
+    /// <summary>
+    /// Exception that is thrown when data partitions feature is disabled.
+    /// </summary>
+    public class DataPartitionsFeatureCannotBeDisabledException : BadRequestException
+    {
+        public DataPartitionsFeatureCannotBeDisabledException()
+            : base(string.Format(CultureInfo.InvariantCulture, DicomCoreResource.DataPartitionFeatureCannotBeDisabled))
+        {
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Core/Exceptions/DataPartitionsFeatureCannotBeDisabledException.cs
+++ b/src/Microsoft.Health.Dicom.Core/Exceptions/DataPartitionsFeatureCannotBeDisabledException.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Globalization;
 
 namespace Microsoft.Health.Dicom.Core.Exceptions
@@ -10,7 +11,7 @@ namespace Microsoft.Health.Dicom.Core.Exceptions
     /// <summary>
     /// Exception that is thrown when data partitions feature is disabled.
     /// </summary>
-    public class DataPartitionsFeatureCannotBeDisabledException : BadRequestException
+    public class DataPartitionsFeatureCannotBeDisabledException : InvalidOperationException
     {
         public DataPartitionsFeatureCannotBeDisabledException()
             : base(string.Format(CultureInfo.InvariantCulture, DicomCoreResource.DataPartitionFeatureCannotBeDisabled))

--- a/src/Microsoft.Health.Dicom.Core/Features/Partition/PartitionCache.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Partition/PartitionCache.cs
@@ -11,9 +11,8 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Dicom.Core.Configs;
-using Microsoft.Health.Dicom.Core.Features.Partition;
 
-namespace Microsoft.Health.Dicom.Core.Features.ChangeFeed
+namespace Microsoft.Health.Dicom.Core.Features.Partition
 {
     public class PartitionCache : IDisposable
     {

--- a/src/Microsoft.Health.Dicom.Core/Features/Partition/PartitionService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Partition/PartitionService.cs
@@ -8,10 +8,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Extensions.Logging;
-using Microsoft.Health.Dicom.Core.Features.Partition;
 using Microsoft.Health.Dicom.Core.Messages.Partition;
 
-namespace Microsoft.Health.Dicom.Core.Features.ChangeFeed
+namespace Microsoft.Health.Dicom.Core.Features.Partition
 {
     public class PartitionService : IPartitionService
     {

--- a/src/Microsoft.Health.Dicom.Core/Modules/ServiceModule.cs
+++ b/src/Microsoft.Health.Dicom.Core/Modules/ServiceModule.cs
@@ -13,6 +13,7 @@ using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 using Microsoft.Health.Dicom.Core.Features.HealthCheck;
 using Microsoft.Health.Dicom.Core.Features.Indexing;
 using Microsoft.Health.Dicom.Core.Features.Operations;
+using Microsoft.Health.Dicom.Core.Features.Partition;
 using Microsoft.Health.Dicom.Core.Features.Query;
 using Microsoft.Health.Dicom.Core.Features.Retrieve;
 using Microsoft.Health.Dicom.Core.Features.Store;

--- a/src/Microsoft.Health.Dicom.Web/Startup.cs
+++ b/src/Microsoft.Health.Dicom.Web/Startup.cs
@@ -38,7 +38,8 @@ namespace Microsoft.Health.Dicom.Web
                 .AddMetadataStorageDataStore(Configuration)
                 .AddSqlServer(Configuration)
                 .AddAzureFunctionsClient(Configuration)
-                .AddBackgroundWorkers();
+                .AddBackgroundWorkers()
+                .AddHostedServices();
 
             AddApplicationInsightsTelemetry(services);
         }

--- a/src/Microsoft.Health.Dicom.Web/appsettings.Development.json
+++ b/src/Microsoft.Health.Dicom.Web/appsettings.Development.json
@@ -1,7 +1,7 @@
 {
   "DicomServer": {
     "Features": {      
-      "EnableDataPartitions": true
+      "EnableDataPartitions": false
     }
   },
   "DicomFunctions": {


### PR DESCRIPTION
## Description
This PR includes changes to ensure user cannot disable DataPartitions feature flag if they already created partitioned data other than the default partition.

## Related issues
Addresses [[AB#85406](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/85406)].