### PR TITLE
Add Symbol Indexing and Fix Test Package Publish

### DIFF
--- a/build/package-nugets.yml
+++ b/build/package-nugets.yml
@@ -5,7 +5,7 @@ steps:
     inputs:
       command: pack
       configuration: '$(buildConfiguration)'
-      packagesToPack: '**/*.csproj;!**/*.UnitTests.csproj'
+      packagesToPack: '**/*.csproj;!**/*Test*.csproj'
       packDirectory: '$(build.artifactStagingDirectory)/nupkgs'
       versioningScheme: byEnvVar
       versionEnvVar: 'nuGetVersion'
@@ -17,3 +17,11 @@ steps:
       pathtoPublish: '$(build.artifactStagingDirectory)/nupkgs'
       artifactName: 'nuget'
       publishLocation: 'container'
+
+  - task: PublishSymbols@2
+    displayName: 'Publish symbols'
+    inputs:
+      searchFolder: '$(build.artifactStagingDirectory)'
+      searchPattern: '**\*.pdb'
+      symbolServerType: 'TeamServices'
+      indexSources: false # done in build step

--- a/build/package-nugets.yml
+++ b/build/package-nugets.yml
@@ -5,7 +5,7 @@ steps:
     inputs:
       command: pack
       configuration: '$(buildConfiguration)'
-      packagesToPack: '**/*.csproj;!**/*Test*.csproj'
+      packagesToPack: '**/*.csproj;!**/*.UnitTests.csproj'
       packDirectory: '$(build.artifactStagingDirectory)/nupkgs'
       versioningScheme: byEnvVar
       versionEnvVar: 'nuGetVersion'
@@ -21,7 +21,7 @@ steps:
   - task: PublishSymbols@2
     displayName: 'Publish symbols'
     inputs:
-      searchFolder: '$(build.artifactStagingDirectory)'
+      searchFolder: '$(build.sourcesDirectory)'
       searchPattern: '**\*.pdb'
       symbolServerType: 'TeamServices'
       indexSources: false # done in build step

--- a/src/Microsoft.Health.Dicom.Core/Features/Validation/ValidationErrorCode.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Validation/ValidationErrorCode.cs
@@ -10,16 +10,13 @@ namespace Microsoft.Health.Dicom.Core.Features.Validation
     /// <summary>
     /// Validation Error Code.
     /// </summary>
-    /// <remarks>Error Code is  4 letter number. 
-    /// First 2 letters indicate VR:
-    ///  00 - General error for all VR
-    ///  01 - Error for PN
-    /// Last 2 letters indicate specific errors for VR.
-    /// ErrorCode naming convention:
-    /// VR specific error code should start with VR name.
-    /// e.g: PatientNameGroupIsTooLong starts with PatientName.
+    /// <remarks>
+    /// Error Code is smallint/short ranging between [0, 32,767].
+    /// For convenience, codes are grouped together by VR where the first 1000 values are agnostic of VR.
+    /// By convention, each VR-specific error code should start with the VR name.
+    /// e.g. <see cref="PersonNameExceedMaxGroups"/> starts with PersonName.
     /// </remarks>
-    [SuppressMessage(category: "Design", checkId: "CA1028: Enum Storage should be Int32", Justification = "aule is stroed in SQL as SMALLINT")]
+    [SuppressMessage(category: "Design", checkId: "CA1028: Enum Storage should be Int32", Justification = "Value is stored in SQL as SMALLINT")]
     public enum ValidationErrorCode : short
     {
         /// <summary>
@@ -32,27 +29,27 @@ namespace Microsoft.Health.Dicom.Core.Features.Validation
         /// <summary>
         /// The dicom element has multiple values.
         /// </summary>
-        MultiValues = 0001,
+        MultiValues = 1,
 
         /// <summary>
         /// The length of dicom element value exceed max allowed.
         /// </summary>
-        ExceedMaxLength = 0002,
+        ExceedMaxLength = 2,
 
         /// <summary>
         /// The length of dicom element value is not expected.
         /// </summary>
-        UnexpectedLength = 0003,
+        UnexpectedLength = 3,
 
         /// <summary>
         /// The dicom element value has invalid characters.
         /// </summary>
-        InvalidCharacters = 0004,
+        InvalidCharacters = 4,
 
         /// <summary>
         /// The VR of dicom element is not expected.
         /// </summary>
-        UnexpectedVR = 0005,
+        UnexpectedVR = 5,
 
         // Person Name specific errors
 

--- a/src/Microsoft.Health.Dicom.Core/Features/Validation/ValidationErrorCode.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Validation/ValidationErrorCode.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Validation
         /// <summary>
         /// Implicit VR Transfer Syntax is not allowed.
         /// </summary>
-        ImplicitVRNotAllowed = 0011,
+        ImplicitVRNotAllowed = 6,
 
         // Person Name specific errors
 

--- a/src/Microsoft.Health.Dicom.Tests.Common/Microsoft.Health.Dicom.Tests.Common.csproj
+++ b/src/Microsoft.Health.Dicom.Tests.Common/Microsoft.Health.Dicom.Tests.Common.csproj
@@ -6,11 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="fo-dicom" Version="$(FoDicomVersion)" />
+    <PackageReference Include="fo-dicom.Json" Version="$(FoDicomVersion)" NoWarn="NU1701" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Health.Dicom.Tests.Common/Microsoft.Health.Dicom.Tests.Common.csproj
+++ b/src/Microsoft.Health.Dicom.Tests.Common/Microsoft.Health.Dicom.Tests.Common.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.assert" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
- Add symbol indexing for Dicom NuGet packages
- Fix `Microsoft.Health.Dicom.Tests.Common` dependencies
- Edit `ValidationErrorCode` XML and `ImplicitVRNotAllowed` value

## Related issues
[AB#78417](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/78417)

## Testing
Packed locally
