### PR TITLE
Update Microsoft.Health.Dicom.Functions to dotnet pack.

### DIFF
--- a/Microsoft.Health.Dicom.sln
+++ b/Microsoft.Health.Dicom.sln
@@ -53,6 +53,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{176641B3-297
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{8C9A0050-5D22-4398-9F93-DDCD80B3BA51}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Dicom.Functions.Hosting", "src\Microsoft.Health.Dicom.Functions.Hosting\Microsoft.Health.Dicom.Functions.Hosting.csproj", "{31206C5A-76F0-412E-8ADF-CD4604AEA5CB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -135,6 +137,10 @@ Global
 		{1D0ECFDA-2AF2-4796-995D-A7C6E18C9CD1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1D0ECFDA-2AF2-4796-995D-A7C6E18C9CD1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1D0ECFDA-2AF2-4796-995D-A7C6E18C9CD1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{31206C5A-76F0-412E-8ADF-CD4604AEA5CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{31206C5A-76F0-412E-8ADF-CD4604AEA5CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{31206C5A-76F0-412E-8ADF-CD4604AEA5CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{31206C5A-76F0-412E-8ADF-CD4604AEA5CB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -158,6 +164,7 @@ Global
 		{ECC018C1-BFA8-44BE-B560-ACB05CA57251} = {176641B3-297C-4E04-A83D-8F80F80485E8}
 		{BFB96311-9B1A-41C1-ABF1-4F6522660084} = {176641B3-297C-4E04-A83D-8F80F80485E8}
 		{1D0ECFDA-2AF2-4796-995D-A7C6E18C9CD1} = {8C9A0050-5D22-4398-9F93-DDCD80B3BA51}
+		{31206C5A-76F0-412E-8ADF-CD4604AEA5CB} = {176641B3-297C-4E04-A83D-8F80F80485E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		RESX_SortFileContentOnSave = True

--- a/build/deploy.yml
+++ b/build/deploy.yml
@@ -74,5 +74,5 @@ jobs:
       azureSubscription: $(azureSubscriptionName)
       webAppKind: 'functionApp'
       webAppName: '$(deploymentName)-functions'
-      package: '$(System.ArtifactsDirectory)/deploy/Microsoft.Health.Dicom.Functions.zip'
+      package: '$(System.ArtifactsDirectory)/deploy/Microsoft.Health.Dicom.Functions.Hosting.zip'
       takeAppOfflineFlag: true

--- a/build/package.yml
+++ b/build/package.yml
@@ -14,7 +14,7 @@ steps:
     displayName: 'dotnet publish functions'
     inputs:
       command: publish
-      projects: '**/Microsoft.Health.Dicom.Functions.csproj'
+      projects: '**/Microsoft.Health.Dicom.Functions.Hosting.csproj'
       arguments: '--configuration $(buildConfiguration) --output $(build.artifactStagingDirectory)/functions --no-build'
       publishWebProjects: false
 
@@ -26,7 +26,7 @@ steps:
       arguments: '--configuration $(buildConfiguration) --output "$(build.binariesdirectory)/IntegrationTests" --no-build'
       publishWebProjects: false
       zipAfterPublish: false
- 
+
   # Publish artifacts
 
   - task: PublishBuildArtifacts@1

--- a/samples/templates/default-azuredeploy.json
+++ b/samples/templates/default-azuredeploy.json
@@ -211,7 +211,7 @@
         "storageResourceId": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
         "keyVaultResourceId": "[resourceId('Microsoft.KeyVault/vaults', variables('serviceName'))]",
         "defaultWebDeployPackageUrl": "https://dcmcistorage.blob.core.windows.net/cibuild/Microsoft.Health.Dicom.Web.zip",
-        "defaultFunctionAppDeployPackageUrl": "https://dcmcistorage.blob.core.windows.net/cibuild/Microsoft.Health.Dicom.Functions.zip",
+        "defaultFunctionAppDeployPackageUrl": "https://dcmcistorage.blob.core.windows.net/cibuild/Microsoft.Health.Dicom.Functions.Hosting.zip",
         "deployWebPackageUrl": "[if(empty(parameters('deployWebPackageUrl')),variables('defaultWebDeployPackageUrl'),parameters('deployWebPackageUrl'))]",
         "deployFunctionAppPackageUrl": "[if(empty(parameters('deployFunctionAppPackageUrl')),variables('defaultFunctionAppDeployPackageUrl'),parameters('deployFunctionAppPackageUrl'))]",
         "sqlServerConnectionStringName": "SqlServerConnectionString",

--- a/src/Microsoft.Health.Dicom.Functions.Hosting/Microsoft.Health.Dicom.Functions.Hosting.csproj
+++ b/src/Microsoft.Health.Dicom.Functions.Hosting/Microsoft.Health.Dicom.Functions.Hosting.csproj
@@ -4,6 +4,7 @@
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <FunctionsInDependencies>true</FunctionsInDependencies>
     <TargetFramework>net6.0</TargetFramework>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Microsoft.Health.Dicom.Functions.Hosting/Microsoft.Health.Dicom.Functions.Hosting.csproj
+++ b/src/Microsoft.Health.Dicom.Functions.Hosting/Microsoft.Health.Dicom.Functions.Hosting.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <FunctionsInDependencies>true</FunctionsInDependencies>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" PrivateAssets="All" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Health.Dicom.Functions\Microsoft.Health.Dicom.Functions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.Health.Dicom.Functions.Hosting/Microsoft.Health.Dicom.Functions.Hosting.csproj
+++ b/src/Microsoft.Health.Dicom.Functions.Hosting/Microsoft.Health.Dicom.Functions.Hosting.csproj
@@ -18,4 +18,14 @@
     <ProjectReference Include="..\Microsoft.Health.Dicom.Functions\Microsoft.Health.Dicom.Functions.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/src/Microsoft.Health.Dicom.Functions.Hosting/Microsoft.Health.Dicom.Functions.Hosting.csproj
+++ b/src/Microsoft.Health.Dicom.Functions.Hosting/Microsoft.Health.Dicom.Functions.Hosting.csproj
@@ -12,13 +12,19 @@
   </ItemGroup>
   
   <ItemGroup>
+    <PackageReference Include="Ensure.That" Version="10.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.30" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.6.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.12" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" PrivateAssets="All" />
   </ItemGroup>
-  
-  <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Health.Dicom.Functions\Microsoft.Health.Dicom.Functions.csproj" />
-  </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Health.Dicom.Core\Microsoft.Health.Dicom.Core.csproj" />
+    <ProjectReference Include="..\Microsoft.Health.Dicom.Operations\Microsoft.Health.Dicom.Operations.csproj" />
+  </ItemGroup>
+  
   <ItemGroup>
     <None Update="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Microsoft.Health.Dicom.Functions.Hosting/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Health.Dicom.Functions.Hosting/Properties/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Resources;
+
+[assembly: NeutralResourcesLanguage("en-us")]
+[assembly: CLSCompliant(false)]

--- a/src/Microsoft.Health.Dicom.Functions.Hosting/Startup.cs
+++ b/src/Microsoft.Health.Dicom.Functions.Hosting/Startup.cs
@@ -1,0 +1,28 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using EnsureThat;
+using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Health.Dicom.Operations.Configuration;
+
+[assembly: FunctionsStartup(typeof(Microsoft.Health.Dicom.Functions.Startup))]
+namespace Microsoft.Health.Dicom.Functions
+{
+    public class Startup : FunctionsStartup
+    {
+        public override void Configure(IFunctionsHostBuilder builder)
+        {
+            EnsureArg.IsNotNull(builder, nameof(builder));
+
+            IConfiguration config = builder.GetHostConfiguration();
+            builder.Services
+                .ConfigureFunctions(config)
+                .AddMetadataStorageDataStore(config)
+                .AddSqlServer(config);
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Functions.Hosting/host.json
+++ b/src/Microsoft.Health.Dicom.Functions.Hosting/host.json
@@ -1,0 +1,74 @@
+﻿{
+  "version": "2.0",
+  "BlobStore": {
+    "ConnectionString": null,
+    "Containers": {
+      "Metadata": "metadatacontainer"
+    },
+    "Initialization": {
+      "RetryDelay": "00:00:15",
+      "Timeout": "00:06:00"
+    },
+    "Operations": {
+      "Download": {
+        "MaximumConcurrency": 5
+      },
+      "Upload": {
+        "MaximumConcurrency": 5
+      }
+    },
+    "Retry": {
+      "Delay": "00:00:04",
+      "MaxRetries": 6,
+      "Mode": "Exponential",
+      "NetworkTimeout": "00:02:00"
+    }
+  },
+  "DicomFunctions": {
+    "Indexing": {
+      "BatchSize": 100,
+      "BatchThreadCount": 5,
+      "MaxParallelBatches": 10,
+      "RetryOptions": {
+        "BackoffCoefficient": 3,
+        "FirstRetryInterval": "00:01:00",
+        "MaxNumberOfAttempts": 4
+      }
+    },
+    "PurgeHistory": {
+      "Frequency": "0 0 * * *",
+      "MinimumAgeDays": 14,
+      "RuntimeStatuses": [ "Completed" ]
+    }
+  },
+  "extensions": {
+    "durableTask": {
+      "hubName": "DicomTaskHub"
+    }
+  },
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Azure.Core": "Warning",
+      "Default": "Information",
+      "DurableTask": "Warning",
+      "Host": "Warning",
+      "Worker": "Warning"
+    },
+    "ApplicationInsights": {
+      "LogLevel": {
+        "Microsoft.Health": "Information",
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
+    }
+  },
+  "SqlServer": {
+    "TransientFaultRetryPolicy": {
+      "InitialDelay": "00:00:00.100",
+      "RetryCount": 3,
+      "Factor": 2,
+      "FastFirst": true
+    }
+  }
+}

--- a/src/Microsoft.Health.Dicom.Functions.Hosting/local.settings.json
+++ b/src/Microsoft.Health.Dicom.Functions.Hosting/local.settings.json
@@ -1,0 +1,8 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureFunctionsJobHost__SqlServer__ConnectionString": "server=(local);Initial Catalog=Dicom;Integrated Security=true;TrustServerCertificate=true",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet"
+  }
+}

--- a/src/Microsoft.Health.Dicom.Functions/Microsoft.Health.Dicom.Functions.csproj
+++ b/src/Microsoft.Health.Dicom.Functions/Microsoft.Health.Dicom.Functions.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.30" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="4.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.6.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.12" />
   </ItemGroup>

--- a/src/Microsoft.Health.Dicom.Functions/Microsoft.Health.Dicom.Functions.csproj
+++ b/src/Microsoft.Health.Dicom.Functions/Microsoft.Health.Dicom.Functions.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.30" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="4.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.6.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.12" />
   </ItemGroup>

--- a/src/Microsoft.Health.Dicom.Functions/Microsoft.Health.Dicom.Functions.csproj
+++ b/src/Microsoft.Health.Dicom.Functions/Microsoft.Health.Dicom.Functions.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.30" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.6.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.12" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
By having a reference to `Microsoft.NET.Sdk.Functions` the `Microsoft.Health.Dicom.Functions` project will not pack into a nuget. This will cause any downstream dependency on `Microsoft.Health.Dicom.Web.Tests.E2E` to not restore properly since a dependency cannot be resolved.

## Related issues
Addresses [AB#87579](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/87579).

## Testing
Manually ran `dotnet pack` against `Microsoft.Health.Dicom.Functions`