### PR TITLE
Treat the "Implicit VR not allowed" validation failure as "Warning"

### DIFF
--- a/docs/resources/conformance-statement.md
+++ b/docs/resources/conformance-statement.md
@@ -156,6 +156,7 @@ An example response with `Accept` header `application/dicom+json`:
 | 43265 | The provided instance StudyInstanceUID did not match the specified StudyInstanceUID in the store request. |
 | 45070 | A DICOM instance with the same StudyInstanceUID, SeriesInstanceUID and SopInstanceUID has already been stored. If you wish to update the contents, delete this instance first. |
 | 45071 | A DICOM instance is being created by another process, or the previous attempt to create has failed and the cleanup process has not had chance to clean up yet. Please delete the instance first before attempting to create again. |
+| 45063 | A DICOM instance Data Set does not match SOP Class. The Studies Store Transaction (Section 10.5) observed that the Data Set did not match the constraints of the SOP Class during storage of the instance. |
 
 ## Retrieve (WADO-RS)
 

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/DicomStoreServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/DicomStoreServiceTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Store
 
             await ExecuteAndValidateAsync(dicomInstanceEntry);
 
-            _storeResponseBuilder.Received(1).AddSuccess(_dicomDataset1);
+            _storeResponseBuilder.Received(1).AddSuccess(_dicomDataset1, Arg.Is<ushort?>(v => v.Value == FailureReasonCodes.DataSetDoesNotMatchSOPClass));
             _storeResponseBuilder.DidNotReceiveWithAnyArgs().AddFailure(default);
         }
 
@@ -180,7 +180,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Store
 
             await ExecuteAndValidateAsync(dicomInstanceEntryToSucceed, dicomInstanceEntryToFail);
 
-            _storeResponseBuilder.Received(1).AddSuccess(_dicomDataset1);
+            _storeResponseBuilder.Received(0).AddSuccess(_dicomDataset1);
             _storeResponseBuilder.Received(1).AddFailure(_dicomDataset2, TestConstants.ProcessingFailureReasonCode);
         }
 

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/StoreDatasetValidatorTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/StoreDatasetValidatorTests.cs
@@ -69,13 +69,15 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Store
 
         [Theory]
         [MemberData(nameof(GetNonExplicitVRTransferSyntax))]
