### PR TITLE
Skip two flaky extendedQueryTag tests.

### DIFF
--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/ExtendedQueryTagTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/ExtendedQueryTagTests.cs
@@ -39,7 +39,7 @@ public class ExtendedQueryTagTests : IClassFixture<WebJobsIntegrationTestFixture
         _instanceManager = new DicomInstancesManager(_client);
     }
 
-    [Fact]
+    [Fact(Skip = "Bug#90068")]
     [Trait("Category", "bvt")]
     public async Task GivenExtendedQueryTag_WhenReindexing_ThenShouldSucceed()
     {
@@ -218,7 +218,7 @@ public class ExtendedQueryTagTests : IClassFixture<WebJobsIntegrationTestFixture
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
-    [Fact]
+    [Fact(Skip = "Bug#90068")]
     public async Task GivenInvalidISAndIndexed_WhenStoring_ThenServerShouldReturnConflict()
     {
         DicomTag tag = DicomTag.StageNumber;


### PR DESCRIPTION
## Description
CI has 2 flaky tests that fails. Skip these tests, to be fixed with mentioned bug

## Related issues
[AB#90068](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/90068)

## Testing
NA
