### PR TITLE
Return partial content for query workitems

### DIFF
--- a/docs/concepts/worklist.md
+++ b/docs/concepts/worklist.md
@@ -131,6 +131,7 @@ The query API will return one of the following status codes in the response:
 | Code                      | Description |
 | :------------------------ | :---------- |
 | 200 (OK)                  | The response payload contains all the matching resource. |
+| 206 (Partial Content)     | The response payload contains only some of the search results, and the rest can be requested through the appropriate request. |
 | 204 (No Content)          | The search completed successfully but returned no results. |
 | 400 (Bad Request)         | The was a problem with the request. For example, invalid Query Parameter syntax. Response body contains details of the failure. |
 | 401 (Unauthorized)        | The client is not authenticated. |
@@ -142,6 +143,7 @@ The query API will return one of the following status codes in the response:
 - Paged results are optimized to return matched *newest* instance first, this may result in duplicate records in subsequent pages if newer data matching the query was added.
 - Matching is case insensitive and accent insensitive for PN VR types.
 - Matching is case insensitive and accent sensitive for other string VR types.
+- If there is a scenario where canceling a Workitem and querying the same happens at the same time, then the query will most likely exclude the Workitem that is getting updated and the response code will be 206 (Partial Content).
 
 ## Request Cancellation
 

--- a/src/Microsoft.Health.Dicom.Api/Controllers/WorkitemController.Query.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/WorkitemController.Query.cs
@@ -50,6 +50,6 @@ public partial class WorkitemController
             options.ToBaseQueryParameters(Request.Query),
             cancellationToken: HttpContext.RequestAborted);
 
-        return response.ResponseDatasets.Any() ? StatusCode((int)HttpStatusCode.OK, response.ResponseDatasets) : NoContent();
+        return response.ResponseDatasets.Any() ? StatusCode((int)response.Status.QueryResponseToHttpStatusCode(), response.ResponseDatasets) : NoContent();
     }
 }

--- a/src/Microsoft.Health.Dicom.Api/Extensions/WorkitemResponseStatusExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Api/Extensions/WorkitemResponseStatusExtensions.cs
@@ -29,6 +29,14 @@ public static class WorkitemResponseStatusExtensions
             { WorkitemResponseStatus.Conflict, HttpStatusCode.Conflict }
         };
 
+    private static readonly IReadOnlyDictionary<WorkitemResponseStatus, HttpStatusCode> QueryResponseStatusToHttpStatusCodeMapping =
+        new Dictionary<WorkitemResponseStatus, HttpStatusCode>()
+        {
+            { WorkitemResponseStatus.Success, HttpStatusCode.OK },
+            { WorkitemResponseStatus.NoContent, HttpStatusCode.NoContent },
+            { WorkitemResponseStatus.PartialContent, HttpStatusCode.PartialContent },
+        };
+
     /// <summary>
     /// Converts from <see cref="WorkitemResponseStatus"/> to <see cref="HttpStatusCode"/>.
     /// </summary>
@@ -44,4 +52,12 @@ public static class WorkitemResponseStatusExtensions
     /// <returns>The converted <see cref="HttpStatusCode"/>.</returns>
     public static HttpStatusCode CancelResponseToHttpStatusCode(this WorkitemResponseStatus status)
         => CancelResponseStatusToHttpStatusCodeMapping[status];
+
+    /// <summary>
+    /// Converts from <see cref="WorkitemResponseStatus"/> to <see cref="HttpStatusCode"/>.
+    /// </summary>
+    /// <param name="status">The status to convert.</param>
+    /// <returns>The converted <see cref="HttpStatusCode"/>.</returns>
+    public static HttpStatusCode QueryResponseToHttpStatusCode(this WorkitemResponseStatus status)
+        => QueryResponseStatusToHttpStatusCodeMapping[status];
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Workitem/Model/WorkitemInstanceIdentifier.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Workitem/Model/WorkitemInstanceIdentifier.cs
@@ -51,5 +51,5 @@ public class WorkitemInstanceIdentifier
         => (PartitionKey + WorkitemUid + WorkitemKey.ToString() + Watermark.ToString()).GetHashCode(EqualsStringComparison);
 
     public override string ToString()
-        => $"PartitionKey: {PartitionKey}, WorkitemUID: {WorkitemUid}, WorkitemKey: {WorkitemKey}, Watermark: {Watermark}";
+        => $"PartitionKey: {PartitionKey}, WorkitemKey: {WorkitemKey}, Watermark: {Watermark}";
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Workitem/WorkitemOrchestrator.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Workitem/WorkitemOrchestrator.cs
@@ -199,7 +199,7 @@ public class WorkitemOrchestrator : IWorkitemOrchestrator
         }
         catch (ItemNotFoundException ex)
         {
-            _logger.LogWarning(ex, "Workitem blob doesn't exist due to simultaneous GET and UPDATE request.");
+            _logger.LogWarning(ex, "Workitem [{Identifier}] blob doesn't exist due to simultaneous GET and UPDATE request.", identifier);
             return null;
         }
     }

