### PR TITLE
Read all data from Dicom file when retrieving a frame.

### DIFF
--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/FrameHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/FrameHandler.cs
@@ -36,7 +36,10 @@ namespace Microsoft.Health.Dicom.Core.Features.Retrieve
             EnsureArg.IsNotNull(stream, nameof(stream));
             EnsureArg.IsNotNull(frames, nameof(frames));
 
-            DicomFile dicomFile = await DicomFile.OpenAsync(stream);
+            // The default behavior is to read only small data elements (<= 64 kb) and save a stream reference for downloading
+            // large tags such as pixel data. However, as demonstrated in #1248 there is an issue with fo-dicom reading buffered
+            // streams. Until the fix is released, we will force reading all data into memory. 
+            DicomFile dicomFile = await DicomFile.OpenAsync(stream, FileReadOption.ReadAll);
 
             // Validate requested frame index exists in file and retrieve the pixel data associated with the file.
             DicomPixelData pixelData = dicomFile.GetPixelDataAndValidateFrames(frames);


### PR DESCRIPTION
## Description
When retrieving a frame, forces reading all pixel data as a workaround while we await the fix from fo-dicom.

## Related issues
Addresses [AB#87723](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/87723), #1248

## Testing
All tests pass.
