### PR TITLE
Cleanup test dicom instances after tests complete

### DIFF
--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Common/DicomInstanceId.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Common/DicomInstanceId.cs
@@ -1,0 +1,31 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using EnsureThat;
+using Microsoft.Health.Dicom.Core.Features.Model;
+
+namespace Microsoft.Health.Dicom.Web.Tests.E2E.Common
+{
+    internal class DicomInstanceId
+    {
+        public DicomInstanceId(string partitionName, string studyInstanceUid, string seriesInstanceUid, string sopInstanceUid)
+        {
+            StudyInstanceUid = EnsureArg.IsNotNullOrWhiteSpace(studyInstanceUid, nameof(studyInstanceUid));
+            SeriesInstanceUid = EnsureArg.IsNotNullOrWhiteSpace(seriesInstanceUid, nameof(seriesInstanceUid));
+            SopInstanceUid = EnsureArg.IsNotNullOrWhiteSpace(sopInstanceUid, nameof(sopInstanceUid));
+            PartitionName = partitionName;
+        }
+
+        public string StudyInstanceUid { get; }
+        public string SeriesInstanceUid { get; }
+        public string SopInstanceUid { get; }
+        public string PartitionName { get; }
+
+        public static DicomInstanceId FromInstanceIdentifier(InstanceIdentifier instanceIdentifier, string partitionName = default)
+        {
+            return new DicomInstanceId(partitionName, instanceIdentifier.StudyInstanceUid, instanceIdentifier.SeriesInstanceUid, instanceIdentifier.SopInstanceUid);
+        }
+    }
+}

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Common/DicomInstanceId.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Common/DicomInstanceId.cs
@@ -3,7 +3,9 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Dicom;
 using EnsureThat;
+using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Core.Features.Model;
 
 namespace Microsoft.Health.Dicom.Web.Tests.E2E.Common
@@ -23,8 +25,9 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Common
         public string SopInstanceUid { get; }
         public string PartitionName { get; }
 
-        public static DicomInstanceId FromInstanceIdentifier(InstanceIdentifier instanceIdentifier, string partitionName = default)
+        public static DicomInstanceId FromDicomFile(DicomFile dicomFile, string partitionName = default)
         {
+            InstanceIdentifier instanceIdentifier = dicomFile.Dataset.ToInstanceIdentifier();
             return new DicomInstanceId(partitionName, instanceIdentifier.StudyInstanceUid, instanceIdentifier.SeriesInstanceUid, instanceIdentifier.SopInstanceUid);
         }
     }

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Common/DicomInstanceId.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Common/DicomInstanceId.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using Dicom;
 using EnsureThat;
 using Microsoft.Health.Dicom.Core.Extensions;
