### PR TITLE
Fix dependabot GitHub action to look at checks

### DIFF
--- a/.github/workflows/combine-dependabot-prs.yml
+++ b/.github/workflows/combine-dependabot-prs.yml
@@ -52,18 +52,14 @@ jobs:
                 statusOK = true;
                 if(${{ github.event.inputs.mustBeGreen }}) {
                   console.log('Checking green status: ' + branch);
-                  const statuses = await github.paginate('GET /repos/{owner}/{repo}/commits/{ref}/status', {
+                  const statuses = await github.request('GET /repos/{owner}/{repo}/commits/{ref}/status', {
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     ref: branch
                   });
-                  if(statuses.length > 0) {
-                    const latest_status = statuses[0]['state'];
-                    console.log('Validating status: ' + latest_status);
-                    if(latest_status != 'success') {
-                      console.log('Discarding ' + branch + ' with status ' + latest_status);
-                      statusOK = false;
-                    }
+                  if(statuses.state !== 'success') {
+                    console.log('Discarding ' + branch + ' with status ' + statuses.state);
+                    statusOK = false;
                   }
                 }
                 console.log('Checking labels: ' + branch);

--- a/.github/workflows/combine-dependabot-prs.yml
+++ b/.github/workflows/combine-dependabot-prs.yml
@@ -52,16 +52,38 @@ jobs:
                 statusOK = true;
                 if(${{ github.event.inputs.mustBeGreen }}) {
                   console.log('Checking green status: ' + branch);
-                  const statuses = await github.request('GET /repos/{owner}/{repo}/commits/{ref}/status', {
+                  const statuses = await github.paginate('GET /repos/{owner}/{repo}/commits/{ref}/status', {
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     ref: branch
                   });
-                  if(statuses.state !== 'success') {
-                    console.log('Discarding ' + branch + ' with status ' + statuses.state);
-                    statusOK = false;
+
+                  if(statuses.length > 0) {
+                    const latest_status = statuses[0]['state'];
+                    console.log('Validating status: ' + latest_status);
+                    if(latest_status != 'success') {
+                      console.log('Discarding ' + branch + ' with status ' + latest_status);
+                      statusOK = false;
+                    }
+                  }
+
+                  console.log('Checking check suites: ' + branch);
+                  const checks = await github.paginate('GET /repos/{owner}/{repo}/commits/{ref}/check-suites', {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    ref: branch
+                  });
+
+                  for (const check of checks) {
+                    const isSuccess = (check.status == 'completed' && check.conclusion == 'success')
+                    const isDependabot = check.app.slug == 'dependabot'
+                    if (!isSuccess && !isDependabot) {
+                      console.log('Discarding ' + branch + ' with check suite ' + check.url);
+                      statusOK = false;
+                    }
                   }
                 }
+
                 console.log('Checking labels: ' + branch);
                 const labels = pull['labels'];
                 for(const label of labels) {


### PR DESCRIPTION
## Description
This Github Action only checks the status of pr branches, but we run many [checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks#types-of-status-checks-on-github) that all should be passing - ADO pipelines triggered by the Azure Dev Ops app is a check rather than a status. Added logic to check that all check suites are passing, but also to ignore dependabot checks, since they are queued but never seem to run.

## Testing
Manual