### PR TITLE
Allow Store Implementations whose Versions are Less than the Minimum

### DIFF
--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/VersionedCache.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/VersionedCache.cs
@@ -41,15 +41,16 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.Schema
             SchemaVersion version = await _schemaVersionResolver.GetCurrentVersionAsync(cancellationToken);
 
             // Return the latest version of the entity. If the entity is not found, throw an exception.
-            T value = _entities.Where(entity => entity.Version <= version && (int)entity.Version >= SchemaVersionConstants.Min).FirstOrDefault();
+            T value = _entities.Where(entity => entity.Version <= version).FirstOrDefault();
 
-            if (value != null) return value;
-
-            string msg = version == SchemaVersion.Unknown
+            if (value == null)
+            {
+                throw new InvalidSchemaVersionException(version == SchemaVersion.Unknown
                     ? DicomSqlServerResource.UnknownSchemaVersion
-                    : string.Format(CultureInfo.InvariantCulture, DicomSqlServerResource.SchemaVersionOutOfRange, version);
+                    : string.Format(CultureInfo.InvariantCulture, DicomSqlServerResource.SchemaVersionOutOfRange, version));
+            }
 
-            throw new InvalidSchemaVersionException(msg);
+            return value;
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/VersionedCache.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/VersionedCache.cs
@@ -38,16 +38,16 @@ namespace Microsoft.Health.Dicom.SqlServer.Features.Schema
 
         private async Task<T> ResolveAsync(CancellationToken cancellationToken = default)
         {
-            SchemaVersion version = await _schemaVersionResolver.GetCurrentVersionAsync(cancellationToken);
+            SchemaVersion current = await _schemaVersionResolver.GetCurrentVersionAsync(cancellationToken);
 
             // Return the latest version of the entity. If the entity is not found, throw an exception.
-            T value = _entities.Where(entity => entity.Version <= version).FirstOrDefault();
+            T value = _entities.FirstOrDefault(x => x.Version <= current);
 
             if (value == null)
             {
-                throw new InvalidSchemaVersionException(version == SchemaVersion.Unknown
+                throw new InvalidSchemaVersionException(current == SchemaVersion.Unknown
                     ? DicomSqlServerResource.UnknownSchemaVersion
-                    : string.Format(CultureInfo.InvariantCulture, DicomSqlServerResource.SchemaVersionOutOfRange, version));
+                    : string.Format(CultureInfo.InvariantCulture, DicomSqlServerResource.SchemaVersionOutOfRange, current));
             }
 
             return value;


### PR DESCRIPTION
## Description
The `VersionedCache<T>` errroneously prevents store implementations whose version predates the minimum from being used.

## Related issues
Fixes [AB#88740](https://microsofthealth.visualstudio.com/Health/_workitems/edit/88740)

## Testing
Update tests with values that are less than the minimum