@@ -12,6 +13,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Common
 {
     internal class DicomInstanceId
     {
+        private const StringComparison EqualsStringComparison = StringComparison.Ordinal;
         public DicomInstanceId(string partitionName, string studyInstanceUid, string seriesInstanceUid, string sopInstanceUid)
         {
             StudyInstanceUid = EnsureArg.IsNotNullOrWhiteSpace(studyInstanceUid, nameof(studyInstanceUid));
@@ -30,5 +32,21 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Common
             InstanceIdentifier instanceIdentifier = dicomFile.Dataset.ToInstanceIdentifier();
             return new DicomInstanceId(partitionName, instanceIdentifier.StudyInstanceUid, instanceIdentifier.SeriesInstanceUid, instanceIdentifier.SopInstanceUid);
         }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is DicomInstanceId instanceId)
+            {
+                return StudyInstanceUid.Equals(instanceId.StudyInstanceUid, EqualsStringComparison) &&
+                        SeriesInstanceUid.Equals(instanceId.SeriesInstanceUid, EqualsStringComparison) &&
+                        SopInstanceUid.Equals(instanceId.SopInstanceUid, EqualsStringComparison) &&
+                        PartitionName.Equals(instanceId.PartitionName, EqualsStringComparison);
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode() => HashCode.Combine(StudyInstanceUid, SeriesInstanceUid, SopInstanceUid, PartitionName);
+
     }
 }

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Common/DicomInstanceId.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Common/DicomInstanceId.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Common
     internal class DicomInstanceId
     {
         private const StringComparison EqualsStringComparison = StringComparison.Ordinal;
-        public DicomInstanceId(string partitionName, string studyInstanceUid, string seriesInstanceUid, string sopInstanceUid)
+        public DicomInstanceId(string studyInstanceUid, string seriesInstanceUid, string sopInstanceUid, string partitionName)
         {
             StudyInstanceUid = EnsureArg.IsNotNullOrWhiteSpace(studyInstanceUid, nameof(studyInstanceUid));
             SeriesInstanceUid = EnsureArg.IsNotNullOrWhiteSpace(seriesInstanceUid, nameof(seriesInstanceUid));
@@ -30,7 +30,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Common
         public static DicomInstanceId FromDicomFile(DicomFile dicomFile, string partitionName = default)
         {
             InstanceIdentifier instanceIdentifier = dicomFile.Dataset.ToInstanceIdentifier();
-            return new DicomInstanceId(partitionName, instanceIdentifier.StudyInstanceUid, instanceIdentifier.SeriesInstanceUid, instanceIdentifier.SopInstanceUid);
+            return new DicomInstanceId(instanceIdentifier.StudyInstanceUid, instanceIdentifier.SeriesInstanceUid, instanceIdentifier.SopInstanceUid, partitionName);
         }
 
         public override bool Equals(object obj)

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Common/DicomInstancesManager.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Common/DicomInstancesManager.cs
@@ -4,26 +4,28 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Dicom;
 using EnsureThat;
 using Microsoft.Health.Dicom.Client;
 using Microsoft.Health.Dicom.Core.Extensions;
-using Microsoft.Health.Dicom.Core.Features.Model;
 
 namespace Microsoft.Health.Dicom.Web.Tests.E2E.Common
 {
     internal class DicomInstancesManager : IAsyncDisposable
     {
+
         private readonly IDicomWebClient _dicomWebClient;
-        private readonly HashSet<InstanceIdentifier> _instanceIds;
+        private readonly ConcurrentBag<DicomInstanceId> _instanceIds;
 
         public DicomInstancesManager(IDicomWebClient dicomWebClient)
         {
             _dicomWebClient = EnsureArg.IsNotNull(dicomWebClient, nameof(dicomWebClient));
-            _instanceIds = new HashSet<InstanceIdentifier>();
+            _instanceIds = new ConcurrentBag<DicomInstanceId>();
         }
 
         public async ValueTask DisposeAsync()
@@ -32,7 +34,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Common
             {
                 try
                 {
-                    await _dicomWebClient.DeleteInstanceAsync(id.StudyInstanceUid, id.SeriesInstanceUid, id.SopInstanceUid);
+                    await _dicomWebClient.DeleteInstanceAsync(id.StudyInstanceUid, id.SeriesInstanceUid, id.SopInstanceUid, id.PartitionName);
                 }
                 catch (DicomWebException)
                 {
@@ -41,12 +43,33 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Common
             }
         }
 
-        public async Task StoreAsync(DicomFile dicomFile, CancellationToken cancellationToken = default)
+        public async Task<DicomWebResponse<DicomDataset>> StoreAsync(DicomFile dicomFile, string studyInstanceUid = default, string partitionName = default, CancellationToken cancellationToken = default)
         {
             EnsureArg.IsNotNull(dicomFile, nameof(dicomFile));
-            _instanceIds.Add(dicomFile.Dataset.ToInstanceIdentifier());
-            await _dicomWebClient.StoreAsync(dicomFile, cancellationToken: cancellationToken);
+            _instanceIds.Add(DicomInstanceId.FromInstanceIdentifier(dicomFile.Dataset.ToInstanceIdentifier(), partitionName));
+            return await _dicomWebClient.StoreAsync(dicomFile, studyInstanceUid, partitionName, cancellationToken);
         }
 
+        public async Task<DicomWebResponse<DicomDataset>> StoreAsync(HttpContent content, string partitionName = default, CancellationToken cancellationToken = default, DicomInstanceId instanceId = default)
+        {
+            EnsureArg.IsNotNull(content, nameof(content));
+            // Null instanceId indiates Store will fail
+            if (instanceId != null)
+            {
+                _instanceIds.Add(instanceId);
+            }
+            return await _dicomWebClient.StoreAsync(content, partitionName, cancellationToken);
+        }
+
+        public async Task<DicomWebResponse<DicomDataset>> StoreAsync(IEnumerable<DicomFile> dicomFiles, string studyInstanceUid = default, string partitionName = default, CancellationToken cancellationToken = default)
+        {
+            EnsureArg.IsNotNull(dicomFiles, nameof(dicomFiles));
+            foreach (var file in dicomFiles)
+            {
+                _instanceIds.Add(DicomInstanceId.FromInstanceIdentifier(file.Dataset.ToInstanceIdentifier(), partitionName));
+            }
+
+            return await _dicomWebClient.StoreAsync(dicomFiles, studyInstanceUid, partitionName, cancellationToken);
+        }
     }
 }

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/DicomRetrieveMetadataETagTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/DicomRetrieveMetadataETagTests.cs
@@ -15,20 +15,23 @@ using Microsoft.Health.Dicom.Client;
 using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Core.Messages;
 using Microsoft.Health.Dicom.Tests.Common;
+using Microsoft.Health.Dicom.Web.Tests.E2E.Common;
 using Microsoft.Net.Http.Headers;
 using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
 {
-    public class DicomRetrieveMetadataETagTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
+    public class DicomRetrieveMetadataETagTests : IClassFixture<HttpIntegrationTestFixture<Startup>>, IAsyncLifetime
     {
         private readonly IDicomWebClient _client;
+        private readonly DicomInstancesManager _instancesManager;
 
         public DicomRetrieveMetadataETagTests(HttpIntegrationTestFixture<Startup> fixture)
         {
             EnsureArg.IsNotNull(fixture, nameof(fixture));
-            _client = fixture.Client;
+            _client = fixture.GetDicomWebClient();
+            _instancesManager = new DicomInstancesManager(_client);
         }
 
         [Fact]
@@ -319,6 +322,13 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             ValidateResponseMetadataDataset(storedInstance, datasets[0]);
         }
 
+        public Task InitializeAsync() => Task.CompletedTask;
+
+        public async Task DisposeAsync()
+        {
+            await _instancesManager.DisposeAsync();
+        }
+
         private string GetEtagFromResponse(DicomWebAsyncEnumerableResponse<DicomDataset> response)
         {
             string eTag = null;
@@ -356,7 +366,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
                 dicomFile.Dataset.AddOrUpdate(dataSet);
             }
 
-            using DicomWebResponse<DicomDataset> response = await _client.StoreAsync(new[] { dicomFile });
+            using DicomWebResponse<DicomDataset> response = await _instancesManager.StoreAsync(new[] { dicomFile });
 
             return dicomFile.Dataset;
         }

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/DicomRetrieveMetadataTransactionTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/DicomRetrieveMetadataTransactionTests.cs
@@ -14,19 +14,22 @@ using Microsoft.Health.Dicom.Client;
 using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Core.Messages;
 using Microsoft.Health.Dicom.Tests.Common;
+using Microsoft.Health.Dicom.Web.Tests.E2E.Common;
 using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
 {
-    public class DicomRetrieveMetadataTransactionTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
+    public class DicomRetrieveMetadataTransactionTests : IClassFixture<HttpIntegrationTestFixture<Startup>>, IAsyncLifetime
     {
         private readonly IDicomWebClient _client;
+        private readonly DicomInstancesManager _instancesManager;
 
         public DicomRetrieveMetadataTransactionTests(HttpIntegrationTestFixture<Startup> fixture)
         {
             EnsureArg.IsNotNull(fixture, nameof(fixture));
-            _client = fixture.Client;
+            _client = fixture.GetDicomWebClient();
+            _instancesManager = new DicomInstancesManager(_client);
         }
 
         [Theory]
@@ -220,12 +223,20 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
                 dicomFile.Dataset.AddOrUpdate(dataSet);
             }
 
-            using (DicomWebResponse<DicomDataset> response = await _client.StoreAsync(new[] { dicomFile }))
+            using (DicomWebResponse<DicomDataset> response = await _instancesManager.StoreAsync(new[] { dicomFile }))
             {
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             }
 
             return dicomFile.Dataset;
+        }
+
+        public Task InitializeAsync()
+           => Task.CompletedTask;
+
+        public async Task DisposeAsync()
+        {
+            await _instancesManager.DisposeAsync();
         }
     }
 }

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/ExtendedQueryTagTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/ExtendedQueryTagTests.cs
@@ -30,8 +30,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
         public ExtendedQueryTagTests(WebJobsIntegrationTestFixture<Startup> fixture)
         {
             EnsureArg.IsNotNull(fixture, nameof(fixture));
-            EnsureArg.IsNotNull(fixture.Client, nameof(fixture.Client));
-            _client = fixture.Client;
+            _client = fixture.GetDicomWebClient();
             _tagManager = new DicomTagsManager(_client);
             _instanceManager = new DicomInstancesManager(_client);
         }

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/HttpIntegrationTestFixture.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/HttpIntegrationTestFixture.cs
@@ -32,8 +32,6 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
 
         public bool IsInProcess => TestDicomWebServer is InProcTestDicomWebServer;
 
