### PR TITLE
Fix broken E2E test due to data partitions validation

### DIFF
--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Common/InProcTestDicomWebServer.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Common/InProcTestDicomWebServer.cs
@@ -46,6 +46,15 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E
                 { "DicomServer:Features:EnableDataPartitions", enableDataPartitions.ToString() },
             };
 
+            var dbName = enableDataPartitions ? "DicomWithPartitions" : "Dicom";
+
+            // Overriding sqlserver connection string to provide different DB for data partition test
+            // This will ensure there is no multiple partitions when the flag is off
+            var sqlSettings = new Dictionary<string, string>
+            {
+                { "SqlServer:ConnectionString", $"server=(local);Initial Catalog={dbName};Integrated Security=true" },
+            };
+
             IWebHostBuilder builder = WebHost.CreateDefaultBuilder()
                 .UseContentRoot(contentRoot)
                 .UseStartup(startupType)
@@ -53,6 +62,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E
                 {
                     config.AddInMemoryCollection(authSettings);
                     config.AddInMemoryCollection(featureSettings);
+                    config.AddInMemoryCollection(sqlSettings);
                     var existingConfig = config.Build();
                     config.AddDevelopmentAuthEnvironmentIfConfigured(existingConfig, "DicomServer");
                     if (string.Equals(existingConfig["DicomServer:Security:Enabled"], bool.TrueString, StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
## Description
Currently E2E tests are failing locally due to data partition tests using same DB. This PR uses a different DB for data partition enabled tests

## Related issues
Addresses [[AB#86511](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/86511)].

## Testing
Ran local tests to ensure tests are passed
