### PR TITLE
Remove old SQL client(system.Data.SqlClient) package reference

### DIFF
--- a/src/Microsoft.Health.Dicom.SqlServer/Microsoft.Health.Dicom.SqlServer.csproj
+++ b/src/Microsoft.Health.Dicom.SqlServer/Microsoft.Health.Dicom.SqlServer.csproj
@@ -28,7 +28,6 @@
     <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="Scrutor" Version="3.3.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Microsoft.Health.Dicom.Tests.Integration.csproj
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Microsoft.Health.Dicom.Tests.Integration.csproj
@@ -28,7 +28,8 @@
     <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="Microsoft.SqlServer.DACFx" Version="160.5400.1" /> </ItemGroup>
+    <PackageReference Include="Microsoft.SqlServer.DACFx" Version="160.5400.1" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Health.Dicom.Blob\Microsoft.Health.Dicom.Blob.csproj" />

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Microsoft.Health.Dicom.Tests.Integration.csproj
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Microsoft.Health.Dicom.Tests.Integration.csproj
@@ -30,7 +30,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <!-- TODO: Replace with stable version once available. Preview needed to fix issue in .NET 6 -->
     <PackageReference Include="Microsoft.SqlServer.DACFx" Version="160.5332.1-preview" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
It is replaced already with the new Microsoft.Data.SqlClient

## Related issues
[AB#88198](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/88198)

## Testing
Existing tests pass