-        public HttpClient HttpClient => GetDicomWebClient().HttpClient;
-
         protected TestDicomWebServer TestDicomWebServer { get; }
 
         public RecyclableMemoryStreamManager RecyclableMemoryStreamManager { get; } = new RecyclableMemoryStreamManager();
@@ -110,7 +108,6 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
         {
             if (disposing)
             {
-                HttpClient.Dispose();
                 TestDicomWebServer.Dispose();
             }
         }

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/HttpIntegrationTestFixture.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/HttpIntegrationTestFixture.cs
@@ -28,18 +28,15 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
         protected HttpIntegrationTestFixture(string targetProjectParentDirectory, bool enableDataPartitions = false)
         {
             TestDicomWebServer = TestDicomWebServerFactory.GetTestDicomWebServer(typeof(TStartup), enableDataPartitions);
-            Client = GetDicomWebClient();
         }
 
         public bool IsInProcess => TestDicomWebServer is InProcTestDicomWebServer;
 
-        public HttpClient HttpClient => Client.HttpClient;
+        public HttpClient HttpClient => GetDicomWebClient().HttpClient;
 
         protected TestDicomWebServer TestDicomWebServer { get; }
 
         public RecyclableMemoryStreamManager RecyclableMemoryStreamManager { get; } = new RecyclableMemoryStreamManager();
