### PR TITLE
Correct tag and descriptions in Store section of the Conformance Statement

### DIFF
--- a/docs/resources/conformance-statement.md
+++ b/docs/resources/conformance-statement.md
@@ -81,15 +81,15 @@ Each dataset in the `FailedSOPSequence` will have the following elements (if the
 | Tag          | Name                     | Description |
 | :----------- | :----------------------- | :---------- |
 | (0008, 1150) | ReferencedSOPClassUID    | The SOP class unique identifier of the instance that failed to store. |
-| (0008, 1150) | ReferencedSOPInstanceUID | The SOP instance unique identifier of the instance that failed to store. |
+| (0008, 1155) | ReferencedSOPInstanceUID | The SOP instance unique identifier of the instance that failed to store. |
 | (0008, 1197) | FailureReason            | The reason code why this instance failed to store. |
 
 Each dataset in the `ReferencedSOPSequence` will have the following elements:
 
 | Tag          | Name                     | Description |
 | :----------- | :----------------------- | :---------- |
-| (0008, 1150) | ReferencedSOPClassUID    | The SOP class unique identifier of the instance that failed to store. |
-| (0008, 1150) | ReferencedSOPInstanceUID | The SOP instance unique identifier of the instance that failed to store. |
+| (0008, 1150) | ReferencedSOPClassUID    | The SOP class unique identifier of the instance that was stored. |
+| (0008, 1155) | ReferencedSOPInstanceUID | The SOP instance unique identifier of the instance that was stored. |
 | (0008, 1190) | RetrieveURL              | The retrieve URL of this instance on the DICOM server. |
 
 An example response with `Accept` header `application/dicom+json`:


### PR DESCRIPTION
## Description
This corrects two small errors in the store (STOW-RS) section of the DICOM conformance statement.
1. The tags for `ReferencedSOPInstanceUID` were incorrect, and should be [(0008, 1155)](https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_10.8.html#table_10-11)
2. The description for the successful set described it as containing the failed instances.


## Related issues
None

## Testing
N/A; I don't think this document is linked to any other generated documentation.