--- a/src/Microsoft.Health.Dicom.Core/Features/Workitem/WorkitemOrchestrator.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Workitem/WorkitemOrchestrator.cs
@@ -199,7 +199,7 @@ public class WorkitemOrchestrator : IWorkitemOrchestrator
         }
         catch (ItemNotFoundException ex)
         {
-            _logger.LogWarning(ex, "Workitem [{Identifier}] blob doesn't exist due to simultaneous GET and UPDATE request.", identifier);
+            _logger.LogWarning(ex, "Workitem [{Identifier}] blob doesn't exist due to simultaneous GET and UPDATE request or it could just be missing.", identifier);
             return null;
         }
     }

--- a/src/Microsoft.Health.Dicom.Core/Features/Workitem/WorkitemQueryResponseBuilder.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Workitem/WorkitemQueryResponseBuilder.cs
@@ -79,7 +79,7 @@ public static class WorkitemQueryResponseBuilder
         {
             status = WorkitemResponseStatus.PartialContent;
         }
-        else if (!datasets.Any())
+        else if (datasets.Any())
         {
             status = WorkitemResponseStatus.Success;
         }

--- a/src/Microsoft.Health.Dicom.Core/Features/Workitem/WorkitemQueryResponseBuilder.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Workitem/WorkitemQueryResponseBuilder.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using EnsureThat;
 using FellowOakDicom;
 using Microsoft.Health.Dicom.Core.Features.Query.Model;
+using Microsoft.Health.Dicom.Core.Messages.Workitem;
 
 namespace Microsoft.Health.Dicom.Core.Features.Workitem;
 
@@ -67,10 +68,32 @@ public static class WorkitemQueryResponseBuilder
     };
 
     /// <summary>
+    /// Builds workitem query response
+    /// </summary>
+    /// <returns></returns>
+    public static QueryWorkitemResourceResponse BuildWorkitemQueryResponse(IReadOnlyList<DicomDataset> datasets, BaseQueryExpression queryExpression)
+    {
+        var status = WorkitemResponseStatus.NoContent;
+
+        if (datasets.Any(x => x == null))
+        {
+            status = WorkitemResponseStatus.PartialContent;
+        }
+        else if (!datasets.Any())
+        {
+            status = WorkitemResponseStatus.Success;
+        }
+
+        var workitemResponses = datasets.Where(x => x != null).Select(m => GenerateResponseDataset(m, queryExpression)).ToList();
+
+        return new QueryWorkitemResourceResponse(workitemResponses, status);
+    }
+
+    /// <summary>
     /// Includes workitem attributes as specified in
     /// <see href='https://dicom.nema.org/medical/dicom/current/output/html/part18.html#sect_11.9.2'/>.
     /// </summary>
-    public static DicomDataset GenerateResponseDataset(DicomDataset dicomDataset, BaseQueryExpression queryExpression)
+    private static DicomDataset GenerateResponseDataset(DicomDataset dicomDataset, BaseQueryExpression queryExpression)
     {
         EnsureArg.IsNotNull(dicomDataset, nameof(dicomDataset));
         EnsureArg.IsNotNull(queryExpression, nameof(queryExpression));

--- a/src/Microsoft.Health.Dicom.Core/Messages/WorkItem/QueryWorkitemResourceResponse.cs
+++ b/src/Microsoft.Health.Dicom.Core/Messages/WorkItem/QueryWorkitemResourceResponse.cs
@@ -11,10 +11,13 @@ namespace Microsoft.Health.Dicom.Core.Messages.Workitem;
 
 public sealed class QueryWorkitemResourceResponse
 {
-    public QueryWorkitemResourceResponse(IReadOnlyList<DicomDataset> responseDataset)
+    public QueryWorkitemResourceResponse(IReadOnlyList<DicomDataset> responseDataset, WorkitemResponseStatus status)
     {
         ResponseDatasets = EnsureArg.IsNotNull(responseDataset, nameof(responseDataset));
+        Status = status;
     }
+
+    public WorkitemResponseStatus Status { get; }
 
     public IReadOnlyList<DicomDataset> ResponseDatasets { get; }
 }

--- a/src/Microsoft.Health.Dicom.Core/Messages/WorkItem/WorkitemResponseStatus.cs
+++ b/src/Microsoft.Health.Dicom.Core/Messages/WorkItem/WorkitemResponseStatus.cs
@@ -34,4 +34,14 @@ public enum WorkitemResponseStatus
     /// Workitem instance already exist.
     /// </summary>
     Conflict,
+
+    /// <summary>
+    /// All matching workitem instance(s) found
+    /// </summary>
+    NoContent,
+
+    /// <summary>
+    /// Only partial workitem instance(s) found
+    /// </summary>
+    PartialContent,
 }


### PR DESCRIPTION
## Description
This PR handles the conflict that could while querying workitems and return partial content if in case it is not able to find the result dataset.

## Related issues
Addresses [AB#90099](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/90099).

## Testing
Added unit tests