-
-        public IDicomWebClient Client { get; }
 
         public IDicomWebClient GetDicomWebClient()
         {

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Common.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Common.cs
@@ -11,6 +11,7 @@ using Microsoft.Health.Dicom.Client;
 using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Core.Features.Model;
 using Microsoft.Health.Dicom.Tests.Common;
+using Microsoft.Health.Dicom.Web.Tests.E2E.Common;
 using Xunit;
 
 namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
@@ -26,29 +27,21 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
         private const string RequestOriginalContentTestFolder = TestFileFolder + "RequestOriginalContent";
 
         private readonly IDicomWebClient _client;
-        private readonly HashSet<string> _studiesToClean = new HashSet<string>();
+        private readonly DicomInstancesManager _instancesManager;
 
         public RetrieveTransactionResourceTests(HttpIntegrationTestFixture<Startup> fixture)
         {
             EnsureArg.IsNotNull(fixture, nameof(fixture));
-            _client = fixture.Client;
+            _client = fixture.GetDicomWebClient();
+            _instancesManager = new DicomInstancesManager(_client);
         }
 
         private async Task<(InstanceIdentifier, DicomFile)> CreateAndStoreDicomFile(int numberOfFrames = 0)
         {
             DicomFile dicomFile = Samples.CreateRandomDicomFileWithPixelData(frames: numberOfFrames);
             var dicomInstance = dicomFile.Dataset.ToInstanceIdentifier();
-            await InternalStoreAsync(new[] { dicomFile });
+            await _instancesManager.StoreAsync(new[] { dicomFile });
             return (dicomInstance, dicomFile);
-        }
-
-        private async Task InternalStoreAsync(IEnumerable<DicomFile> dicomFiles)
-        {
-            await _client.StoreAsync(dicomFiles);
-            foreach (DicomFile dicomFile in dicomFiles)
-            {
-                _studiesToClean.Add(dicomFile.Dataset.GetString(DicomTag.StudyInstanceUID));
-            }
         }
 
         private InstanceIdentifier RandomizeInstanceIdentifier(DicomDataset dataset)
@@ -60,19 +53,11 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             return newId;
         }
 
-        public Task InitializeAsync()
-        {
-            return Task.CompletedTask;
-        }
+        public Task InitializeAsync() => Task.CompletedTask;
 
         public async Task DisposeAsync()
         {
-            foreach (string studyUid in _studiesToClean)
-            {
-                await _client.DeleteStudyAsync(studyUid);
-            }
-
-            _studiesToClean.Clear();
+            await _instancesManager.DisposeAsync();
         }
 
         public static IEnumerable<object[]> GetUnsupportedAcceptHeadersForStudiesAndSeries

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Frame.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Frame.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             DicomFile inputDicomFile = await DicomFile.OpenAsync(transcoderTestData.InputDicomFile);
             var instanceId = RandomizeInstanceIdentifier(inputDicomFile.Dataset);
 
-            await InternalStoreAsync(new[] { inputDicomFile });
+            await _instancesManager.StoreAsync(new[] { inputDicomFile });
 
             DicomFile outputDicomFile = DicomFile.Open(transcoderTestData.ExpectedOutputDicomFile);
             DicomPixelData pixelData = DicomPixelData.Create(outputDicomFile.Dataset);
@@ -89,7 +89,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
                 transferSyntax: DicomTransferSyntax.HEVCH265Main10ProfileLevel51.UID.UID,
                 encode: false);
 
-            await InternalStoreAsync(new[] { dicomFile });
+            await _instancesManager.StoreAsync(new[] { dicomFile });
 
             // Check for series
             using DicomWebAsyncEnumerableResponse<Stream> response = await _client.RetrieveFramesAsync(
@@ -120,7 +120,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
                 transferSyntax: DicomTransferSyntax.HEVCH265Main10ProfileLevel51.UID.UID,
                 encode: false);
 
