### PR TITLE
Publish Symbols in Windows Stage

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -36,19 +36,6 @@ steps:
       alertWarningLevel: 'High'
       failOnAlert: true
 
-  # Temp
-  - task: CopyFiles@2
-    displayName: 'copy symbols'
-    inputs:
-      sourceFolder: '$(build.sourcesDirectory)'
-      contents: |
-        **/*.pdb
-        !**/*.UnitTests.pdb
-      targetFolder: '$(build.artifactStagingDirectory)/symbols'
-      cleanTargetFolder: true
-      flattenFolders: true
-      overWrite: true
-
   - task: PublishBuildArtifacts@1
     displayName: 'publish symbol artifacts'
     inputs:

--- a/build/build.yml
+++ b/build/build.yml
@@ -36,6 +36,23 @@ steps:
       alertWarningLevel: 'High'
       failOnAlert: true
 
+  # Temp
+  - task: CopyFiles@2
+    displayName: 'copy symbols'
+    inputs:
+      SourceFolder: '$(build.sourcesDirectory)'
+      Contents: '**/*.pdb'
+      TargetFolder: '$(build.artifactStagingDirectory)/symbols'
+      CleanTargetFolder: true
+      flattenFolders: true
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'publish symbol artifacts'
+    inputs:
+      pathtoPublish: '$(build.artifactStagingDirectory)/symbols'
+      artifactName: 'symbols'
+      publishLocation: 'container'
+
   - ${{ if eq(parameters.packageArtifacts, 'true') }}:
     - template: package.yml
 

--- a/build/build.yml
+++ b/build/build.yml
@@ -41,7 +41,9 @@ steps:
     displayName: 'copy symbols'
     inputs:
       sourceFolder: '$(build.sourcesDirectory)'
-      contents: '**/*.pdb;!**/*.UnitTests.pdb'
+      contents: |
+        **/*.pdb
+        !**/*.UnitTests.pdb
       targetFolder: '$(build.artifactStagingDirectory)/symbols'
       cleanTargetFolder: true
       flattenFolders: true

--- a/build/build.yml
+++ b/build/build.yml
@@ -41,7 +41,7 @@ steps:
     displayName: 'copy symbols'
     inputs:
       sourceFolder: '$(build.sourcesDirectory)'
-      contents: '**/*.pdb'
+      contents: '**/*.pdb;!**/*.UnitTests.pdb'
       targetFolder: '$(build.artifactStagingDirectory)/symbols'
       cleanTargetFolder: true
       flattenFolders: true

--- a/build/build.yml
+++ b/build/build.yml
@@ -40,11 +40,12 @@ steps:
   - task: CopyFiles@2
     displayName: 'copy symbols'
     inputs:
-      SourceFolder: '$(build.sourcesDirectory)'
-      Contents: '**/*.pdb'
-      TargetFolder: '$(build.artifactStagingDirectory)/symbols'
-      CleanTargetFolder: true
+      sourceFolder: '$(build.sourcesDirectory)'
+      contents: '**/*.pdb'
+      targetFolder: '$(build.artifactStagingDirectory)/symbols'
+      cleanTargetFolder: true
       flattenFolders: true
+      overWrite: true
 
   - task: PublishBuildArtifacts@1
     displayName: 'publish symbol artifacts'

--- a/build/build.yml
+++ b/build/build.yml
@@ -36,13 +36,6 @@ steps:
       alertWarningLevel: 'High'
       failOnAlert: true
 
-  - task: PublishBuildArtifacts@1
-    displayName: 'publish symbol artifacts'
-    inputs:
-      pathtoPublish: '$(build.artifactStagingDirectory)/symbols'
-      artifactName: 'symbols'
-      publishLocation: 'container'
-
   - ${{ if eq(parameters.packageArtifacts, 'true') }}:
     - template: package.yml
 

--- a/build/package-nugets.yml
+++ b/build/package-nugets.yml
@@ -21,11 +21,12 @@ steps:
   - task: CopyFiles@2
     displayName: 'copy symbols'
     inputs:
-      SourceFolder: '$(build.sourcesDirectory)'
-      Contents: '**/*.pdb'
-      TargetFolder: '$(build.artifactStagingDirectory)/symbols'
-      CleanTargetFolder: true
+      sourceFolder: '$(build.sourcesDirectory)'
+      contents: '**/*.pdb'
+      targetFolder: '$(build.artifactStagingDirectory)/symbols'
+      cleanTargetFolder: true
       flattenFolders: true
