### PR TITLE
Support querying same tag under a sequence

### DIFF
--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Workitem/WorkitemQueryParserTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Workitem/WorkitemQueryParserTests.cs
@@ -204,6 +204,40 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
             Assert.Equal(expectedQueryTag.Tag, BaseQueryExpression.FilterConditions.First().QueryTag.Tag);
         }
 
+        [Fact]
+        public void GivenWorkitemQueryTag_WithSameLastLevelKey_ThenReturnsSuccessfully()
+        {
+            var item1 = new DicomSequence(
+                    DicomTag.ScheduledStationClassCodeSequence,
+                        new DicomDataset[] {
+                            new DicomDataset(
+                                new DicomShortString(
+                                DicomTag.CodeValue, "Foo"))});
+            var item2 = new DicomSequence(
+                    DicomTag.ScheduledStationNameCodeSequence,
+                        new DicomDataset[] {
+                            new DicomDataset(
+                                new DicomShortString(
+                                DicomTag.CodeValue, "Bar"))});
+            QueryTag[] tags = new QueryTag[]
+            {
+              new QueryTag(Tests.Common.Extensions.DicomTagExtensions.BuildWorkitemQueryTagStoreEntry("00404025.00080100", 1, item1.ValueRepresentation.Code)),
+              new QueryTag(Tests.Common.Extensions.DicomTagExtensions.BuildWorkitemQueryTagStoreEntry("00404026.00080100", 2, item2.ValueRepresentation.Code))
+            };
+
+            var expectedQueryTag = new QueryTag(Tests.Common.Extensions.DicomTagExtensions.BuildWorkitemQueryTagStoreEntry("00080100", 1, DicomTag.AccessionNumber.GetDefaultVR().Code));
+            var filterConditions = new Dictionary<string, string>();
+            filterConditions.Add("00404025.00080100", "Foo");
+            filterConditions.Add("00404026.00080100", "Bar");
+
+            BaseQueryExpression BaseQueryExpression = _queryParser
+                 .Parse(CreateParameters(filterConditions), tags);
+
+            Assert.Equal(2, BaseQueryExpression.FilterConditions.Count);
+            Assert.Equal(expectedQueryTag.Tag, BaseQueryExpression.FilterConditions.First().QueryTag.Tag);
+            Assert.Equal(expectedQueryTag.Tag, BaseQueryExpression.FilterConditions.Last().QueryTag.Tag);
+        }
+
         private void VerifyIncludeFieldsForValidAttributeIds(params string[] values)
         {
             BaseQueryExpression BaseQueryExpression = _queryParser.Parse(

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Workitem/WorkitemQueryParserTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Workitem/WorkitemQueryParserTests.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
         }
 
         [Fact]
-        public void GivenWorkitemQueryTag_WithSameLastLevelKey_ThenReturnsSuccessfully()
+        public void GivenTwoWorkitemQueryTags_WithSameLastLevelKey_ThenReturnsSuccessfully()
         {
             var item1 = new DicomSequence(
                     DicomTag.ScheduledStationClassCodeSequence,
@@ -213,12 +213,14 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Query
                             new DicomDataset(
                                 new DicomShortString(
                                 DicomTag.CodeValue, "Foo"))});
+
             var item2 = new DicomSequence(
                     DicomTag.ScheduledStationNameCodeSequence,
                         new DicomDataset[] {
                             new DicomDataset(
                                 new DicomShortString(
                                 DicomTag.CodeValue, "Bar"))});
+
             QueryTag[] tags = new QueryTag[]
             {
               new QueryTag(Tests.Common.Extensions.DicomTagExtensions.BuildWorkitemQueryTagStoreEntry("00404025.00080100", 1, item1.ValueRepresentation.Code)),

--- a/src/Microsoft.Health.Dicom.Core/Features/Workitem/WorkitemQueryParser.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Workitem/WorkitemQueryParser.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Query
             EnsureArg.IsNotNull(parameters, nameof(parameters));
             EnsureArg.IsNotNull(queryTags, nameof(queryTags));
 
-            var filterConditions = new Dictionary<DicomTag, QueryFilterCondition>();
+            var filterConditions = new Dictionary<int, QueryFilterCondition>();
             foreach (KeyValuePair<string, string> filter in parameters.Filters)
             {
                 // filter conditions with attributeId as key
@@ -40,7 +40,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Query
                     throw new QueryParseException(string.Format(DicomCoreResource.UnsupportedSearchParameter, filter.Key));
                 }
 
-                if (!filterConditions.TryAdd(condition.QueryTag.Tag, condition))
+                if (!filterConditions.TryAdd(condition.QueryTag.WorkitemQueryTagStoreEntry.Key, condition))
                 {
                     throw new QueryParseException(string.Format(DicomCoreResource.DuplicateAttribute, filter.Key));
                 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Workitem/WorkitemQueryResponseBuilder.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Workitem/WorkitemQueryResponseBuilder.cs
@@ -43,9 +43,9 @@ namespace Microsoft.Health.Dicom.Core.Features.Workitem
             DicomTag.PatientName,
             DicomTag.PatientID,
 
-                // Issuer of Patient ID Macro
-                DicomTag.IssuerOfPatientID,
-                DicomTag.IssuerOfPatientIDQualifiersSequence,
+            // Issuer of Patient ID Macro
+            DicomTag.IssuerOfPatientID,
+            DicomTag.IssuerOfPatientIDQualifiersSequence,
 
             DicomTag.OtherPatientIDsSequence,
             DicomTag.PatientBirthDate,

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/WorkItemTransactionTests.Query.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/WorkItemTransactionTests.Query.cs
@@ -57,6 +57,26 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
         }
 
         [Fact]
+        public async Task WhenQueryingWorkitemWithFilter_TheServerShouldReturnWorkitemSuccessfully()
+        {
+            var workitemUid = TestUidGenerator.Generate();
+            DicomDataset dicomDataset = Samples.CreateRandomWorkitemInstanceDataset(workitemUid);
+
+            using DicomWebResponse response = await _client.AddWorkitemAsync(Enumerable.Repeat(dicomDataset, 1), workitemUid);
+
+            Assert.True(response.IsSuccessStatusCode);
+
+            using DicomWebAsyncEnumerableResponse<DicomDataset> queryResponse = await _client.QueryWorkitemAsync("ProcedureStepState=SCHEDULED");
+
+            Assert.Equal(KnownContentTypes.ApplicationDicomJson, queryResponse.ContentHeaders.ContentType.MediaType);
+            DicomDataset[] datasets = await queryResponse.ToArrayAsync();
+
+            Assert.NotNull(datasets);
+            DicomDataset testDataResponse = datasets.FirstOrDefault(ds => ds.GetSingleValue<string>(DicomTag.ProcedureStepState) == "SCHEDULED");
+            Assert.NotNull(testDataResponse);
+        }
+
+        [Fact]
         public async Task WhenQueryingWorkitemWithSequenceMatching_TheServerShouldReturnWorkitemSuccessfully()
         {
             var workitemUid = TestUidGenerator.Generate();


### PR DESCRIPTION
## Description
Add support for querying the same DICOM tag under a different sequence.

## Related issues
Addresses [AB#89340](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/89340).

## Testing
Added unit test to validate the scenario and also added additional E2E tests.