-            await InternalStoreAsync(new[] { dicomFile });
+            await _instancesManager.StoreAsync(new[] { dicomFile });
 
             DicomWebException exception = await Assert.ThrowsAsync<DicomWebException>(() => _client.RetrieveFramesAsync(
                 studyInstanceUid,
@@ -141,7 +141,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             DicomPixelData pixelData = DicomPixelData.Create(dicomFile1.Dataset);
             InstanceIdentifier dicomInstance = dicomFile1.Dataset.ToInstanceIdentifier();
 
-            await InternalStoreAsync(new[] { dicomFile1 });
+            await _instancesManager.StoreAsync(new[] { dicomFile1 });
 
             using DicomWebAsyncEnumerableResponse<Stream> response = await _client.RetrieveFramesAsync(
                 dicomInstance.StudyInstanceUid,

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Instance.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Instance.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             DicomFile inputDicomFile = DicomFile.Open(transcoderTestData.InputDicomFile);
             var instanceId = RandomizeInstanceIdentifier(inputDicomFile.Dataset);
 
-            await InternalStoreAsync(new[] { inputDicomFile });
+            await _instancesManager.StoreAsync(new[] { inputDicomFile });
 
             using DicomWebResponse<DicomFile> response = await _client.RetrieveInstanceAsync(instanceId.StudyInstanceUid, instanceId.SeriesInstanceUid, instanceId.SopInstanceUid, transferSyntax);
 
@@ -61,7 +61,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             DicomFile inputDicomFile = DicomFile.Open(transcoderTestData.InputDicomFile);
             var instanceId = RandomizeInstanceIdentifier(inputDicomFile.Dataset);
 
-            await InternalStoreAsync(new[] { inputDicomFile });
+            await _instancesManager.StoreAsync(new[] { inputDicomFile });
 
             var requestUri = new Uri(DicomApiVersions.Latest + string.Format(DicomWebConstants.BaseInstanceUriFormat, instanceId.StudyInstanceUid, instanceId.SeriesInstanceUid, instanceId.SopInstanceUid), UriKind.Relative);
 
@@ -96,7 +96,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
                 transferSyntax: DicomTransferSyntax.MPEG2.UID.UID,
                 encode: false);
 
-            await InternalStoreAsync(new[] { dicomFile });
+            await _instancesManager.StoreAsync(new[] { dicomFile });
             DicomWebException exception = await Assert.ThrowsAsync<DicomWebException>(() => _client.RetrieveInstanceAsync(studyInstanceUid, seriesInstanceUid, sopInstanceUid, dicomTransferSyntax: DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID));
             Assert.Equal(HttpStatusCode.NotAcceptable, exception.StatusCode);
         }
@@ -116,7 +116,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
                 transferSyntax: DicomTransferSyntax.MPEG2.UID.UID,
                 encode: false);
 
-            await InternalStoreAsync(new[] { dicomFile });
+            await _instancesManager.StoreAsync(new[] { dicomFile });
 
             using DicomWebResponse<DicomFile> instancesInStudy = await _client.RetrieveInstanceAsync(studyInstanceUid, seriesInstanceUid, sopInstanceUid, dicomTransferSyntax: "*");
             Assert.Equal(dicomFile.ToByteArray(), (await instancesInStudy.GetValueAsync()).ToByteArray());
@@ -136,7 +136,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             var seriesInstanceUid = TestUidGenerator.Generate();
             var sopInstanceUid = TestUidGenerator.Generate();
             DicomFile dicomFile1 = Samples.CreateRandomDicomFile(studyInstanceUid, seriesInstanceUid, sopInstanceUid);
-            await InternalStoreAsync(new[] { dicomFile1 });
+            await _instancesManager.StoreAsync(new[] { dicomFile1 });
 
             using DicomWebResponse<DicomFile> instanceRetrieve = await _client.RetrieveInstanceAsync(studyInstanceUid, seriesInstanceUid, sopInstanceUid, dicomTransferSyntax: "*");
             Assert.Equal(dicomFile1.ToByteArray(), (await instanceRetrieve.GetValueAsync()).ToByteArray());

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Series.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Series.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             TranscoderTestData transcoderTestData = TranscoderTestDataHelper.GetTestData(testDataFolder);
             DicomFile inputDicomFile = DicomFile.Open(transcoderTestData.InputDicomFile);
             var instanceId = RandomizeInstanceIdentifier(inputDicomFile.Dataset);
-            await InternalStoreAsync(new[] { inputDicomFile });
+            await _instancesManager.StoreAsync(new[] { inputDicomFile });
 
             using DicomWebAsyncEnumerableResponse<DicomFile> response = await _client.RetrieveSeriesAsync(instanceId.StudyInstanceUid, instanceId.SeriesInstanceUid, transferSyntax);
             Assert.Equal(DicomWebConstants.MultipartRelatedMediaType, response.ContentHeaders.ContentType.MediaType);
@@ -86,7 +86,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
                 TestUidGenerator.Generate(),
                 transferSyntax: DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID);
 
-            await InternalStoreAsync(new[] { dicomFile1, dicomFile2, dicomFile3 });
+            await _instancesManager.StoreAsync(new[] { dicomFile1, dicomFile2, dicomFile3 });
 
             using DicomWebAsyncEnumerableResponse<DicomFile> response = await _client.RetrieveSeriesAsync(studyInstanceUid, seriesInstanceUid);
 
