### PR TITLE
Fix Dependabot Alert

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,3 +73,11 @@ updates:
       time: "09:00"
       timezone: "America/Los_Angeles"
     open-pull-requests-limit: 30
+
+  - package-ecosystem: "npm"
+    directory: "/tools/dicom-web-electron"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 30

--- a/tools/dicom-web-electron/package-lock.json
+++ b/tools/dicom-web-electron/package-lock.json
@@ -1648,8 +1648,8 @@
     },
     "node_modules/follow-redirects": {
       "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-      "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
       "funding": [
         {
           "type": "individual",


### PR DESCRIPTION
## Description
As per the [alert] (https://github.com/microsoft/dicom-server/security/dependabot/tools/dicom-web-electron/package-lock.json/follow-redirects/open), follows-redirect version has been updated to 1.14.7.