### PR TITLE
Remove response size calculation from request middleware

### DIFF
--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Context/DicomRequestContextMiddlewareTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Context/DicomRequestContextMiddlewareTests.cs
@@ -32,24 +32,10 @@ namespace Microsoft.Health.Dicom.Api.UnitTests.Features.Context
             Assert.Equal(new Uri("https://localhost:30/studies"), dicomRequestContext.BaseUri);
         }
 
-        [Fact]
-        public async Task GivenAnHttpRequest_WhenExecutingDicomRequestContextMiddleware_ThenResponseSizeShouldBeSet()
-        {
-            long largeRequestLength = 2000000000; // 2gb
-            long headerSize = 2;
-            IDicomRequestContext dicomRequestContext = await SetupAsync(CreateHttpContext(), largeRequestLength);
-
-            Assert.Equal(largeRequestLength + headerSize, dicomRequestContext.ResponseSize);
-        }
-
-        private async Task<IDicomRequestContext> SetupAsync(HttpContext httpContext, long byteLength = 256)
+        private async Task<IDicomRequestContext> SetupAsync(HttpContext httpContext)
         {
             var dicomRequestContextAccessor = Substitute.For<IDicomRequestContextAccessor>();
-            var dicomContextMiddleware = new DicomRequestContextMiddleware(next: (innerHttpContext) =>
-            {
-                innerHttpContext.Response.Body.Write(new byte[byteLength]);
-                return Task.CompletedTask;
-            });
+            var dicomContextMiddleware = new DicomRequestContextMiddleware(next: (innerHttpContext) => Task.CompletedTask);
 
             await dicomContextMiddleware.Invoke(httpContext, dicomRequestContextAccessor);
 

--- a/src/Microsoft.Health.Dicom.Api/Features/Context/DicomRequestContextMiddleware.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Context/DicomRequestContextMiddleware.cs
@@ -8,8 +8,6 @@ using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
-using Microsoft.Health.Api.Extensions;
-using Microsoft.Health.Core.Features.MonitorStream;
 using Microsoft.Health.Dicom.Core.Features.Context;
 
 namespace Microsoft.Health.Dicom.Api.Features.Context
@@ -51,26 +49,8 @@ namespace Microsoft.Health.Dicom.Api.Features.Context
 
             dicomRequestContextAccessor.RequestContext = dicomRequestContext;
 
-            using (MonitoredStream byteCountingStream = new MonitoredStream(context.Response.Body))
-            {
-                context.Response.Body = byteCountingStream;
-
-                try
-                {
-                    // Call the next delegate/middleware in the pipeline
-                    await _next(context);
-
-                    long responseBodySize = byteCountingStream.WriteCount;
-                    long responseHeaderSize = context.Response.Headers.GetTotalHeaderLength();
-                    long totalResponseSize = responseBodySize + responseHeaderSize;
-
-                    dicomRequestContextAccessor.RequestContext.ResponseSize = totalResponseSize;
-                }
-                finally
-                {
-                    dicomRequestContextAccessor.RequestContext.ResponseSize2 = -3;
-                }
-            }
+            // Call the next delegate/middleware in the pipeline
+            await _next(context);
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Api/Features/Context/DicomRequestContextMiddleware.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Context/DicomRequestContextMiddleware.cs
@@ -59,14 +59,16 @@ namespace Microsoft.Health.Dicom.Api.Features.Context
                 {
                     // Call the next delegate/middleware in the pipeline
                     await _next(context);
-                }
-                finally
-                {
+
                     long responseBodySize = byteCountingStream.WriteCount;
                     long responseHeaderSize = context.Response.Headers.GetTotalHeaderLength();
                     long totalResponseSize = responseBodySize + responseHeaderSize;
 
                     dicomRequestContextAccessor.RequestContext.ResponseSize = totalResponseSize;
+                }
+                finally
+                {
+                    dicomRequestContextAccessor.RequestContext.ResponseSize2 = -3;
                 }
             }
         }

--- a/src/Microsoft.Health.Dicom.Core/Features/Context/IDicomRequestContext.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Context/IDicomRequestContext.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Health.Dicom.Core.Features.Context
 
         long ResponseSize { get; set; }
 
+        long ResponseSize2 { get; set; }
+
         PartitionEntry DataPartitionEntry { get; set; }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Context/IDicomRequestContext.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Context/IDicomRequestContext.cs
@@ -20,10 +20,6 @@ namespace Microsoft.Health.Dicom.Core.Features.Context
 
         long BytesTranscoded { get; set; }
 
-        long ResponseSize { get; set; }
-
-        long ResponseSize2 { get; set; }
-
         PartitionEntry DataPartitionEntry { get; set; }
     }
 }


### PR DESCRIPTION
## Description
This calculation will now be done in workspace platform code. Due to the order of execution of the middleware, this was only being run after billing middleware had finished, so it would not get the response size

PR in workspace platform - https://microsofthealth.visualstudio.com/Health/_git/workspace-platform/pullrequest/17048

## Related issues
Addresses [#87344].

## Testing
Ran unit tests