### PR TITLE
Update DICOM Cast Table Health Check

### DIFF
--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.TableStorage/Features/Storage/TableClientReadWriteTestProvider.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.TableStorage/Features/Storage/TableClientReadWriteTestProvider.cs
@@ -38,8 +38,6 @@ namespace Microsoft.Health.DicomCast.TableStorage.Features.Storage
             await tableClient.GetEntityAsync<HealthEntity>(TestPartitionKey, TestRowKey, cancellationToken: cancellationToken);
 
             await tableClient.DeleteEntityAsync(TestPartitionKey, TestRowKey, cancellationToken: cancellationToken);
-
-            await _testServiceClient.DeleteTableAsync(TestTable, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
## Description
This PR updates the Dicom Cast table health check to remove deleting the table as part of the check. This operation could take up to 40 seconds to complete and during a subsequent health check it would fail as the table was in the process of being deleted.

## Related issues
Addresses [AB#89298](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/89298)

## Testing
Manually pull downstream and tested.
