### PR TITLE
Small changes to request cancellation

### DIFF
--- a/docs/resources/data-partition-feature.postman_collection.json
+++ b/docs/resources/data-partition-feature.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "e43ef83d-7f6c-421e-80f4-254a92917695",
+		"_postman_id": "2096f878-0365-40e6-afd6-4799a6821cd3",
 		"name": "Dicom Data Partition Feature",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -315,6 +315,63 @@
 							"key": "PatientName",
 							"value": "Last^First"
 						}
+					]
+				},
+				"description": "For the body of the request, select the red-triangle.dcm file located in the GitHub repo at ../docs/dcms.  Ensure you attach the file as `binary`.\r\n\r\n> NOTE: This is a non-standard API that allows the upload of a single DICOM file without the need to configure the POST for multipart/related. It allows the use of Postman to upload files to the DICOMweb service.\r\n\r\nThe following is required to upload a single DICOM file.\r\n\r\n* Path: ../studies\r\n* Method: POST\r\n* Headers:\r\n   *  `Accept: application/dicom+json`\r\n   *  `Content-Type: application/dicom`\r\n* Body:\r\n    * Contains the DICOM file as a bytes.\r\n\r\n> This API is currently not implemented\r\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Request-cancellation-workitem",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"accept": true,
+					"accept-encoding": true,
+					"connection": true,
+					"content-type": true,
+					"user-agent": true
+				}
+			},
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"type": "text",
+						"value": "application/dicom+json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "[\r\n    {\r\n        \"00741238\": {\r\n            \"vr\": \"LT\",\r\n            \"Value\": [\r\n                \"This Workitem should be cancelled.\"\r\n            ]\r\n        },\r\n        \"0074100A\": {\r\n            \"vr\": \"UR\",\r\n            \"Value\": [\r\n                \"https://microsoft.com\"\r\n            ]\r\n        },\r\n        \"0074100C\": {\r\n            \"vr\": \"LO\",\r\n            \"Value\": [\r\n                \"Microsoft\"\r\n            ]\r\n        },\r\n        \"0074100E\": {\r\n            \"vr\": \"SQ\",\r\n            \"Value\": [\r\n                {\r\n                    \"00080100\": {\r\n                        \"vr\": \"SH\",\r\n                        \"Value\": [\r\n                            \"ABC123\"\r\n                        ]\r\n                    },\r\n                    \"00080102\": {\r\n                        \"vr\": \"SH\",\r\n                        \"Value\": [\r\n                            \"123ABC\"\r\n                        ]\r\n                    },\r\n                    \"00080104\": {\r\n                        \"vr\": \"LO\",\r\n                        \"Value\": [\r\n                            \"Requested procedure\"\r\n                        ]\r\n                    }\r\n                }\r\n            ]\r\n        }\r\n    }\r\n]",
+					"options": {
+						"raw": {
+							"language": "text"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{baseUrl}}/partitions/{{partitionName}}/workitems/{{workitem1}}/cancelrequest",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"partitions",
+						"{{partitionName}}",
+						"workitems",
+						"{{workitem1}}",
+						"cancelrequest"
 					]
 				},
 				"description": "For the body of the request, select the red-triangle.dcm file located in the GitHub repo at ../docs/dcms.  Ensure you attach the file as `binary`.\r\n\r\n> NOTE: This is a non-standard API that allows the upload of a single DICOM file without the need to configure the POST for multipart/related. It allows the use of Postman to upload files to the DICOMweb service.\r\n\r\nThe following is required to upload a single DICOM file.\r\n\r\n* Path: ../studies\r\n* Method: POST\r\n* Headers:\r\n   *  `Accept: application/dicom+json`\r\n   *  `Content-Type: application/dicom`\r\n* Body:\r\n    * Contains the DICOM file as a bytes.\r\n\r\n> This API is currently not implemented\r\n"

--- a/src/Microsoft.Health.Dicom.Api/Controllers/WorkitemController.Cancel.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/WorkitemController.Cancel.cs
@@ -60,6 +60,12 @@ namespace Microsoft.Health.Dicom.Api.Controllers
                     HttpContext.RequestAborted)
                 .ConfigureAwait(false);
 
+            if (response.Status is Core.Messages.Workitem.WorkitemResponseStatus.Conflict
+                && !string.IsNullOrEmpty(response.Message))
+            {
+                Response.Headers.Warning = string.Format(DicomApiResource.WarningHeader, response.Message);
+            }
+
             return StatusCode((int)response.Status.CancelResponseToHttpStatusCode(), response.Message);
         }
     }

