### PR TITLE
Add support to client certificate credentials to dicom cast.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
     <FhirServerPackageVersion>2.0.55</FhirServerPackageVersion>
     <FoDicomVersion>4.0.8</FoDicomVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <HealthcareSharedPackageVersion>4.0.3</HealthcareSharedPackageVersion>
+    <HealthcareSharedPackageVersion>4.0.4</HealthcareSharedPackageVersion>
     <HighEntropyVA>true</HighEntropyVA>
     <Hl7FhirPackageVersion>3.6.0</Hl7FhirPackageVersion>
     <LangVersion>Latest</LangVersion>

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Configurations/AuthenticationConfiguration.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Configurations/AuthenticationConfiguration.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Health.DicomCast.Core.Configurations
 
         public AuthenticationType? AuthenticationType { get; set; }
 
+        public OAuth2ClientCertificateCredentialConfiguration OAuth2ClientCertificateCredential { get; set; }
+
         public OAuth2ClientCredentialConfiguration OAuth2ClientCredential { get; set; }
 
         public OAuth2UserPasswordCredentialConfiguration OAuth2UserPasswordCredential { get; set; }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Extensions/IHttpClientBuilderRegistrationExtensions.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Extensions/IHttpClientBuilderRegistrationExtensions.cs
@@ -30,6 +30,9 @@ namespace Microsoft.Health.DicomCast.Core.Extensions
                 case AuthenticationType.ManagedIdentity:
                     services.AddNamedManagedIdentityCredentialProvider(authenticationConfiguration.ManagedIdentityCredential, credentialProviderName);
                     break;
+                case AuthenticationType.OAuth2ClientCertificateCredential:
+                    services.AddNamedOAuth2ClientCertificateCredentialProvider(authenticationConfiguration.OAuth2ClientCertificateCredential, credentialProviderName);
+                    break;
                 case AuthenticationType.OAuth2ClientCredential:
                     services.AddNamedOAuth2ClientCredentialProvider(authenticationConfiguration.OAuth2ClientCredential, credentialProviderName);
                     break;

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Modules/ServiceCollectionExtensions.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Modules/ServiceCollectionExtensions.cs
@@ -32,6 +32,23 @@ namespace Microsoft.Health.DicomCast.Core.Modules
                 .AsService<NamedCredentialProvider>();
         }
 
+        public static void AddNamedOAuth2ClientCertificateCredentialProvider(this IServiceCollection serviceCollection, OAuth2ClientCertificateCredentialConfiguration oAuth2ClientCertificateCredentialConfiguration, string name)
+        {
+            EnsureArg.IsNotNull(serviceCollection, nameof(serviceCollection));
+            EnsureArg.IsNotNull(oAuth2ClientCertificateCredentialConfiguration, nameof(oAuth2ClientCertificateCredentialConfiguration));
+            EnsureArg.IsNotNullOrWhiteSpace(name, nameof(name));
+
+            serviceCollection.Add(provider =>
+                {
+                    var options = Options.Create(oAuth2ClientCertificateCredentialConfiguration);
+                    var httpClient = new HttpClient();
+                    var credentialProvider = new OAuth2ClientCertificateCredentialProvider(options, httpClient);
+                    return new NamedCredentialProvider(name, credentialProvider);
+                })
+                .Singleton()
+                .AsService<NamedCredentialProvider>();
+        }
+
         public static void AddNamedOAuth2ClientCredentialProvider(this IServiceCollection serviceCollection, OAuth2ClientCredentialConfiguration oAuth2ClientCredentialConfiguration, string name)
         {
             EnsureArg.IsNotNull(serviceCollection, nameof(serviceCollection));


### PR DESCRIPTION
## Description
This PR brings in the latest version of the shared components and adds support for the client certificate credentials to DICOM Cast.

## Related issues
Addresses [AB#87283](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/87283).

## Testing
Manual testing.