-        public async Task GivenAValidDicomDatasetWithImplicitVR_WhenValidated_ThenItShouldThrowNotAcceptableException(DicomTransferSyntax transferSyntax)
+        public async Task GivenAValidDicomDatasetWithImplicitVR_WhenValidated_ReturnsFalse(DicomTransferSyntax transferSyntax)
         {
             var dicomDataset = Samples
                 .CreateRandomInstanceDataset(dicomTransferSyntax: transferSyntax)
                 .NotValidated();
 
-            await Assert.ThrowsAsync<NotAcceptableException>(() => _dicomDatasetValidator.ValidateAsync(dicomDataset, requiredStudyInstanceUid: null));
+            var actual = await _dicomDatasetValidator.ValidateAsync(dicomDataset, requiredStudyInstanceUid: null);
+
+            Assert.False(actual);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Validation/ImplicitValueRepresentationValidatorTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Validation/ImplicitValueRepresentationValidatorTests.cs
@@ -5,7 +5,6 @@
 
 using System.Collections.Generic;
 using FellowOakDicom;
-using Microsoft.Health.Dicom.Core.Exceptions;
 using Microsoft.Health.Dicom.Core.Features.Validation;
 using Microsoft.Health.Dicom.Tests.Common;
 using Xunit;
@@ -16,24 +15,24 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Validation
     {
         [Theory]
         [MemberData(nameof(GetExplicitVRTransferSyntax))]
-        public void GivenDicomDatasetWithNonImplicitVR_WhenValidating_ThenItShouldSucceed(DicomTransferSyntax transferSyntax)
+        public void GivenDicomDatasetWithNonImplicitVR_WhenValidating_ReturnsTrue(DicomTransferSyntax transferSyntax)
         {
             var dicomDataset = Samples
                 .CreateRandomInstanceDataset(dicomTransferSyntax: transferSyntax)
                 .NotValidated();
 
-            ImplicitValueRepresentationValidator.Validate(dicomDataset);
+            Assert.False(ImplicitValueRepresentationValidator.IsImplicitVR(dicomDataset));
         }
 
         [Theory]
         [MemberData(nameof(GetNonExplicitVRTransferSyntax))]
-        public void GivenDicomDatasetWithImplicitVR_WhenValidating_ThenItShouldThrowNotAcceptableException(DicomTransferSyntax transferSyntax)
+        public void GivenDicomDatasetWithImplicitVR_WhenValidating_ReturnsFalse(DicomTransferSyntax transferSyntax)
         {
             var dicomDataset = Samples
                 .CreateRandomInstanceDataset(dicomTransferSyntax: transferSyntax)
                 .NotValidated();
 
-            Assert.Throws<NotAcceptableException>(() => ImplicitValueRepresentationValidator.Validate(dicomDataset));
+            Assert.True(ImplicitValueRepresentationValidator.IsImplicitVR(dicomDataset));
         }
 
         public static IEnumerable<object[]> GetExplicitVRTransferSyntax()

--- a/src/Microsoft.Health.Dicom.Core/Features/Store/FailureReasonCodes.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Store/FailureReasonCodes.cs
@@ -34,5 +34,13 @@ namespace Microsoft.Health.Dicom.Core.Features.Store
         /// The DICOM instance is being created.
         /// </summary>
         public const ushort PendingSopInstance = 45071;
+
+        /// <summary>
+        /// Data Set does not match SOP Class
+        /// </summary>
+        /// <remarks>
+        /// The Studies Store Transaction (Section 10.5) observed that the Data Set did not match the constraints of the SOP Class during storage of the instance.
+        /// </remarks>
+        public const ushort DataSetDoesNotMatchSOPClass = 45063;
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Store/IStoreDatasetValidator.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Store/IStoreDatasetValidator.cs
@@ -23,6 +23,10 @@ namespace Microsoft.Health.Dicom.Core.Features.Store
         /// </param>
         /// <param name="cancellationToken">The cancellation token</param>
         /// <exception cref="DatasetValidationException">Thrown when the validation fails.</exception>
-        Task ValidateAsync(DicomDataset dicomDataset, string requiredStudyInstanceUid, CancellationToken cancellationToken = default);
+        /// <returns>
+        /// True if there is no warning.
+        /// False if there are any warnings.
+        /// </returns>
+        Task<bool> ValidateAsync(DicomDataset dicomDataset, string requiredStudyInstanceUid, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Store/IStoreResponseBuilder.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Store/IStoreResponseBuilder.cs
@@ -24,14 +24,8 @@ namespace Microsoft.Health.Dicom.Core.Features.Store
         /// Adds a Success entry to the response.
         /// </summary>
         /// <param name="dicomDataset">The DICOM dataset that was successfully stored.</param>
-        void AddSuccess(DicomDataset dicomDataset);
-
-        /// <summary>
-        /// Adds a Warning entry to the response.
-        /// </summary>
-        /// <param name="dicomDataset">The DICOM dataset that was successfully stored.</param>
         /// <param name="warningReasonCode">The warning reason code.</param>
-        void AddWarning(DicomDataset dicomDataset, ushort warningReasonCode);
+        void AddSuccess(DicomDataset dicomDataset, ushort? warningReasonCode = null);
 
         /// <summary>
         /// Adds a failed entry to the response.

--- a/src/Microsoft.Health.Dicom.Core/Features/Store/IStoreResponseBuilder.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Store/IStoreResponseBuilder.cs
@@ -21,10 +21,17 @@ namespace Microsoft.Health.Dicom.Core.Features.Store
         StoreResponse BuildResponse(string studyInstanceUid);
 
         /// <summary>
-        /// Adds a successful entry to the response.
+        /// Adds a Success entry to the response.
         /// </summary>
         /// <param name="dicomDataset">The DICOM dataset that was successfully stored.</param>
         void AddSuccess(DicomDataset dicomDataset);
+
+        /// <summary>
+        /// Adds a Warning entry to the response.
+        /// </summary>
+        /// <param name="dicomDataset">The DICOM dataset that was successfully stored.</param>
+        /// <param name="warningReasonCode">The warning reason code.</param>
+        void AddWarning(DicomDataset dicomDataset, ushort warningReasonCode);
 
         /// <summary>
         /// Adds a failed entry to the response.

--- a/src/Microsoft.Health.Dicom.Core/Features/Store/StoreDatasetValidator.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Store/StoreDatasetValidator.cs
@@ -38,7 +38,8 @@ namespace Microsoft.Health.Dicom.Core.Features.Store
             _queryTagService = queryTagService;
         }
 
-        public async Task ValidateAsync(DicomDataset dicomDataset, string requiredStudyInstanceUid, CancellationToken cancellationToken)
+        /// <inheritdoc/>
+        public async Task<bool> ValidateAsync(DicomDataset dicomDataset, string requiredStudyInstanceUid, CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(dicomDataset, nameof(dicomDataset));
 
@@ -53,13 +54,18 @@ namespace Microsoft.Health.Dicom.Core.Features.Store
             {
                 await ValidateIndexedItems(dicomDataset, cancellationToken);
             }
+
+            // Validate for Implicit VR at the end
+            if (ImplicitValueRepresentationValidator.IsImplicitVR(dicomDataset))
+            {
+                return false;
+            }
+
+            return true;
         }
 
         private static void ValidateCoreTags(DicomDataset dicomDataset, string requiredStudyInstanceUid)
         {
-            // Validate for Implicit VR
-            ImplicitValueRepresentationValidator.Validate(dicomDataset);
-
             // Ensure required tags are present.
             EnsureRequiredTagIsPresent(DicomTag.PatientID);
             EnsureRequiredTagIsPresent(DicomTag.SOPClassUID);

--- a/src/Microsoft.Health.Dicom.Core/Features/Store/StoreResponseBuilder.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Store/StoreResponseBuilder.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Store
         }
 
         /// <inheritdoc />
-        public void AddSuccess(DicomDataset dicomDataset)
+        public void AddSuccess(DicomDataset dicomDataset, ushort? warningReasonCode = null)
         {
             EnsureArg.IsNotNull(dicomDataset, nameof(dicomDataset));
 
@@ -75,27 +75,19 @@ namespace Microsoft.Health.Dicom.Core.Features.Store
 
             var dicomInstance = dicomDataset.ToInstanceIdentifier();
 
-            var referencedSop = new DicomDataset()
+            var referencedSop = new DicomDataset
             {
                 { DicomTag.ReferencedSOPInstanceUID, dicomDataset.GetSingleValue<string>(DicomTag.SOPInstanceUID) },
                 { DicomTag.RetrieveURL, _urlResolver.ResolveRetrieveInstanceUri(dicomInstance).ToString() },
                 { DicomTag.ReferencedSOPClassUID, dicomDataset.GetSingleValueOrDefault<string>(DicomTag.SOPClassUID) },
             };
 
-            referencedSopSequence.Items.Add(referencedSop);
-        }
-
-        /// <inheritdoc/>
-        public void AddWarning(DicomDataset dicomDataset, ushort warningReasonCode)
-        {
-            EnsureArg.IsNotNull(dicomDataset, nameof(dicomDataset));
-
-            CreateDatasetIfNeeded();
-
-            if (!dicomDataset.TryGetSequence(DicomTag.WarningReason, out DicomSequence _))
+            if (warningReasonCode.HasValue)
             {
-                dicomDataset.Add(DicomTag.WarningReason, warningReasonCode);
+                referencedSop.Add(DicomTag.WarningReason, warningReasonCode.Value);
             }
+
+            referencedSopSequence.Items.Add(referencedSop);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.Health.Dicom.Core/Features/Store/StoreResponseBuilder.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Store/StoreResponseBuilder.cs
@@ -85,6 +85,19 @@ namespace Microsoft.Health.Dicom.Core.Features.Store
             referencedSopSequence.Items.Add(referencedSop);
         }
 
+        /// <inheritdoc/>
+        public void AddWarning(DicomDataset dicomDataset, ushort warningReasonCode)
+        {
+            EnsureArg.IsNotNull(dicomDataset, nameof(dicomDataset));
+
+            CreateDatasetIfNeeded();
+
+            if (!dicomDataset.TryGetSequence(DicomTag.WarningReason, out DicomSequence _))
+            {
+                dicomDataset.Add(DicomTag.WarningReason, warningReasonCode);
+            }
+        }
+
         /// <inheritdoc />
         public void AddFailure(DicomDataset dicomDataset, ushort failureReasonCode)
         {

--- a/src/Microsoft.Health.Dicom.Core/Features/Store/StoreService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Store/StoreService.cs
@@ -106,6 +106,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Store
         {
             IDicomInstanceEntry dicomInstanceEntry = _dicomInstanceEntries[index];
 
+            var warningReasonCode = (ushort?)null;
             DicomDataset dicomDataset = null;
 
             try
@@ -116,9 +117,9 @@ namespace Microsoft.Health.Dicom.Core.Features.Store
                 var isValid = await _dicomDatasetValidator.ValidateAsync(dicomDataset, _requiredStudyInstanceUid, cancellationToken);
                 if (!isValid)
                 {
-                    LogValidationSucceededWithWarningDelegate(_logger, index, FailureReasonCodes.DataSetDoesNotMatchSOPClass, null);
+                    warningReasonCode = FailureReasonCodes.DataSetDoesNotMatchSOPClass;
 
-                    _storeResponseBuilder.AddWarning(dicomDataset, FailureReasonCodes.DataSetDoesNotMatchSOPClass);
+                    LogValidationSucceededWithWarningDelegate(_logger, index, FailureReasonCodes.DataSetDoesNotMatchSOPClass, null);
                 }
             }
             catch (Exception ex)
@@ -156,7 +157,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Store
 
                 LogSuccessfullyStoredDelegate(_logger, index, null);
 
-                _storeResponseBuilder.AddSuccess(dicomDataset);
+                _storeResponseBuilder.AddSuccess(dicomDataset, warningReasonCode);
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.Health.Dicom.Core/Features/Validation/ImplicitValueRepresentationValidator.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Validation/ImplicitValueRepresentationValidator.cs
@@ -5,22 +5,17 @@
 
 using EnsureThat;
 using FellowOakDicom;
-using Microsoft.Health.Dicom.Core.Exceptions;
-using Microsoft.Health.Dicom.Core.Extensions;
 
 namespace Microsoft.Health.Dicom.Core.Features.Validation
 {
     public static class ImplicitValueRepresentationValidator
     {
-        public static void Validate(DicomDataset dicomDataset)
+        public static bool IsImplicitVR(DicomDataset dicomDataset)
         {
             EnsureArg.IsNotNull(dicomDataset, nameof(dicomDataset));
             EnsureArg.IsNotNull(dicomDataset.InternalTransferSyntax, nameof(dicomDataset.InternalTransferSyntax));
 
-            if (!dicomDataset.InternalTransferSyntax.IsExplicitVR)
-            {
-                throw new NotAcceptableException(ValidationErrorCode.ImplicitVRNotAllowed.GetMessage());
-            }
+            return !dicomDataset.InternalTransferSyntax.IsExplicitVR;
         }
     }
 }


### PR DESCRIPTION
## Description
Treat the "Implicit VR not allowed" validation failure as "Warning".

## Related issues
Addresses [issue #]. [AB#88125](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/88125)

## Testing
Added Unit Test coverage
