### PR TITLE
Centralize and Expand Json Serializer Options

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
@@ -5,9 +5,7 @@
 
 using System;
 using System.Reflection;
-using System.Text.Json;
 using EnsureThat;
-using FellowOakDicom.Serialization;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
@@ -32,7 +30,6 @@ using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Core.Features.Context;
 using Microsoft.Health.Dicom.Core.Features.Routing;
 using Microsoft.Health.Dicom.Core.Registration;
-using Microsoft.Health.Dicom.Core.Serialization;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.IO;
 using Swashbuckle.AspNetCore.SwaggerGen;
@@ -109,13 +106,7 @@ namespace Microsoft.AspNetCore.Builder
                     options.EnableEndpointRouting = false;
                     options.RespectBrowserAcceptHeader = true;
                 })
-                .AddJsonSerializerOptions(o =>
-                {
-                    o.Converters.Add(new StrictStringEnumConverterFactory());
-                    o.Converters.Add(new DicomJsonConverter(writeTagsAsKeywords: false));
-                    o.PropertyNameCaseInsensitive = true;
-                    o.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
-                });
+                .AddJsonSerializerOptions(o => o.ConfigureDefaultDicomSettings());
 
             services.AddApiVersioning(c =>
             {

--- a/src/Microsoft.Health.Dicom.Client/DicomWebClient.cs
+++ b/src/Microsoft.Health.Dicom.Client/DicomWebClient.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Health.Dicom.Client
             _apiVersion = apiVersion;
             _jsonSerializerOptions = new JsonSerializerOptions
             {
-                AllowTrailingCommas = false,
+                AllowTrailingCommas = true,
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
                 DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
                 Encoder = null,
@@ -54,7 +54,7 @@ namespace Microsoft.Health.Dicom.Client
                 NumberHandling = JsonNumberHandling.Strict,
                 PropertyNameCaseInsensitive = true,
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                ReadCommentHandling = JsonCommentHandling.Disallow,
+                ReadCommentHandling = JsonCommentHandling.Skip,
                 WriteIndented = false,
             };
 

--- a/src/Microsoft.Health.Dicom.Client/DicomWebClient.cs
+++ b/src/Microsoft.Health.Dicom.Client/DicomWebClient.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Health.Dicom.Client
                 IgnoreReadOnlyFields = false,
                 IgnoreReadOnlyProperties = false,
                 IncludeFields = false,
-                MaxDepth = 0,
+                MaxDepth = 0, // 0 indicates the max depth of 64
                 NumberHandling = JsonNumberHandling.Strict,
                 PropertyNameCaseInsensitive = true,
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,

--- a/src/Microsoft.Health.Dicom.Client/DicomWebClient.cs
+++ b/src/Microsoft.Health.Dicom.Client/DicomWebClient.cs
@@ -43,8 +43,19 @@ namespace Microsoft.Health.Dicom.Client
             _apiVersion = apiVersion;
             _jsonSerializerOptions = new JsonSerializerOptions
             {
+                AllowTrailingCommas = false,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+                DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
+                Encoder = null,
+                IgnoreReadOnlyFields = false,
+                IgnoreReadOnlyProperties = false,
+                IncludeFields = false,
+                MaxDepth = 0,
+                NumberHandling = JsonNumberHandling.Strict,
                 PropertyNameCaseInsensitive = true,
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                ReadCommentHandling = JsonCommentHandling.Disallow,
+                WriteIndented = false,
             };
 
             _jsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Extensions/JsonSerializerOptionsExtensionsTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Extensions/JsonSerializerOptionsExtensionsTests.cs
@@ -3,8 +3,10 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using FellowOakDicom;
 using FellowOakDicom.Serialization;
 using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Core.Serialization;
@@ -14,29 +16,189 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Extensions
 {
     public class JsonSerializerOptionsExtensionsTests
     {
+        private readonly JsonSerializerOptions _options;
+
+        public JsonSerializerOptionsExtensionsTests()
+        {
+            _options = new JsonSerializerOptions();
+            _options.ConfigureDefaultDicomSettings();
+        }
+
         [Fact]
         public void GivenOptions_WhenConfiguringDefaults_ThenUpdateProperties()
         {
-            var actual = new JsonSerializerOptions();
-            actual.ConfigureDefaultDicomSettings();
+            Assert.Equal(2, _options.Converters.Count);
+            Assert.Equal(typeof(StrictStringEnumConverterFactory), _options.Converters[0].GetType());
+            Assert.Equal(typeof(DicomJsonConverter), _options.Converters[1].GetType());
 
-            Assert.Equal(2, actual.Converters.Count);
-            Assert.Equal(typeof(StrictStringEnumConverterFactory), actual.Converters[0].GetType());
-            Assert.Equal(typeof(DicomJsonConverter), actual.Converters[1].GetType());
+            Assert.True(_options.AllowTrailingCommas);
+            Assert.Equal(JsonIgnoreCondition.WhenWritingNull, _options.DefaultIgnoreCondition);
+            Assert.Equal(JsonNamingPolicy.CamelCase, _options.DictionaryKeyPolicy);
+            Assert.Null(_options.Encoder);
+            Assert.False(_options.IgnoreReadOnlyFields);
+            Assert.False(_options.IgnoreReadOnlyProperties);
+            Assert.False(_options.IncludeFields);
+            Assert.Equal(0, _options.MaxDepth);
+            Assert.Equal(JsonNumberHandling.Strict, _options.NumberHandling);
+            Assert.True(_options.PropertyNameCaseInsensitive);
+            Assert.Equal(JsonNamingPolicy.CamelCase, _options.PropertyNamingPolicy);
+            Assert.Equal(JsonCommentHandling.Skip, _options.ReadCommentHandling);
+            Assert.False(_options.WriteIndented);
+        }
 
-            Assert.False(actual.AllowTrailingCommas);
-            Assert.Equal(JsonIgnoreCondition.WhenWritingNull, actual.DefaultIgnoreCondition);
-            Assert.Equal(JsonNamingPolicy.CamelCase, actual.DictionaryKeyPolicy);
-            Assert.Null(actual.Encoder);
-            Assert.False(actual.IgnoreReadOnlyFields);
-            Assert.False(actual.IgnoreReadOnlyProperties);
-            Assert.False(actual.IncludeFields);
-            Assert.Equal(0, actual.MaxDepth);
-            Assert.Equal(JsonNumberHandling.Strict, actual.NumberHandling);
-            Assert.True(actual.PropertyNameCaseInsensitive);
-            Assert.Equal(JsonNamingPolicy.CamelCase, actual.PropertyNamingPolicy);
-            Assert.Equal(JsonCommentHandling.Disallow, actual.ReadCommentHandling);
-            Assert.False(actual.WriteIndented);
+        [Fact]
+        public void GivenSerializationOptions_WhenDeserializingNumbers_ThenAcceptOnlyNumberTokens()
+        {
+            // PascalCase + trailing comma too!
+            const string json = @"
+{
+  ""Word"": ""Hello"",
+  ""Number"": 123,
+}
+";
+
+            Example actual = JsonSerializer.Deserialize<Example>(json, _options);
+            Assert.Equal("Hello", actual.Word);
+            Assert.Equal(123, actual.Number);
+
+            // Invalid
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Example>(@"
+{
+  ""Word"": ""World"",
+  ""Number"": ""456"",
+}
+",
+                _options));
+        }
+
+        [Theory]
+        [InlineData("50", 50)]
+        [InlineData("50.0", 50)]
+        [InlineData("\"50\"", 50)]
+        [InlineData("-1.23e4", -1.23e4)]
+        [InlineData("\"-1.23e4\"", -1.23e4)]
+        public void GivenSerializationOptions_WhenDeserializingDsVr_ThenAcceptEitherTokenKind(string weightJson, decimal expected)
+        {
+            string json = @$"
+{{
+  ""00101030"":{{
+    ""vr"":""DS"",
+    ""Value"":[
+      {weightJson}
+    ]
+  }}
+}}
+";
+            DicomDataset actual = JsonSerializer.Deserialize<DicomDataset>(json, _options);
+            Assert.Equal(expected, actual.GetValue<decimal>(DicomTag.PatientWeight, 0));
+        }
+
+        [Fact]
+        public void GivenSerializationOptions_WhenDeserializingDicomComments_ThenSkipThem()
+        {
+            const string json = @"
+{
+  // Study Date
+  ""00080020"":{
+    ""vr"":""DA"", // Date
+    ""Value"":[
+      ""20080701""
+    ]
+  },
+  // Modality
+  ""00080060"":{
+    ""vr"":""CS"", // Code String
+    ""Value"":[
+      ""XRAY""
+    ]
+  },
+}
+";
+
+            DicomDataset actual = JsonSerializer.Deserialize<DicomDataset>(json, _options);
+            Assert.Equal(new DateTime(2008, 07, 01), actual.GetValue<DateTime>(DicomTag.StudyDate, 0));
+            Assert.Equal("XRAY", actual.GetValue<string>(DicomTag.Modality, 0));
+        }
+
+        [Fact]
+        public void GivenSerializationOptions_WhenDeserializingCustomComments_ThenSkipThem()
+        {
+            const string json = @"
+{
+  // Comment one
+  ""Word"": ""Foo Bar"", // Comment two
+  ""Number"": 789,
+  // Comment three
+}
+";
+
+            _options.Converters.Add(new CommentlessConverter());
+            Example ex = JsonSerializer.Deserialize<Example>(json, _options);
+            Assert.Equal("Foo Bar", ex.Word);
+            Assert.Equal(789, ex.Number);
+        }
+
+        private sealed class Example
+        {
+            public string Word { get; set; }
+
+            public int Number { get; set; }
+        }
+
+        private sealed class CommentlessConverter : JsonConverter<Example>
+        {
+            public override Example Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TokenType != JsonTokenType.StartObject)
+                {
+                    throw new JsonException();
+                }
+
+                StringComparison comparison = options.PropertyNameCaseInsensitive
+                    ? StringComparison.OrdinalIgnoreCase
+                    : StringComparison.Ordinal;
+
+                var example = new Example();
+                while (reader.Read())
+                {
+                    switch (reader.TokenType)
+                    {
+                        case JsonTokenType.PropertyName:
+                            // Get property name
+                            string name = reader.GetString();
+                            if (!reader.Read())
+                            {
+                                throw new JsonException();
+                            }
+
+                            // Assign property
+                            if (string.Equals(name, nameof(Example.Word), comparison))
+                            {
+                                example.Word = reader.GetString();
+                            }
+                            else if (string.Equals(name, nameof(Example.Number), comparison))
+                            {
+                                example.Number = reader.GetInt32();
+                            }
+                            else
+                            {
+                                throw new JsonException();
+                            }
+                            break;
+                        case JsonTokenType.EndObject:
+                            return example;
+                        default:
+                            throw new JsonException();
+                    }
+                }
+
+                throw new JsonException();
+            }
+
+            public override void Write(Utf8JsonWriter writer, Example value, JsonSerializerOptions options)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Extensions/JsonSerializerOptionsExtensionsTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Extensions/JsonSerializerOptionsExtensionsTests.cs
@@ -1,0 +1,42 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FellowOakDicom.Serialization;
+using Microsoft.Health.Dicom.Core.Extensions;
+using Microsoft.Health.Dicom.Core.Serialization;
+using Xunit;
+
+namespace Microsoft.Health.Dicom.Core.UnitTests.Extensions
+{
+    public class JsonSerializerOptionsExtensionsTests
+    {
+        [Fact]
+        public void GivenOptions_WhenConfiguringDefaults_ThenUpdateProperties()
+        {
+            var actual = new JsonSerializerOptions();
+            actual.ConfigureDefaultDicomSettings();
+
+            Assert.Equal(2, actual.Converters.Count);
+            Assert.Equal(typeof(StrictStringEnumConverterFactory), actual.Converters[0].GetType());
+            Assert.Equal(typeof(DicomJsonConverter), actual.Converters[1].GetType());
+
+            Assert.False(actual.AllowTrailingCommas);
+            Assert.Equal(JsonIgnoreCondition.WhenWritingNull, actual.DefaultIgnoreCondition);
+            Assert.Equal(JsonNamingPolicy.CamelCase, actual.DictionaryKeyPolicy);
+            Assert.Null(actual.Encoder);
+            Assert.False(actual.IgnoreReadOnlyFields);
+            Assert.False(actual.IgnoreReadOnlyProperties);
+            Assert.False(actual.IncludeFields);
+            Assert.Equal(0, actual.MaxDepth);
+            Assert.Equal(JsonNumberHandling.Strict, actual.NumberHandling);
+            Assert.True(actual.PropertyNameCaseInsensitive);
+            Assert.Equal(JsonNamingPolicy.CamelCase, actual.PropertyNamingPolicy);
+            Assert.Equal(JsonCommentHandling.Disallow, actual.ReadCommentHandling);
+            Assert.False(actual.WriteIndented);
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Core/Extensions/JsonSerializerOptionsExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Extensions/JsonSerializerOptionsExtensions.cs
@@ -1,0 +1,49 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using EnsureThat;
+using FellowOakDicom.Serialization;
+using Microsoft.Health.Dicom.Core.Serialization;
+
+namespace Microsoft.Health.Dicom.Core.Extensions
+{
+    /// <summary>
+    /// Provides <see langword="static"/> methods configuring <see cref="JsonSerializerOptions"/>.
+    /// </summary>
+    public static class JsonSerializerOptionsExtensions
+    {
+        /// <summary>
+        /// Configures an instance of <see cref="JsonSerializerOptions"/> for usage within
+        /// the DICOM server and related services.
+        /// </summary>
+        /// <param name="options">A set of existing options.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="options"/> is <see langword="null"/>.</exception>
+        public static void ConfigureDefaultDicomSettings(this JsonSerializerOptions options)
+        {
+            EnsureArg.IsNotNull(options, nameof(options));
+
+            options.Converters.Clear();
+            options.Converters.Add(new StrictStringEnumConverterFactory());
+            options.Converters.Add(new DicomJsonConverter(writeTagsAsKeywords: false));
+
+            options.AllowTrailingCommas = false;
+            options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+            options.DictionaryKeyPolicy = JsonNamingPolicy.CamelCase;
+            options.Encoder = null;
+            options.IgnoreReadOnlyFields = false;
+            options.IgnoreReadOnlyProperties = false;
+            options.IncludeFields = false;
+            options.MaxDepth = 0;
+            options.NumberHandling = JsonNumberHandling.Strict;
+            options.PropertyNameCaseInsensitive = true;
+            options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+            options.ReadCommentHandling = JsonCommentHandling.Disallow;
+            options.WriteIndented = false;
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Core/Extensions/JsonSerializerOptionsExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Extensions/JsonSerializerOptionsExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Health.Dicom.Core.Extensions
             options.IgnoreReadOnlyFields = false;
             options.IgnoreReadOnlyProperties = false;
             options.IncludeFields = false;
-            options.MaxDepth = 0;
+            options.MaxDepth = 0; // 0 indicates the max depth of 64
             options.NumberHandling = JsonNumberHandling.Strict;
             options.PropertyNameCaseInsensitive = true;
             options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;

--- a/src/Microsoft.Health.Dicom.Core/Extensions/JsonSerializerOptionsExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Extensions/JsonSerializerOptionsExtensions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Dicom.Core.Extensions
             options.Converters.Add(new StrictStringEnumConverterFactory());
             options.Converters.Add(new DicomJsonConverter(writeTagsAsKeywords: false));
 
-            options.AllowTrailingCommas = false;
+            options.AllowTrailingCommas = true;
             options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
             options.DictionaryKeyPolicy = JsonNamingPolicy.CamelCase;
             options.Encoder = null;
@@ -42,7 +42,7 @@ namespace Microsoft.Health.Dicom.Core.Extensions
             options.NumberHandling = JsonNumberHandling.Strict;
             options.PropertyNameCaseInsensitive = true;
             options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
-            options.ReadCommentHandling = JsonCommentHandling.Disallow;
+            options.ReadCommentHandling = JsonCommentHandling.Skip;
             options.WriteIndented = false;
         }
     }

--- a/src/Microsoft.Health.Dicom.Operations/Registration/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Operations/Registration/ServiceCollectionExtensions.cs
@@ -5,16 +5,15 @@
 
 using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using EnsureThat;
 using FellowOakDicom;
-using FellowOakDicom.Serialization;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Health.Blob.Configs;
 using Microsoft.Health.Dicom.Core.Configs;
+using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Core.Modules;
 using Microsoft.Health.Dicom.Core.Registration;
 using Microsoft.Health.Dicom.Operations.Configuration;
@@ -55,13 +54,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddFellowOakDicomExtension()
                 .AddFunctionsOptions<QueryTagIndexingOptions>(configuration, QueryTagIndexingOptions.SectionName, bindNonPublicProperties: true)
                 .AddFunctionsOptions<PurgeHistoryOptions>(configuration, PurgeHistoryOptions.SectionName)
-                .AddJsonSerializerOptions(o =>
-                {
-                    o.Converters.Add(new JsonStringEnumConverter());
-                    o.Converters.Add(new DicomJsonConverter(writeTagsAsKeywords: false));
-                    o.PropertyNameCaseInsensitive = true;
-                    o.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
-                }));
+                .AddJsonSerializerOptions(o => o.ConfigureDefaultDicomSettings()));
         }
 
         /// <summary>
@@ -120,7 +113,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             EnsureArg.IsNotNull(services, nameof(services));
 
-            services.AddFellowOakDicomServices(skipValidation: true);
+            // Note: Fellow Oak Services have already been added as part of the ServiceModule
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IExtensionConfigProvider, FellowOakExtensionConfiguration>());
 
             return services;

--- a/src/Microsoft.Health.Dicom.Tests.Common/Serialization/AppSerializerOptions.cs
+++ b/src/Microsoft.Health.Dicom.Tests.Common/Serialization/AppSerializerOptions.cs
@@ -4,7 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Text.Json;
-using FellowOakDicom.Serialization;
+using Microsoft.Health.Dicom.Core.Extensions;
 
 namespace Microsoft.Health.Dicom.Tests.Common.Serialization
 {
@@ -14,13 +14,8 @@ namespace Microsoft.Health.Dicom.Tests.Common.Serialization
 
         private static JsonSerializerOptions CreateJsonSerializerOptions()
         {
-            var options = new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true,
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            };
-
-            options.Converters.Add(new DicomJsonConverter(writeTagsAsKeywords: false));
+            var options = new JsonSerializerOptions();
+            options.ConfigureDefaultDicomSettings();
 
             return options;
         }


### PR DESCRIPTION
## Description
- Expand the set of specified JSON serializer options for stricter API contracts
- Centralize the options for consistent rules across services

## Related issues
N/A

## Testing
Pipeline + New tests
