### PR TITLE
Eagerly Fail XQT Tests if Deletion Fails due to Unknown Reason

### DIFF
--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Common/DicomTagsManager.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Common/DicomTagsManager.cs
@@ -36,14 +36,7 @@ internal class DicomTagsManager : IAsyncDisposable
     {
         foreach (var tag in _tags)
         {
-            try
-            {
-                await _dicomWebClient.DeleteExtendedQueryTagAsync(tag);
-            }
-            catch (DicomWebException)
-            {
-
-            }
+            await _dicomWebClient.DeleteExtendedQueryTagAsync(tag);
         }
     }
 
@@ -114,8 +107,16 @@ internal class DicomTagsManager : IAsyncDisposable
     public async Task<bool> DeleteExtendedQueryTagAsync(string tagPath, CancellationToken cancellationToken = default)
     {
         EnsureArg.IsNotNull(tagPath, nameof(tagPath));
+        _tags.Remove(tagPath);
 
-        var response = await _dicomWebClient.DeleteExtendedQueryTagAsync(tagPath, cancellationToken);
-        return response.StatusCode == System.Net.HttpStatusCode.NoContent;
+        try
+        {
+            var response = await _dicomWebClient.DeleteExtendedQueryTagAsync(tagPath, cancellationToken);
+            return response.StatusCode == System.Net.HttpStatusCode.NoContent;
+        }
+        catch (DicomWebException dwe) when (dwe.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return false;
+        }
     }
 }

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/ExtendedQueryTagTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/ExtendedQueryTagTests.cs
@@ -47,8 +47,8 @@ public class ExtendedQueryTagTests : IClassFixture<WebJobsIntegrationTestFixture
         DicomTag filmTag = DicomTag.NumberOfFilms;
 
         // Try to delete these extended query tags.
-        await CleanupExtendedQueryTag(genderTag);
-        await CleanupExtendedQueryTag(filmTag);
+        await _tagManager.DeleteExtendedQueryTagAsync(genderTag.GetPath());
+        await _tagManager.DeleteExtendedQueryTagAsync(filmTag.GetPath());
 
         // Define DICOM files
         DicomDataset instance1 = Samples.CreateRandomInstanceDataset();
@@ -107,7 +107,7 @@ public class ExtendedQueryTagTests : IClassFixture<WebJobsIntegrationTestFixture
         string tagValue = "053Y";
 
         // Try to delete this extended query tag if it exists.
-        await CleanupExtendedQueryTag(tag);
+        await _tagManager.DeleteExtendedQueryTagAsync(tag.GetPath());
 
         // Define DICOM files
         DicomDataset instance1 = Samples.CreateRandomInstanceDataset();
@@ -208,8 +208,8 @@ public class ExtendedQueryTagTests : IClassFixture<WebJobsIntegrationTestFixture
     {
         DicomTag dsTag = DicomTag.PatientSize;
         DicomTag isTag = DicomTag.ReferencedFrameNumber;
-        await CleanupExtendedQueryTag(dsTag);
-        await CleanupExtendedQueryTag(isTag);
+        await _tagManager.DeleteExtendedQueryTagAsync(dsTag.GetPath());
+        await _tagManager.DeleteExtendedQueryTagAsync(isTag.GetPath());
         DicomFile dicomFile = Samples.CreateRandomDicomFile();
         var dataSet = dicomFile.Dataset.NotValidated();
         dataSet.Add(dsTag, "InvalidDSValue");
@@ -223,7 +223,7 @@ public class ExtendedQueryTagTests : IClassFixture<WebJobsIntegrationTestFixture
     {
         DicomTag tag = DicomTag.StageNumber;
 
-        await CleanupExtendedQueryTag(tag);
+        await _tagManager.DeleteExtendedQueryTagAsync(tag.GetPath());
 
         // add extended query tag
         Assert.Equal(
@@ -237,18 +237,6 @@ public class ExtendedQueryTagTests : IClassFixture<WebJobsIntegrationTestFixture
         dataSet.Add(tag, "InvalidISValue");
         DicomWebException exception = await Assert.ThrowsAsync<DicomWebException>(() => _client.StoreAsync(dicomFile));
         Assert.Equal(HttpStatusCode.Conflict, exception.StatusCode);
-    }
-
-    private async Task CleanupExtendedQueryTag(DicomTag tag)
-    {
-        // Try to delete this extended query tag.
-        try
-        {
-            await _tagManager.DeleteExtendedQueryTagAsync(tag.GetPath());
-        }
-        catch (DicomWebException)
-        {
-        }
     }
 
     public static IEnumerable<object[]> GetRequestBodyWithMissingProperty


### PR DESCRIPTION
## Description
- Attempt to retrieve more diagnostic information by increasing strictness for tag deletion before tests. If the deletion fails for a reason other than it's not found, throw the exception

## Related issues
[AB#88316](https://microsofthealth.visualstudio.com/Health/_workitems/edit/88316/)

## Testing
Pipeline