+      overWrite: true
 
   - task: PublishBuildArtifacts@1
     displayName: 'publish symbol artifacts'

--- a/build/package-nugets.yml
+++ b/build/package-nugets.yml
@@ -22,7 +22,7 @@ steps:
     displayName: 'copy symbols'
     inputs:
       sourceFolder: '$(build.sourcesDirectory)'
-      contents: '**/*.pdb'
+      contents: '**/*.pdb;!**/*.UnitTests.pdb'
       targetFolder: '$(build.artifactStagingDirectory)/symbols'
       cleanTargetFolder: true
       flattenFolders: true

--- a/build/package-nugets.yml
+++ b/build/package-nugets.yml
@@ -22,7 +22,9 @@ steps:
     displayName: 'copy symbols'
     inputs:
       sourceFolder: '$(build.sourcesDirectory)'
-      contents: '**/*.pdb;!**/*.UnitTests.pdb'
+      contents: |
+        **/*.pdb
+        !**/*.UnitTests.pdb
       targetFolder: '$(build.artifactStagingDirectory)/symbols'
       cleanTargetFolder: true
       flattenFolders: true

--- a/build/package-nugets.yml
+++ b/build/package-nugets.yml
@@ -18,10 +18,18 @@ steps:
       artifactName: 'nuget'
       publishLocation: 'container'
 
-  - task: PublishSymbols@2
-    displayName: 'Publish symbols'
+  - task: CopyFiles@2
+    displayName: 'copy symbols'
     inputs:
-      searchFolder: '$(build.sourcesDirectory)'
-      searchPattern: '**\*.pdb'
-      symbolServerType: 'TeamServices'
-      indexSources: false # done in build step
+      SourceFolder: '$(build.sourcesDirectory)'
+      Contents: '**\*.pdb'
+      TargetFolder: '$(build.artifactStagingDirectory)/symbols'
+      CleanTargetFolder: true
+      flattenFolders: true
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'publish symbol artifacts'
+    inputs:
+      pathtoPublish: '$(build.artifactStagingDirectory)/symbols'
+      artifactName: 'symbols'
+      publishLocation: 'container'

--- a/build/package-nugets.yml
+++ b/build/package-nugets.yml
@@ -22,7 +22,7 @@ steps:
     displayName: 'copy symbols'
     inputs:
       SourceFolder: '$(build.sourcesDirectory)'
-      Contents: '**\*.pdb'
+      Contents: '**/*.pdb'
       TargetFolder: '$(build.artifactStagingDirectory)/symbols'
       CleanTargetFolder: true
       flattenFolders: true

--- a/build/publish-nuget.yml
+++ b/build/publish-nuget.yml
@@ -20,3 +20,18 @@ steps:
       command: push
       publishVstsFeed: 'InternalBuilds'
       allowPackageConflicts: true
+
+  - task: DownloadBuildArtifacts@0
+    inputs:
+      buildType: 'current'
+      downloadType: 'single'
+      downloadPath: '$(build.artifactStagingDirectory)'
+      artifactName: 'symbols'
+
+  - task: PublishSymbols@2
+    displayName: 'Publish Symbols'
+    inputs:
+      SymbolsFolder: '$(build.artifactStagingDirectory)/symbols'
+      SearchPattern: '**/*.pdb'
+      SymbolServerType: 'TeamServices'
+      IndexSources: false # done in build step

--- a/build/publish-nuget.yml
+++ b/build/publish-nuget.yml
@@ -31,7 +31,7 @@ steps:
   - task: PublishSymbols@2
     displayName: 'Publish Symbols'
     inputs:
-      SymbolsFolder: '$(build.artifactStagingDirectory)/symbols'
-      SearchPattern: '**/*.pdb'
-      SymbolServerType: 'TeamServices'
-      IndexSources: false # done in build step
+      symbolsFolder: '$(build.artifactStagingDirectory)/symbols'
+      searchPattern: '**/*.pdb'
+      symbolServerType: 'TeamServices'
+      indexSources: false # done in build step


### PR DESCRIPTION
## Description
- Move symbol publish to the existing nuget publish stage that runs on Windows VMs

## Related issues
N/A

## Testing
Ad-hoc run of CI without publish
