### PR TITLE
Set typeNameHandling to none for Newtonsoft deserialize.

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Microsoft.Health.Dicom.Api.csproj
+++ b/src/Microsoft.Health.Dicom.Api/Microsoft.Health.Dicom.Api.csproj
@@ -25,7 +25,6 @@
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.15.0" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.2.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Scrutor" Version="3.3.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.2.3" />

--- a/src/Microsoft.Health.Dicom.Client/DicomWebClient.cs
+++ b/src/Microsoft.Health.Dicom.Client/DicomWebClient.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Health.Dicom.Client
             HttpClient = httpClient;
             _apiVersion = apiVersion;
             _jsonSerializerSettings = new JsonSerializerSettings();
+            _jsonSerializerSettings.TypeNameHandling = TypeNameHandling.None;
             _jsonSerializerSettings.Converters.Add(new JsonDicomConverter(writeTagsAsKeywords: true, autoValidate: false));
 
             // Used by extended query tag apis

--- a/src/Microsoft.Health.Dicom.Core/Microsoft.Health.Dicom.Core.csproj
+++ b/src/Microsoft.Health.Dicom.Core/Microsoft.Health.Dicom.Core.csproj
@@ -27,7 +27,6 @@
     <PackageReference Include="Microsoft.Health.Core" Version="$(HealthcareSharedPackageVersion)" />
     <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="$(HealthcareSharedPackageVersion)" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Scrutor" Version="3.3.0" />
   </ItemGroup>
 

--- a/src/Microsoft.Health.Dicom.Operations.Client/Microsoft.Health.Dicom.Operations.Client.csproj
+++ b/src/Microsoft.Health.Dicom.Operations.Client/Microsoft.Health.Dicom.Operations.Client.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(SdkPackageVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
Safe type handling of deserialization 

## Related issues
AB#12694155.