@@ -117,7 +117,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
                 transferSyntax: DicomTransferSyntax.MPEG2.UID.UID,
                 encode: false);
 
-            await InternalStoreAsync(new[] { dicomFile1, dicomFile2 });
+            await _instancesManager.StoreAsync(new[] { dicomFile1, dicomFile2 });
 
             DicomWebException exception = await Assert.ThrowsAsync<DicomWebException>(() => _client.RetrieveSeriesAsync(studyInstanceUid, seriesInstanceUid, dicomTransferSyntax: DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID));
             Assert.Equal(HttpStatusCode.NotAcceptable, exception.StatusCode);
@@ -140,7 +140,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
                 transferSyntax: DicomTransferSyntax.MPEG2.UID.UID,
                 encode: false);
 
-            await InternalStoreAsync(new[] { dicomFile1, dicomFile2 });
+            await _instancesManager.StoreAsync(new[] { dicomFile1, dicomFile2 });
 
             using DicomWebAsyncEnumerableResponse<DicomFile> response = await _client.RetrieveSeriesAsync(studyInstanceUid, seriesInstanceUid, dicomTransferSyntax: "*");
 
@@ -167,7 +167,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             var studyInstanceUid = TestUidGenerator.Generate();
             var seriesInstanceUid = TestUidGenerator.Generate();
             DicomFile dicomFile1 = Samples.CreateRandomDicomFile(studyInstanceUid, seriesInstanceUid);
-            await InternalStoreAsync(new[] { dicomFile1 });
+            await _instancesManager.StoreAsync(new[] { dicomFile1 });
 
             using DicomWebAsyncEnumerableResponse<DicomFile> response = await _client.RetrieveSeriesAsync(studyInstanceUid, seriesInstanceUid, dicomTransferSyntax: "*");
 

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Study.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Study.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             DicomFile inputDicomFile = DicomFile.Open(transcoderTestData.InputDicomFile);
             var instanceId = RandomizeInstanceIdentifier(inputDicomFile.Dataset);
 
-            await InternalStoreAsync(new[] { inputDicomFile });
+            await _instancesManager.StoreAsync(new[] { inputDicomFile });
             using DicomWebAsyncEnumerableResponse<DicomFile> response = await _client.RetrieveStudyAsync(instanceId.StudyInstanceUid, transferSyntax);
 
             Assert.Equal(DicomWebConstants.MultipartRelatedMediaType, response.ContentHeaders.ContentType.MediaType);
@@ -87,7 +87,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
                 TestUidGenerator.Generate(),
                 transferSyntax: DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID);
 
-            await InternalStoreAsync(new[] { dicomFile1, dicomFile2, dicomFile3 });
+            await _instancesManager.StoreAsync(new[] { dicomFile1, dicomFile2, dicomFile3 });
 
             using DicomWebAsyncEnumerableResponse<DicomFile> response = await _client.RetrieveStudyAsync(studyInstanceUid);
 
@@ -117,7 +117,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
                 transferSyntax: DicomTransferSyntax.MPEG2.UID.UID,
                 encode: false);
 
-            await InternalStoreAsync(new[] { dicomFile1, dicomFile2 });
+            await _instancesManager.StoreAsync(new[] { dicomFile1, dicomFile2 });
             DicomWebException exception = await Assert.ThrowsAsync<DicomWebException>(() => _client.RetrieveStudyAsync(studyInstanceUid, dicomTransferSyntax: DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID));
             Assert.Equal(HttpStatusCode.NotAcceptable, exception.StatusCode);
         }
@@ -138,7 +138,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
                 transferSyntax: DicomTransferSyntax.MPEG2.UID.UID,
                 encode: false);
 
-            await InternalStoreAsync(new[] { dicomFile1, dicomFile2 });
+            await _instancesManager.StoreAsync(new[] { dicomFile1, dicomFile2 });
 
             using DicomWebAsyncEnumerableResponse<DicomFile> response = await _client.RetrieveStudyAsync(studyInstanceUid, dicomTransferSyntax: "*");
 
