### PR TITLE
Move swagger api out of dev to support URSA scan

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
@@ -179,19 +179,6 @@ public static class DicomServerServiceCollectionExtensions
                 if (env.IsDevelopment())
                 {
                     app.UseDeveloperExceptionPage();
-                    app.UseSwagger(c =>
-                    {
-                        c.RouteTemplate = "{documentName}/api.{json|yaml}";
-                    });
-
-                    //Disabling swagger ui until accesability team gets back to us
-                    //app.UseSwaggerUI(options =>
-                    //{
-                    //    foreach (ApiVersionDescription description in provider.ApiVersionDescriptions)
-                    //    {
-                    //        options.SwaggerEndpoint($"/swagger/{description.GroupName}/swagger.yaml", description.GroupName.ToUpperInvariant());
-                    //    }
-                    //});
                 }
 
                 app.UseAudit();
@@ -201,6 +188,21 @@ public static class DicomServerServiceCollectionExtensions
                 app.UseAuthentication();
 
                 app.UseRequestContextAfterAuthentication<IDicomRequestContext>();
+
+                // Dependency on URSA scan. We should see how other teams do this.
+                app.UseSwagger(c =>
+                {
+                    c.RouteTemplate = "{documentName}/api.{json|yaml}";
+                });
+
+                //Disabling swagger ui until accesability team gets back to us
+                //app.UseSwaggerUI(options =>
+                //{
+                //    foreach (ApiVersionDescription description in provider.ApiVersionDescriptions)
+                //    {
+                //        options.SwaggerEndpoint($"/swagger/{description.GroupName}/swagger.yaml", description.GroupName.ToUpperInvariant());
+                //    }
+                //});
 
                 next(app);
             };


### PR DESCRIPTION
## Description
Had moved the swagger to dev only in this PR https://github.com/microsoft/dicom-server/pull/1364/files#diff-dd43c40853387d56010cb41f7edfe564e9b891711897f35fc3c904af0aecfb12
Looks like we have a dependency on this being in prod for URSA scan

## Related issues
[AB#91363](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/91363)

## Testing
NA
