### PR TITLE
Fix for Dependabot Alert.

### DIFF
--- a/tools/dicom-web-electron/package-lock.json
+++ b/tools/dicom-web-electron/package-lock.json
@@ -557,7 +557,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
       "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": ">=1.14.7"
       }
     },
     "node_modules/balanced-match": {
@@ -1647,7 +1647,7 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.4",
+      "version": "1.14.7",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
       "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
       "funding": [
@@ -3906,7 +3906,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
       "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": ">=1.14.7"
       }
     },
     "balanced-match": {
@@ -4757,9 +4757,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-      "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA=="
     },
     "form-data": {
       "version": "4.0.0",

--- a/tools/dicom-web-electron/package-lock.json
+++ b/tools/dicom-web-electron/package-lock.json
@@ -4759,7 +4759,7 @@
     "follow-redirects": {
       "version": "1.14.7",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA=="
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
     },
     "form-data": {
       "version": "4.0.0",


### PR DESCRIPTION
## Description
Updating remaining follow-redirect dependencies in order to resolve the dependabot security alert.

## Related issues
[AB#87864](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/87864).