@@ -164,7 +164,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
         {
             var studyInstanceUid = TestUidGenerator.Generate();
             DicomFile dicomFile1 = Samples.CreateRandomDicomFile(studyInstanceUid);
-            await InternalStoreAsync(new[] { dicomFile1 });
+            await _instancesManager.StoreAsync(new[] { dicomFile1 });
 
             using DicomWebAsyncEnumerableResponse<DicomFile> response = await _client.RetrieveStudyAsync(studyInstanceUid, dicomTransferSyntax: "*");
 

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/StoreTransactionTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/StoreTransactionTests.cs
@@ -13,14 +13,16 @@ using System.Threading.Tasks;
 using Dicom;
 using EnsureThat;
 using Microsoft.Health.Dicom.Client;
+using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Tests.Common;
+using Microsoft.Health.Dicom.Web.Tests.E2E.Common;
 using Microsoft.IO;
 using Microsoft.Net.Http.Headers;
 using Xunit;
 
 namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
 {
-    public class StoreTransactionTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
+    public class StoreTransactionTests : IClassFixture<HttpIntegrationTestFixture<Startup>>, IAsyncLifetime
     {
         private const ushort ValidationFailedFailureCode = 43264;
         private const ushort SopInstanceAlreadyExistsFailureCode = 45070;
@@ -28,11 +30,13 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
 
         private readonly IDicomWebClient _client;
         private readonly RecyclableMemoryStreamManager _recyclableMemoryStreamManager;
+        private readonly DicomInstancesManager _instancesManager;
 
         public StoreTransactionTests(HttpIntegrationTestFixture<Startup> fixture)
         {
             EnsureArg.IsNotNull(fixture, nameof(fixture));
-            _client = fixture.Client;
+            _client = fixture.GetDicomWebClient();
+            _instancesManager = new DicomInstancesManager(_client);
             _recyclableMemoryStreamManager = fixture.RecyclableMemoryStreamManager;
         }
 
@@ -89,7 +93,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             var multiContent = new MultipartContent("related");
             multiContent.Headers.ContentType.Parameters.Add(new System.Net.Http.Headers.NameValueHeaderValue("type", $"\"{DicomWebConstants.MediaTypeApplicationDicom.MediaType}\""));
 
-            using DicomWebResponse response = await _client.StoreAsync(multiContent);
+            using DicomWebResponse response = await _instancesManager.StoreAsync(multiContent);
 
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
         }
@@ -105,7 +109,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             multiContent.Add(byteContent);
 
             DicomWebException exception = await Assert.ThrowsAsync<DicomWebException>(
-                () => _client.StoreAsync(multiContent));
+                () => _instancesManager.StoreAsync(multiContent));
 
             Assert.Equal(HttpStatusCode.Conflict, exception.StatusCode);
         }
@@ -135,7 +139,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
                     multiContent.Add(validByteContent);
                 }
 
-                using DicomWebResponse<DicomDataset> response = await _client.StoreAsync(multiContent);
+                using DicomWebResponse<DicomDataset> response = await _instancesManager.StoreAsync(multiContent, instanceId: DicomInstanceId.FromInstanceIdentifier(validFile.Dataset.ToInstanceIdentifier()));
 
                 Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
@@ -169,7 +173,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
                     multiContent.Add(byteContent);
                 }
 
-                using DicomWebResponse<DicomDataset> response = await _client.StoreAsync(multiContent);
+                using DicomWebResponse<DicomDataset> response = await _instancesManager.StoreAsync(multiContent, instanceId: DicomInstanceId.FromInstanceIdentifier(dicomFile.Dataset.ToInstanceIdentifier()));
 
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
@@ -191,7 +195,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
 
             var studyInstanceUID = TestUidGenerator.Generate();
 
