### PR TITLE
Move required workitem return attributes to response builder

### DIFF
--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Workitem/WorkitemQueryParserTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Workitem/WorkitemQueryParserTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         {
             _queryParser = new WorkitemQueryParser(new DicomTagParser());
 
-            _queryTags = QueryLimit.RequiredWorkitemSingleTags
+            _queryTags = WorkitemQueryResponseBuilder.RequiredReturnTags
                 .Select(x =>
                     {
                         var entry = new WorkitemQueryTagStoreEntry(0, x.GetPath(), x.GetDefaultVR().Code);

--- a/src/Microsoft.Health.Dicom.Core/Features/Query/QueryLimit.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Query/QueryLimit.cs
@@ -49,41 +49,6 @@ namespace Microsoft.Health.Dicom.Core.Features.Query
             DicomTag.CodeValue
         };
 
-        public static readonly HashSet<DicomTag> RequiredWorkitemSingleTags = new HashSet<DicomTag>
-        {
-            DicomTag.WorklistLabel,
-            DicomTag.ExpectedCompletionDateTime,
-            DicomTag.InputReadinessState,
-            DicomTag.PatientName,
-            DicomTag.PatientID,
-            DicomTag.PatientBirthDate,
-            DicomTag.PatientSex,
-            DicomTag.AdmissionID,
-            DicomTag.AccessionNumber,
-            DicomTag.RequestedProcedureID,
-            DicomTag.RequestingService,
-            DicomTag.ProcedureStepLabel,
-            DicomTag.ScheduledProcedureStepPriority,
-            DicomTag.ScheduledProcedureStepStartDateTime
-        };
-
-        public static readonly HashSet<DicomTag> RequiredWorkitemSequenceTags = new HashSet<DicomTag>
-        {
-            DicomTag.IssuerOfAdmissionIDSequence,
-            DicomTag.ReferencedRequestSequence,
-            DicomTag.IssuerOfAccessionNumberSequence,
-            DicomTag.ScheduledWorkitemCodeSequence,
-            DicomTag.ScheduledStationNameCodeSequence,
-            DicomTag.ScheduledStationClassCodeSequence,
-            DicomTag.ScheduledStationGeographicLocationCodeSequence,
-            DicomTag.ScheduledHumanPerformersSequence,
-            DicomTag.HumanPerformerCodeSequence,
-            DicomTag.ReplacedProcedureStepSequence
-        };
-
-        public static readonly HashSet<DicomTag> AllRequiredWorkitemTags = new HashSet<DicomTag>(
-            RequiredWorkitemSingleTags.Union(RequiredWorkitemSequenceTags).Union(new DicomTag[] { DicomTag.ProcedureStepState }));
-
         public static readonly HashSet<DicomTag> CoreTags = new HashSet<DicomTag>(
             CoreStudyTags.Union(CoreSeriesTags).Union(CoreInstanceTags));
 

--- a/src/Microsoft.Health.Dicom.Core/Features/Workitem/WorkitemQueryResponseBuilder.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Workitem/WorkitemQueryResponseBuilder.cs
@@ -7,19 +7,83 @@ using System.Collections.Generic;
 using System.Linq;
 using EnsureThat;
 using FellowOakDicom;
-using Microsoft.Health.Dicom.Core.Features.Query;
 using Microsoft.Health.Dicom.Core.Features.Query.Model;
 
 namespace Microsoft.Health.Dicom.Core.Features.Workitem
 {
     public static class WorkitemQueryResponseBuilder
     {
+        /// <summary>
+        /// Workitem attributes with a return key type of 1 or 2 (including conditionals).
+        /// <see href='https://dicom.nema.org/medical/dicom/current/output/html/part04.html#table_CC.2.5-3'/>.
+        /// </summary>
+        public static readonly HashSet<DicomTag> RequiredReturnTags = new HashSet<DicomTag>
+        {
+            // SOP Common Module
+            DicomTag.SpecificCharacterSet,
+            DicomTag.SOPClassUID,
+            DicomTag.SOPInstanceUID,
+
+            // Unified Procedure Step Scheduled Procedure Information Module
+            DicomTag.ScheduledProcedureStepPriority,
+            DicomTag.ProcedureStepLabel,
+            DicomTag.WorklistLabel,
+            DicomTag.ScheduledProcessingParametersSequence,
+            DicomTag.ScheduledStationNameCodeSequence,
+            DicomTag.ScheduledStationClassCodeSequence,
+            DicomTag.ScheduledStationGeographicLocationCodeSequence,
+            DicomTag.ScheduledHumanPerformersSequence,
+            DicomTag.ScheduledProcedureStepStartDateTime,
+            DicomTag.ScheduledWorkitemCodeSequence,
+            DicomTag.InputReadinessState,
+            DicomTag.InputInformationSequence,
+            DicomTag.StudyInstanceUID,
+
+            // Unified Procedure Step Relationship Module
+            DicomTag.PatientName,
+            DicomTag.PatientID,
+
+                // Issuer of Patient ID Macro
+                DicomTag.IssuerOfPatientID,
+                DicomTag.IssuerOfPatientIDQualifiersSequence,
+
+            DicomTag.OtherPatientIDsSequence,
+            DicomTag.PatientBirthDate,
+            DicomTag.PatientSex,
+            DicomTag.AdmissionID,
+            DicomTag.IssuerOfAdmissionIDSequence,
+            DicomTag.AdmittingDiagnosesDescription,
+            DicomTag.AdmittingDiagnosesCodeSequence,
+            DicomTag.ReferencedRequestSequence,
+
+            // Patient Medical Module
+            DicomTag.MedicalAlerts,
+            DicomTag.PregnancyStatus,
+            DicomTag.SpecialNeeds,
+
+            // Unified Procedure Step Progress Information Module
+            DicomTag.ProcedureStepState,
+            DicomTag.ProcedureStepProgressInformationSequence,
+        };
+
+        /// <summary>
+        /// Includes workitem attributes as specified in
+        /// <see href='https://dicom.nema.org/medical/dicom/current/output/html/part18.html#sect_11.9.2'/>.
+        /// </summary>
         public static DicomDataset GenerateResponseDataset(DicomDataset dicomDataset, BaseQueryExpression queryExpression)
         {
             EnsureArg.IsNotNull(dicomDataset, nameof(dicomDataset));
             EnsureArg.IsNotNull(queryExpression, nameof(queryExpression));
 
-            var tagsToReturn = new HashSet<DicomTag>(QueryLimit.AllRequiredWorkitemTags);
+            // Should never be returned
+            dicomDataset = dicomDataset.Remove(DicomTag.TransactionUID);
+
+            if (queryExpression.IncludeFields.All)
+            {
+                return dicomDataset;
+            }
+
+            var tagsToReturn = new HashSet<DicomTag>(RequiredReturnTags);
 
             foreach (DicomTag tag in queryExpression.IncludeFields.DicomTags)
             {


### PR DESCRIPTION
## Description
Moves the list of required return attributes when searching for workitems to the response builder and revises the list to match the standard.

# Related issues
Addresses [AB#88986](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/88986).

## Testing
Added new unit tests covering more return cases.
