### PR TITLE
Add cases for connection closed exceptions

### DIFF
--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Exceptions/ExceptionHandlingMiddlewareTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Exceptions/ExceptionHandlingMiddlewareTests.cs
@@ -54,7 +54,7 @@ public class ExceptionHandlingMiddlewareTests
 
     [Theory]
     [MemberData(nameof(GetExceptionToStatusCodeMapping))]
-    public async Task GivenAnException_WhenMiddlewareIsExecuted_ThenCorrectStatusCodeShouldBeRetruned(Exception exception, HttpStatusCode expectedStatusCode)
+    public async Task GivenAnException_WhenMiddlewareIsExecuted_ThenCorrectStatusCodeShouldBeReturned(Exception exception, HttpStatusCode expectedStatusCode)
     {
         ExceptionHandlingMiddleware baseExceptionMiddleware = CreateExceptionHandlingMiddleware(innerHttpContext => throw exception);
 

--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Exceptions/ExceptionHandlingMiddlewareTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Exceptions/ExceptionHandlingMiddlewareTests.cs
@@ -5,9 +5,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -44,6 +46,9 @@ public class ExceptionHandlingMiddlewareTests
         yield return new object[] { new ServiceUnavailableException(), HttpStatusCode.ServiceUnavailable };
         yield return new object[] { new ItemNotFoundException(new Exception()), HttpStatusCode.InternalServerError };
         yield return new object[] { new CustomServerException(), HttpStatusCode.ServiceUnavailable };
+        yield return new object[] { new BadHttpRequestException("Unexpected end of request content."), HttpStatusCode.BadRequest };
+        yield return new object[] { new IOException("The request stream was aborted."), HttpStatusCode.BadRequest };
+        yield return new object[] { new ConnectionResetException(string.Empty), HttpStatusCode.BadRequest };
     }
 
     [Theory]

--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Exceptions/ExceptionHandlingMiddlewareTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Exceptions/ExceptionHandlingMiddlewareTests.cs
@@ -49,6 +49,7 @@ public class ExceptionHandlingMiddlewareTests
         yield return new object[] { new BadHttpRequestException("Unexpected end of request content."), HttpStatusCode.BadRequest };
         yield return new object[] { new IOException("The request stream was aborted."), HttpStatusCode.BadRequest };
         yield return new object[] { new ConnectionResetException(string.Empty), HttpStatusCode.BadRequest };
+        yield return new object[] { new OperationCanceledException(), HttpStatusCode.BadRequest };
     }
 
     [Theory]

--- a/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
@@ -4,11 +4,13 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.IO;
 using System.Net;
 using System.Runtime.ExceptionServices;
 using System.Text.Json;
 using System.Threading.Tasks;
 using EnsureThat;
+using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -55,12 +57,12 @@ public class ExceptionHandlingMiddleware
 
         if (exceptionDispatchInfo != null)
         {
-            IActionResult result = MapExceptionToResult(exceptionDispatchInfo.SourceException);
+            IActionResult result = MapExceptionToResult(exceptionDispatchInfo.SourceException, context);
             await ExecuteResultAsync(context, result);
         }
     }
 
-    private IActionResult MapExceptionToResult(Exception exception)
+    private IActionResult MapExceptionToResult(Exception exception, HttpContext context)
     {
         HttpStatusCode statusCode = HttpStatusCode.InternalServerError;
         string message = exception.Message;
@@ -76,6 +78,9 @@ public class ExceptionHandlingMiddleware
             case NotSupportedException _:
             case AuditHeaderCountExceededException _:
             case AuditHeaderTooLargeException _:
+            case BadHttpRequestException br when br.Message.Equals("Unexpected end of request content.", StringComparison.OrdinalIgnoreCase):
+            case IOException io when io.Message.Equals("The request stream was aborted.", StringComparison.OrdinalIgnoreCase):
+            case ConnectionResetException _:
                 statusCode = HttpStatusCode.BadRequest;
                 break;
             case ResourceNotFoundException _:

--- a/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
@@ -57,12 +57,12 @@ public class ExceptionHandlingMiddleware
 
         if (exceptionDispatchInfo != null)
         {
-            IActionResult result = MapExceptionToResult(exceptionDispatchInfo.SourceException, context);
+            IActionResult result = MapExceptionToResult(exceptionDispatchInfo.SourceException);
             await ExecuteResultAsync(context, result);
         }
     }
 
-    private IActionResult MapExceptionToResult(Exception exception, HttpContext context)
+    private IActionResult MapExceptionToResult(Exception exception)
     {
         HttpStatusCode statusCode = HttpStatusCode.InternalServerError;
         string message = exception.Message;

--- a/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
@@ -81,6 +81,7 @@ public class ExceptionHandlingMiddleware
             case BadHttpRequestException br when br.Message.Equals("Unexpected end of request content.", StringComparison.OrdinalIgnoreCase):
             case IOException io when io.Message.Equals("The request stream was aborted.", StringComparison.OrdinalIgnoreCase):
             case ConnectionResetException _:
+            case OperationCanceledException _:
                 statusCode = HttpStatusCode.BadRequest;
                 break;
             case ResourceNotFoundException _:

--- a/src/Microsoft.Health.Dicom.Core/Features/HealthCheck/BackgroundServiceHealthCheck.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/HealthCheck/BackgroundServiceHealthCheck.cs
@@ -49,12 +49,12 @@ public class BackgroundServiceHealthCheck : IHealthCheck
     {
         try
         {
-            Task<DateTimeOffset> oldestWaitingToBeDeleated = _backgroundServiceHealthCheckCache.GetOrAddOldestTimeAsync(_indexDataStore.GetOldestDeletedAsync, cancellationToken);
+            Task<DateTimeOffset> oldestWaitingToBeDeleted = _backgroundServiceHealthCheckCache.GetOrAddOldestTimeAsync(_indexDataStore.GetOldestDeletedAsync, cancellationToken);
             Task<int> numReachedMaxedRetry = _backgroundServiceHealthCheckCache.GetOrAddNumExhaustedDeletionAttemptsAsync(
                 t => _indexDataStore.RetrieveNumExhaustedDeletedInstanceAttemptsAsync(_deletedInstanceCleanupConfiguration.MaxRetries, t),
                 cancellationToken);
 
-            _telemetryClient.GetMetric("Oldest-Requested-Deletion").TrackValue((await oldestWaitingToBeDeleated).ToUnixTimeSeconds());
+            _telemetryClient.GetMetric("Oldest-Requested-Deletion").TrackValue((await oldestWaitingToBeDeleted).ToUnixTimeSeconds());
             _telemetryClient.GetMetric("Count-Deletions-Max-Retry").TrackValue(await numReachedMaxedRetry);
         }
         catch (DataStoreException e) // This is expected when service is starting up without schema initialization


### PR DESCRIPTION
## Description
This PR updates the `ExceptionHandlingMiddleware` to handle cases when the client has closed the connection. It now sets a status of `BadRequest` vs the previously recorded `InternalServerError`. 

## Related issues
Addresses [AB#90280](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/90280).

## Testing
Added unit test, manually tested with local connection closed and downstream implementations.