-            DicomWebException exception = await Assert.ThrowsAsync<DicomWebException>(() => _client.StoreAsync(
+            DicomWebException exception = await Assert.ThrowsAsync<DicomWebException>(() => _instancesManager.StoreAsync(
                 new[] { dicomFile1, dicomFile2 }, studyInstanceUid: studyInstanceUID));
 
             Assert.Equal(HttpStatusCode.Conflict, exception.StatusCode);
@@ -219,7 +223,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
                 DicomFile dicomFile1 = Samples.CreateRandomDicomFile(studyInstanceUid: studyInstanceUID1);
                 DicomFile dicomFile2 = Samples.CreateRandomDicomFile(studyInstanceUid: studyInstanceUID2);
 
-                using DicomWebResponse<DicomDataset> response = await _client.StoreAsync(new[] { dicomFile1, dicomFile2 }, studyInstanceUid: studyInstanceUID1);
+                using DicomWebResponse<DicomDataset> response = await _instancesManager.StoreAsync(new[] { dicomFile1, dicomFile2 }, studyInstanceUid: studyInstanceUID1);
 
                 Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
@@ -250,7 +254,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             var studyInstanceUID = TestUidGenerator.Generate();
             DicomFile dicomFile1 = Samples.CreateRandomDicomFile(studyInstanceUID, studyInstanceUID);
 
-            DicomWebException exception = await Assert.ThrowsAsync<DicomWebException>(() => _client.StoreAsync(new[] { dicomFile1 }));
+            DicomWebException exception = await Assert.ThrowsAsync<DicomWebException>(() => _instancesManager.StoreAsync(new[] { dicomFile1 }));
 
             Assert.Equal(HttpStatusCode.Conflict, exception.StatusCode);
 
@@ -272,7 +276,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             {
                 DicomFile dicomFile1 = Samples.CreateRandomDicomFile(studyInstanceUID);
 
-                using DicomWebResponse<DicomDataset> response = await _client.StoreAsync(new[] { dicomFile1 });
+                using DicomWebResponse<DicomDataset> response = await _instancesManager.StoreAsync(new[] { dicomFile1 });
 
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
@@ -285,7 +289,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
                 Assert.False(dataset.TryGetSequence(DicomTag.FailedSOPSequence, out DicomSequence _));
 
                 DicomWebException exception = await Assert.ThrowsAsync<DicomWebException>(
-                    () => _client.StoreAsync(new[] { dicomFile1 }));
+                    () => _instancesManager.StoreAsync(new[] { dicomFile1 }));
 
                 Assert.Equal(HttpStatusCode.Conflict, exception.StatusCode);
 
@@ -306,7 +310,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
 
             DicomFile dicomFile1 = Samples.CreateRandomDicomFileWithInvalidVr(studyInstanceUID);
 
-            DicomWebException exception = await Assert.ThrowsAsync<DicomWebException>(() => _client.StoreAsync(new[] { dicomFile1 }));
+            DicomWebException exception = await Assert.ThrowsAsync<DicomWebException>(() => _instancesManager.StoreAsync(new[] { dicomFile1 }));
 
             Assert.Equal(HttpStatusCode.Conflict, exception.StatusCode);
             Assert.False(exception.ResponseDataset.TryGetSequence(DicomTag.ReferencedSOPSequence, out DicomSequence _));
@@ -323,7 +327,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
         {
             DicomFile dicomFile1 = Samples.CreateRandomDicomFile(studyInstanceUID, validateItems: false);
 
-            DicomWebException exception = await Assert.ThrowsAsync<DicomWebException>(() => _client.StoreAsync(new[] { dicomFile1 }));
+            DicomWebException exception = await Assert.ThrowsAsync<DicomWebException>(() => _instancesManager.StoreAsync(new[] { dicomFile1 }));
 
             Assert.Equal(HttpStatusCode.Conflict, exception.StatusCode);
 
@@ -353,7 +357,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             var studyInstanceUID = TestUidGenerator.Generate();
             DicomFile dicomFile = Samples.CreateRandomDicomFile(studyInstanceUid: studyInstanceUID);
 
-            using DicomWebResponse<DicomDataset> response = await _client.StoreAsync(dicomFile, studyInstanceUid: studyInstanceUID);
+            using DicomWebResponse<DicomDataset> response = await _instancesManager.StoreAsync(dicomFile, studyInstanceUid: studyInstanceUID);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
@@ -364,6 +368,12 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
                 yield return new object[] { "application/dicom" };
                 yield return new object[] { "application/data" };
             }
+        }
+        public Task InitializeAsync() => Task.CompletedTask;
+
+        public async Task DisposeAsync()
+        {
+            await _instancesManager.DisposeAsync();
         }
 
         private (string SopInstanceUid, string RetrieveUri, string SopClassUid) ConvertToReferencedSopSequenceEntry(DicomDataset dicomDataset)

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/StoreTransactionTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/StoreTransactionTests.cs
@@ -13,7 +13,6 @@ using System.Threading.Tasks;
 using Dicom;
 using EnsureThat;
 using Microsoft.Health.Dicom.Client;
-using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Tests.Common;
 using Microsoft.Health.Dicom.Web.Tests.E2E.Common;
 using Microsoft.IO;
@@ -139,7 +138,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
                     multiContent.Add(validByteContent);
                 }
 
-                using DicomWebResponse<DicomDataset> response = await _instancesManager.StoreAsync(multiContent, instanceId: DicomInstanceId.FromInstanceIdentifier(validFile.Dataset.ToInstanceIdentifier()));
+                using DicomWebResponse<DicomDataset> response = await _instancesManager.StoreAsync(multiContent, instanceId: DicomInstanceId.FromDicomFile(validFile));
 
                 Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
@@ -173,7 +172,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
                     multiContent.Add(byteContent);
                 }
 
-                using DicomWebResponse<DicomDataset> response = await _instancesManager.StoreAsync(multiContent, instanceId: DicomInstanceId.FromInstanceIdentifier(dicomFile.Dataset.ToInstanceIdentifier()));
+                using DicomWebResponse<DicomDataset> response = await _instancesManager.StoreAsync(multiContent, instanceId: DicomInstanceId.FromDicomFile(dicomFile));
 
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
@@ -347,7 +346,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             await using MemoryStream stream = _recyclableMemoryStreamManager.GetStream();
             await dicomFile.SaveAsync(stream);
 
-            using DicomWebResponse<DicomDataset> response = await _client.StoreAsync(stream);
+            using DicomWebResponse<DicomDataset> response = await _instancesManager.StoreAsync(stream, instanceId: DicomInstanceId.FromDicomFile(dicomFile));
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 


### PR DESCRIPTION
## Description
Cleanup test dicom instances after tests complete 

## Related issues
Addresses [AB#85819](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/85819)

## Testing
Locally tests verify no test instances after test complets