--- a/src/Microsoft.Health.Dicom.Api/DicomApiResource.Designer.cs
+++ b/src/Microsoft.Health.Dicom.Api/DicomApiResource.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Microsoft.Health.Dicom.Api
-{
-
-
+namespace Microsoft.Health.Dicom.Api {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Dicom.Api
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class DicomApiResource {
@@ -142,6 +142,15 @@ namespace Microsoft.Health.Dicom.Api
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The syntax of the request body is invalid..
+        /// </summary>
+        internal static string InvalidSyntax {
+            get {
+                return ResourceManager.GetString("InvalidSyntax", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The audit information is missing for Controller: {0} and Action: {1}. This usually means the action is not marked with appropriate attribute..
         /// </summary>
         internal static string MissingAuditInformation {
@@ -183,6 +192,15 @@ namespace Microsoft.Health.Dicom.Api
         internal static string UnsupportedField {
             get {
                 return ResourceManager.GetString("UnsupportedField", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 299: {0}.
+        /// </summary>
+        internal static string WarningHeader {
+            get {
+                return ResourceManager.GetString("WarningHeader", resourceCulture);
             }
         }
     }

--- a/src/Microsoft.Health.Dicom.Api/DicomApiResource.resx
+++ b/src/Microsoft.Health.Dicom.Api/DicomApiResource.resx
@@ -150,6 +150,9 @@
     <value>The field '{0}' in request body is invalid: {1}</value>
     <comment>{0} is key, {1} is error message</comment>
   </data>
+  <data name="InvalidSyntax" xml:space="preserve">
+    <value>The syntax of the request body is invalid.</value>
+  </data>
   <data name="MissingAuditInformation" xml:space="preserve">
     <value>The audit information is missing for Controller: {0} and Action: {1}. This usually means the action is not marked with appropriate attribute.</value>
     <comment>{0} is the controller name and {1} is the action name.</comment>
@@ -168,5 +171,9 @@
   <data name="UnsupportedField" xml:space="preserve">
     <value>The field is not supported: "{0}".</value>
     <comment>{0} is field.</comment>
+  </data>
+  <data name="WarningHeader" xml:space="preserve">
+    <value>299: {0}</value>
+    <comment>{0} is the warning message</comment>
   </data>
 </root>

--- a/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Net;
 using System.Runtime.ExceptionServices;
+using System.Text.Json;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.AspNetCore.Http;
@@ -66,6 +67,11 @@ namespace Microsoft.Health.Dicom.Api.Features.Exceptions
 
             switch (exception)
             {
+                case JsonException:
+                    _logger.LogError(exception, nameof(JsonException));
+                    message = DicomApiResource.InvalidSyntax;
+                    statusCode = HttpStatusCode.BadRequest;
+                    break;
                 case ValidationException _:
                 case NotSupportedException _:
                 case AuditHeaderCountExceededException _:

--- a/src/Microsoft.Health.Dicom.Client/DicomWebClient.Workitem.cs
+++ b/src/Microsoft.Health.Dicom.Client/DicomWebClient.Workitem.cs
@@ -26,13 +26,13 @@ namespace Microsoft.Health.Dicom.Client
             return await PostRequest(uri, dicomDatasets, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<DicomWebResponse> CancelWorkitemAsync(DicomDataset dicomDataset, string workitemUid, string partitionName = default, CancellationToken cancellationToken = default)
+        public async Task<DicomWebResponse> CancelWorkitemAsync(IEnumerable<DicomDataset> dicomDatasets, string workitemUid, string partitionName = default, CancellationToken cancellationToken = default)
         {
-            EnsureArg.IsNotNull(dicomDataset, nameof(dicomDataset));
+            EnsureArg.IsNotNull(dicomDatasets, nameof(dicomDatasets));
 
             var uri = GenerateWorkitemCancelRequestUri(workitemUid, partitionName);
 
-            return await PostRequest(uri, dicomDataset, cancellationToken).ConfigureAwait(false);
+            return await PostRequest(uri, dicomDatasets, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<DicomWebAsyncEnumerableResponse<DicomDataset>> QueryWorkitemAsync(string queryString, string partitionName = default, CancellationToken cancellationToken = default)

--- a/src/Microsoft.Health.Dicom.Client/IDicomWebClient.Workitem.cs
+++ b/src/Microsoft.Health.Dicom.Client/IDicomWebClient.Workitem.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Health.Dicom.Client
     public partial interface IDicomWebClient
     {
         Task<DicomWebResponse> AddWorkitemAsync(IEnumerable<DicomDataset> dicomDatasets, string workitemUid = default, string partitionName = default, CancellationToken cancellationToken = default);
-        Task<DicomWebResponse> CancelWorkitemAsync(DicomDataset dicomDataset, string workitemUid, string partitionName = default, CancellationToken cancellationToken = default);
+        Task<DicomWebResponse> CancelWorkitemAsync(IEnumerable<DicomDataset> dicomDatasets, string workitemUid, string partitionName = default, CancellationToken cancellationToken = default);
         Task<DicomWebAsyncEnumerableResponse<DicomDataset>> QueryWorkitemAsync(string queryString, string partitionName = default, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Workitem/CancelWorkitemDatasetValidatorTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Workitem/CancelWorkitemDatasetValidatorTests.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Workitem
         }
 
         [Fact]
-        public void GivenMissingConditionalRequiredTag_Throws()
+        public void GivenMissingConditionalRequiredTag_DoesNotThrow()
         {
             var dataset = Samples.CreateCanceledWorkitemDataset(@"Unit Test Reason", ProcedureStepState.Canceled);
             dataset.Remove(DicomTag.SpecificCharacterSet);
 
             var target = new CancelWorkitemDatasetValidator();
 
-            Assert.Throws<DatasetValidationException>(() => target.Validate(dataset));
+            target.Validate(dataset);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
@@ -555,15 +555,12 @@ For details on valid range queries, please refer to Search Matching section in C
   </data>
   <data name="CancelWorkitemUnknownReasonCode" xml:space="preserve">
     <value>Cancel Reason not provided</value>
-    <comment></comment>
   </data>
   <data name="WorkitemCancelRequestRejected" xml:space="preserve">
     <value>The UPS may no longer be updated.</value>
-    <comment></comment>
   </data>
   <data name="WorkitemIsAlreadyCanceled" xml:space="preserve">
     <value>The UPS is already in the requested state of CANCELED.</value>
-    <comment>{0} WorkitemInstanceUid</comment>
   </data>
   <data name="WorkitemIsAlreadyCompleted" xml:space="preserve">
     <value>The UPS '{0}' is already COMPLETED.</value>

--- a/src/Microsoft.Health.Dicom.Core/Features/Workitem/CancelWorkitemRequestHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Workitem/CancelWorkitemRequestHandler.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -43,12 +45,12 @@ namespace Microsoft.Health.Dicom.Core.Features.Workitem
 
             request.Validate();
 
-            var workitem = await _workitemSerializer
-                .DeserializeAsync<DicomDataset>(request.RequestBody, request.RequestContentType)
+            var workitems = await _workitemSerializer
+                .DeserializeAsync<IEnumerable<DicomDataset>>(request.RequestBody, request.RequestContentType)
                 .ConfigureAwait(false);
 
             return await _workItemService
-                .ProcessCancelAsync(workitem, request.WorkitemInstanceUid, cancellationToken)
+                .ProcessCancelAsync(workitems.FirstOrDefault(), request.WorkitemInstanceUid, cancellationToken)
                 .ConfigureAwait(false);
         }
     }

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/WorkItemTransactionTests.Cancel.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/WorkItemTransactionTests.Cancel.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
 
             // Cancel
             var cancelDicomDataset = Samples.CreateWorkitemCancelRequestDataset(@"Test Cancel");
-            using var cancelResponse = await _client.CancelWorkitemAsync(cancelDicomDataset, workitemUid);
+            using var cancelResponse = await _client.CancelWorkitemAsync(Enumerable.Repeat(cancelDicomDataset, 1), workitemUid);
             Assert.True(cancelResponse.IsSuccessStatusCode);
 
             // Query
@@ -61,11 +61,11 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
 
             // Cancel
             var cancelDicomDataset = Samples.CreateWorkitemCancelRequestDataset(@"Test Cancel");
-            using var cancelResponse1 = await _client.CancelWorkitemAsync(cancelDicomDataset, workitemUid);
+            using var cancelResponse1 = await _client.CancelWorkitemAsync(Enumerable.Repeat(cancelDicomDataset, 1), workitemUid);
             Assert.True(cancelResponse1.IsSuccessStatusCode);
 
             // Cancel
-            var exception = await Assert.ThrowsAsync<DicomWebException>(() => _client.CancelWorkitemAsync(cancelDicomDataset, workitemUid));
+            var exception = await Assert.ThrowsAsync<DicomWebException>(() => _client.CancelWorkitemAsync(Enumerable.Repeat(cancelDicomDataset, 1), workitemUid));
 
             // Verify
             Assert.Equal("\"" + string.Format(DicomCoreResource.WorkitemIsAlreadyCanceled, workitemUid) + "\"", exception.ResponseMessage);
@@ -88,7 +88,7 @@ namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest
             // Cancel
             var newWorkitemUid = TestUidGenerator.Generate();
             var cancelDicomDataset = Samples.CreateWorkitemCancelRequestDataset(@"Test Cancel");
-            var exception = await Assert.ThrowsAsync<DicomWebException>(() => _client.CancelWorkitemAsync(cancelDicomDataset, newWorkitemUid));
+            var exception = await Assert.ThrowsAsync<DicomWebException>(() => _client.CancelWorkitemAsync(Enumerable.Repeat(cancelDicomDataset, 1), newWorkitemUid));
 
             // Verify
             Assert.Equal("\"" + string.Format(DicomCoreResource.WorkitemInstanceNotFound, newWorkitemUid) + "\"", exception.ResponseMessage);


### PR DESCRIPTION
## Description
- adds docs for request cancel and queryable study instance UID
- adds a Postman request
- adds the warning header to a request where the workitem is already cancelled
- handles JSON serialization exceptions as 400 instead of 500
- makes conditional final state requirements default to false since they are not required by default
- accepts an IEnumerable of datasets
- updates client to do the same.

## Testing
All tests pass, a number of test updated and added.
