### PR TITLE
updating dependabot action to check combined status

### DIFF
--- a/.github/workflows/combine-dependabot-prs.yml
+++ b/.github/workflows/combine-dependabot-prs.yml
@@ -52,18 +52,14 @@ jobs:
                 statusOK = true;
                 if(${{ github.event.inputs.mustBeGreen }}) {
                   console.log('Checking green status: ' + branch);
-                  const statuses = await github.paginate('GET /repos/{owner}/{repo}/commits/{ref}/status', {
+                  const statuses = await github.request('GET /repos/{owner}/{repo}/commits/{ref}/status', {
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     ref: branch
                   });
-                  if(statuses.length > 0) {
-                    const latest_status = statuses[0]['state'];
-                    console.log('Validating status: ' + latest_status);
-                    if(latest_status != 'success') {
-                      console.log('Discarding ' + branch + ' with status ' + latest_status);
-                      statusOK = false;
-                    }
+                  if(statuses.state !== 'success') {
+                    console.log('Discarding ' + branch + ' with status ' + statuses.state);
+                    statusOK = false;
                   }
                 }
                 console.log('Checking labels: ' + branch);


### PR DESCRIPTION
## Description
This action doesn't check all statuses accurately - this change should check all statuses in all contexts: https://docs.github.com/en/rest/reference/commits#get-the-combined-status-for-a-specific-reference

## Testing
Manual testing
