### PR TITLE
Two step adding workitem

### DIFF
--- a/src/Microsoft.Health.Dicom.Core/Features/Workitem/IIndexWorkitemStore.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Workitem/IIndexWorkitemStore.cs
@@ -17,14 +17,23 @@ namespace Microsoft.Health.Dicom.Core.Features.Workitem
     public interface IIndexWorkitemStore
     {
         /// <summary>
-        /// Asynchronously creates a workitem instance.
+        /// Asynchronously begin the creation of a workitem instance.
         /// </summary>
         /// <param name="partitionKey">The partition key.</param>
         /// <param name="dataset">The DICOM dataset to index.</param>
         /// <param name="queryTags">Queryable workitem tags</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A task that gets the workitem key.</returns>
-        Task<long> AddWorkitemAsync(int partitionKey, DicomDataset dataset, IEnumerable<QueryTag> queryTags, CancellationToken cancellationToken = default);
+        Task<long> BeginAddWorkitemAsync(int partitionKey, DicomDataset dataset, IEnumerable<QueryTag> queryTags, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Asynchronously completes the creation of a workitem instance.
+        /// </summary>
+        /// <param name="partitionKey">The partition key.</param>
+        /// <param name="workitemKey">The workitem instance key.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A task that represents the asynchronous update operation.</returns>
+        Task EndAddWorkitemAsync(int partitionKey, long workitemKey, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Asynchronously deletes a workitem instance.

--- a/src/Microsoft.Health.Dicom.Core/Features/Workitem/WorkitemOrchestrator.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Workitem/WorkitemOrchestrator.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Workitem
                 IReadOnlyCollection<QueryTag> queryTags = await _workitemQueryTagService.GetQueryTagsAsync(cancellationToken).ConfigureAwait(false);
 
                 long workitemKey = await _indexWorkitemStore
-                    .AddWorkitemAsync(partitionKey, dataset, queryTags, cancellationToken)
+                    .BeginAddWorkitemAsync(partitionKey, dataset, queryTags, cancellationToken)
                     .ConfigureAwait(false);
 
                 identifier = new WorkitemInstanceIdentifier(
@@ -69,6 +69,8 @@ namespace Microsoft.Health.Dicom.Core.Features.Workitem
                 // We have successfully created the index, store the file.
                 await StoreWorkitemBlobAsync(identifier, dataset, cancellationToken)
                     .ConfigureAwait(false);
+
+                await _indexWorkitemStore.EndAddWorkitemAsync(partitionKey, workitemKey, cancellationToken);
             }
             catch
             {

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/9.diff.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/9.diff.sql
@@ -44,9 +44,11 @@ BEGIN
         WorkitemKey                 BIGINT                            NOT NULL,             --PK
         PartitionKey                INT                               NOT NULL DEFAULT 1,   --FK
         WorkitemUid                 VARCHAR(64)                       NOT NULL,
-        TransactionUid               VARCHAR(64)                      NULL,
+        TransactionUid              VARCHAR(64)                       NULL,
+        Status                      TINYINT                           NOT NULL,
         --audit columns
-        CreatedDate                 DATETIME2(7)                      NOT NULL
+        CreatedDate                 DATETIME2(7)                      NOT NULL,
+        LastStatusUpdatedDate       DATETIME2(7)                      NOT NULL,
     ) WITH (DATA_COMPRESSION = PAGE)
 
     -- Ordering workitems by partition and then by WorkitemKey for partition-specific retrieval
@@ -64,6 +66,7 @@ BEGIN
     INCLUDE
     (
         WorkitemKey,
+        Status,
         TransactionUid
     )
     WITH (DATA_COMPRESSION = PAGE)
@@ -430,6 +433,8 @@ GO
 --         * DateTime extended query tag data
 --     @personNameExtendedQueryTags
 --         * PersonName extended query tag data
+--     @initialStatus
+--         * Initial status of the workitem status, Either 0(Creating) or 1(Created)
 -- RETURN VALUE
 --     The WorkitemKey
 ------------------------------------------------------------------------
@@ -438,7 +443,8 @@ CREATE OR ALTER PROCEDURE dbo.AddWorkitem
     @workitemUid                    VARCHAR(64),
     @stringExtendedQueryTags        dbo.InsertStringExtendedQueryTagTableType_1 READONLY,
     @dateTimeExtendedQueryTags      dbo.InsertDateTimeExtendedQueryTagTableType_2 READONLY,
-    @personNameExtendedQueryTags    dbo.InsertPersonNameExtendedQueryTagTableType_1 READONLY
+    @personNameExtendedQueryTags    dbo.InsertPersonNameExtendedQueryTagTableType_1 READONLY,
+    @initialStatus                  TINYINT
 AS
 BEGIN
     SET NOCOUNT ON
@@ -447,7 +453,6 @@ BEGIN
     BEGIN TRANSACTION
 
     DECLARE @currentDate DATETIME2(7) = SYSUTCDATETIME()
-    DECLARE @workitemResourceType TINYINT = 1
     DECLARE @workitemKey BIGINT
 
     SELECT @workitemKey = WorkitemKey
@@ -461,9 +466,9 @@ BEGIN
     -- The workitem does not exist, insert it.
     SET @workitemKey = NEXT VALUE FOR dbo.WorkitemKeySequence
     INSERT INTO dbo.Workitem
-        (WorkitemKey, PartitionKey, WorkitemUid, CreatedDate)
+        (WorkitemKey, PartitionKey, WorkitemUid, Status, CreatedDate, LastStatusUpdatedDate)
     VALUES
-        (@workitemKey, @partitionKey, @workitemUid, @currentDate)
+        (@workitemKey, @partitionKey, @workitemUid, @initialStatus, @currentDate, @currentDate)
 
     BEGIN TRY
 
@@ -1219,6 +1224,52 @@ BEGIN
             THROW
 
         END CATCH
+
+    COMMIT TRANSACTION
+END
+GO
+
+/*************************************************************
+    Stored procedure for updating a workitem status.
+**************************************************************/
+--
+-- STORED PROCEDURE
+--     UpdateWorkitemStatus
+--
+-- DESCRIPTION
+--     Updates a workitem status.
+--
+-- PARAMETERS
+--     @partitionKey
+--         * The system identifier of the data partition.
+--     @workitemKey
+--         * The workitem key.
+--     @status
+--         * Initial status of the workitem status, Either 0(Creating) or 1(Created)
+-- RETURN VALUE
+--     The WorkitemKey
+------------------------------------------------------------------------
+CREATE OR ALTER PROCEDURE dbo.UpdateWorkitemStatus
+    @partitionKey                   INT,
+    @workitemKey                    BIGINT,
+    @status                         TINYINT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SET XACT_ABORT ON
+    BEGIN TRANSACTION
+
+    DECLARE @currentDate DATETIME2(7) = SYSUTCDATETIME()
+
+    UPDATE dbo.Workitem
+    SET Status = @status, LastStatusUpdatedDate = @currentDate
+    WHERE PartitionKey = @partitionKey
+        AND WorkitemKey = @workitemKey
+
+    -- The workitem instance does not exist. Perhaps it was deleted?
+    IF @@ROWCOUNT = 0
+        THROW 50404, 'Workitem instance does not exist', 1
 
     COMMIT TRANSACTION
 END

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Sql/Sprocs/AddWorkitem.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Sql/Sprocs/AddWorkitem.sql
@@ -19,6 +19,8 @@
 --         * DateTime extended query tag data
 --     @personNameExtendedQueryTags
 --         * PersonName extended query tag data
+--     @initialStatus
+--         * Initial status of the workitem status, Either 0(Creating) or 1(Created)
 -- RETURN VALUE
 --     The WorkitemKey
 ------------------------------------------------------------------------
@@ -27,7 +29,8 @@ CREATE OR ALTER PROCEDURE dbo.AddWorkitem
     @workitemUid                    VARCHAR(64),
     @stringExtendedQueryTags        dbo.InsertStringExtendedQueryTagTableType_1 READONLY,
     @dateTimeExtendedQueryTags      dbo.InsertDateTimeExtendedQueryTagTableType_2 READONLY,
-    @personNameExtendedQueryTags    dbo.InsertPersonNameExtendedQueryTagTableType_1 READONLY
+    @personNameExtendedQueryTags    dbo.InsertPersonNameExtendedQueryTagTableType_1 READONLY,
+    @initialStatus                  TINYINT
 AS
 BEGIN
     SET NOCOUNT ON
@@ -36,7 +39,6 @@ BEGIN
     BEGIN TRANSACTION
 
     DECLARE @currentDate DATETIME2(7) = SYSUTCDATETIME()
-    DECLARE @workitemResourceType TINYINT = 1
     DECLARE @workitemKey BIGINT
 
     SELECT @workitemKey = WorkitemKey
@@ -50,9 +52,9 @@ BEGIN
     -- The workitem does not exist, insert it.
     SET @workitemKey = NEXT VALUE FOR dbo.WorkitemKeySequence
     INSERT INTO dbo.Workitem
-        (WorkitemKey, PartitionKey, WorkitemUid, CreatedDate)
+        (WorkitemKey, PartitionKey, WorkitemUid, Status, CreatedDate, LastStatusUpdatedDate)
     VALUES
-        (@workitemKey, @partitionKey, @workitemUid, @currentDate)
+        (@workitemKey, @partitionKey, @workitemUid, @initialStatus, @currentDate, @currentDate)
 
     BEGIN TRY
 

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Sql/Sprocs/UpdateWorkitemStatus.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Sql/Sprocs/UpdateWorkitemStatus.sql
@@ -1,0 +1,44 @@
+﻿/*************************************************************
+    Stored procedure for updating a workitem status.
+**************************************************************/
+--
+-- STORED PROCEDURE
+--     UpdateWorkitemStatus
+--
+-- DESCRIPTION
+--     Updates a workitem status.
+--
+-- PARAMETERS
+--     @partitionKey
+--         * The system identifier of the data partition.
+--     @workitemKey
+--         * The workitem key.
+--     @status
+--         * Initial status of the workitem status, Either 0(Creating) or 1(Created)
+-- RETURN VALUE
+--     The WorkitemKey
+------------------------------------------------------------------------
+CREATE OR ALTER PROCEDURE dbo.UpdateWorkitemStatus
+    @partitionKey                   INT,
+    @workitemKey                    BIGINT,
+    @status                         TINYINT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SET XACT_ABORT ON
+    BEGIN TRANSACTION
+
+    DECLARE @currentDate DATETIME2(7) = SYSUTCDATETIME()
+
+    UPDATE dbo.Workitem
+    SET Status = @status, LastStatusUpdatedDate = @currentDate
+    WHERE PartitionKey = @partitionKey
+        AND WorkitemKey = @workitemKey
+
+    -- The workitem instance does not exist. Perhaps it was deleted?
+    IF @@ROWCOUNT = 0
+        THROW 50404, 'Workitem instance does not exist', 1
+
+    COMMIT TRANSACTION
+END

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Sql/Tables/Workitem.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Sql/Tables/Workitem.sql
@@ -5,9 +5,11 @@ CREATE TABLE dbo.Workitem (
     WorkitemKey                 BIGINT                            NOT NULL,             --PK
     PartitionKey                INT                               NOT NULL DEFAULT 1,   --FK
     WorkitemUid                 VARCHAR(64)                       NOT NULL,
-    TransactionUid              VARCHAR(64)                      NULL,
+    TransactionUid              VARCHAR(64)                       NULL,
+    Status                      TINYINT                           NOT NULL,
     --audit columns
-    CreatedDate                 DATETIME2(7)                      NOT NULL
+    CreatedDate                 DATETIME2(7)                      NOT NULL,
+    LastStatusUpdatedDate       DATETIME2(7)                      NOT NULL,
 ) WITH (DATA_COMPRESSION = PAGE)
 
 -- Ordering workitems by partition and then by WorkitemKey for partition-specific retrieval
@@ -25,6 +27,7 @@ CREATE UNIQUE NONCLUSTERED INDEX IX_Workitem_WorkitemUid_PartitionKey ON dbo.Wor
 INCLUDE
 (
     WorkitemKey,
+    Status,
     TransactionUid
 )
 WITH (DATA_COMPRESSION = PAGE)

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Workitem/SqlWorkitemStore.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Workitem/SqlWorkitemStore.cs
@@ -21,16 +21,22 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.Workitem
         public SqlWorkitemStore(VersionedCache<ISqlWorkitemStore> cache)
             => _cache = EnsureArg.IsNotNull(cache, nameof(cache));
 
-        public async Task<long> AddWorkitemAsync(int partitionKey, DicomDataset dataset, IEnumerable<QueryTag> queryTags, CancellationToken cancellationToken = default)
+        public async Task<long> BeginAddWorkitemAsync(int partitionKey, DicomDataset dataset, IEnumerable<QueryTag> queryTags, CancellationToken cancellationToken = default)
         {
             ISqlWorkitemStore store = await _cache.GetAsync(cancellationToken: cancellationToken);
-            return await store.AddWorkitemAsync(partitionKey, dataset, queryTags, cancellationToken);
+            return await store.BeginAddWorkitemAsync(partitionKey, dataset, queryTags, cancellationToken);
         }
 
         public async Task DeleteWorkitemAsync(int partitionKey, string workitemUid, CancellationToken cancellationToken = default)
         {
             ISqlWorkitemStore store = await _cache.GetAsync(cancellationToken: cancellationToken);
             await store.DeleteWorkitemAsync(partitionKey, workitemUid, cancellationToken);
+        }
+
+        public async Task EndAddWorkitemAsync(int partitionKey, long workitemKey, CancellationToken cancellationToken = default)
+        {
+            ISqlWorkitemStore store = await _cache.GetAsync(cancellationToken: cancellationToken);
+            await store.EndAddWorkitemAsync(partitionKey, workitemKey, cancellationToken);
         }
 
         public async Task<IReadOnlyList<WorkitemQueryTagStoreEntry>> GetWorkitemQueryTagsAsync(CancellationToken cancellationToken = default)

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/WorkitemTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/WorkitemTests.cs
@@ -38,9 +38,11 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
                 new QueryTag(new ExtendedQueryTagStoreEntry(2, tag2.GetPath(), tag2.GetDefaultVR().Code, null, QueryTagLevel.Instance, ExtendedQueryTagStatus.Ready, QueryStatus.Enabled,0)),
             };
 
-            long workitemKey = await _fixture.IndexWorkitemStore.AddWorkitemAsync(DefaultPartition.Key, dataset, queryTags, CancellationToken.None);
+            long workitemKey = await _fixture.IndexWorkitemStore.BeginAddWorkitemAsync(DefaultPartition.Key, dataset, queryTags, CancellationToken.None);
 
             Assert.True(workitemKey > 0);
+
+            await _fixture.IndexWorkitemStore.EndAddWorkitemAsync(DefaultPartition.Key, workitemKey, CancellationToken.None);
         }
 
         [Fact]
@@ -58,12 +60,12 @@ namespace Microsoft.Health.Dicom.Tests.Integration.Persistence
                 new QueryTag(new ExtendedQueryTagStoreEntry(2, tag2.GetPath(), tag2.GetDefaultVR().Code, null, QueryTagLevel.Instance, ExtendedQueryTagStatus.Ready, QueryStatus.Enabled,0)),
             };
 
-            long workitemKey = await _fixture.IndexWorkitemStore.AddWorkitemAsync(DefaultPartition.Key, dataset, queryTags, CancellationToken.None);
+            long workitemKey = await _fixture.IndexWorkitemStore.BeginAddWorkitemAsync(DefaultPartition.Key, dataset, queryTags, CancellationToken.None);
 
             await _fixture.IndexWorkitemStore.DeleteWorkitemAsync(DefaultPartition.Key, workitemUid, CancellationToken.None);
 
             // Try adding it back again, if this succeeds, then assume that Delete operation has succeeded.
-            workitemKey = await _fixture.IndexWorkitemStore.AddWorkitemAsync(DefaultPartition.Key, dataset, queryTags, CancellationToken.None);
+            workitemKey = await _fixture.IndexWorkitemStore.BeginAddWorkitemAsync(DefaultPartition.Key, dataset, queryTags, CancellationToken.None);
             Assert.True(workitemKey > 0);
 
             await _fixture.IndexWorkitemStore.DeleteWorkitemAsync(DefaultPartition.Key, workitemUid, CancellationToken.None);


### PR DESCRIPTION
## Description
This PR includes changes that will save workitem in two step. First it will create the workitem record in the DB with Creating status and after the blob upload is successful it will update the status to Created.

For Retrieve and search transaction only Created status workitem are returned back.

## Related issues
Addresses [[AB#87263](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/87263)].

## Testing
Integration tests added to ensure workitem is added.
