### PR TITLE
Refactor Json.NET Serialization and Add Configuration Binder Set Method

### DIFF
--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Extensions/ConfigurationBinderExtensionsTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Extensions/ConfigurationBinderExtensionsTests.cs
@@ -1,0 +1,173 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Health.Dicom.Core.Extensions;
+using Xunit;
+
+namespace Microsoft.Health.Dicom.Core.UnitTests.Extensions;
+
+public class ConfigurationBinderExtensionsTests
+{
+    [Fact]
+    public void GivenObject_WhenBindingToConfiguration_ThenWriteKeyValues()
+    {
+        var options = new ExampleOptions
+        {
+            DoubleNumber = 3.14D,
+            FloatNumber = -10.11F,
+            LongNumber = 98765L,
+            Nested = new NestedOptions
+            {
+                Character = '!',
+                DateAndTime = new DateTime(1000, 10, 10, 10, 10, 10, DateTimeKind.Utc),
+                DecimalNumber = 0.9999M,
+                OffsetDateAndTime = new DateTimeOffset(new DateTime(2000, 2, 2), TimeSpan.FromHours(3)),
+                Text = "Hello World",
+            },
+            UIntNumber = 2468,
+            ULongNumber = 1357911,
+        };
+
+        ExampleOptions.ByteArray = new byte[] { 1, 2, 3 };
+        ExampleOptions.Flag = true;
+        ExampleOptions.SByteNumber = 7;
+        ExampleOptions.ShortEnumerable = new short[] { 4, 5, 6, 7, 8 };
+
+        NestedOptions.AnotherLevel = new ReallyNestedOptions
+        {
+            Duration = TimeSpan.Parse("11.22:33:44"),
+            Id = Guid.Parse("a5980f6d-abe4-4495-a972-8b9844962d28"),
+            IntList = new List<int> { 10, 20, -30, -40 },
+            Resource = new Uri("https://www.bing.com"),
+        };
+
+        NestedOptions.UShortCollection = new ushort[] { 1 };
+
+        IConfigurationSection section;
+        IConfiguration config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        config.Set(options);
+
+        Assert.Equal("True", config[nameof(ExampleOptions.Flag)]);
+        Assert.Equal("7", config[nameof(ExampleOptions.SByteNumber)]);
+        Assert.Equal("2468", config[nameof(ExampleOptions.UIntNumber)]);
+        Assert.Equal("98765", config[nameof(ExampleOptions.LongNumber)]);
+        Assert.Equal("1357911", config[nameof(ExampleOptions.ULongNumber)]);
+        Assert.Equal("-10.11", config[nameof(ExampleOptions.FloatNumber)]);
+        Assert.Equal("3.14", config[nameof(ExampleOptions.DoubleNumber)]);
+        Assert.Null(config[nameof(ExampleOptions.Ignored1)]);
+        Assert.Null(config[nameof(ExampleOptions.Ignored2)]);
+
+        section = config.GetSection(nameof(ExampleOptions.ByteArray));
+        Assert.Equal(3, section.GetChildren().Count(x => x.Value != null));
+        Assert.Equal("1", section["0"]);
+        Assert.Equal("2", section["1"]);
+        Assert.Equal("3", section["2"]);
+
+        section = config.GetSection(nameof(ExampleOptions.ShortEnumerable));
+        Assert.Equal(5, section.GetChildren().Count(x => x.Value != null));
+        Assert.Equal("4", section["0"]);
+        Assert.Equal("5", section["1"]);
+        Assert.Equal("6", section["2"]);
+        Assert.Equal("7", section["3"]);
+        Assert.Equal("8", section["4"]);
+
+        config = config.GetSection(nameof(ExampleOptions.Nested));
+        Assert.Equal("0.9999", config[nameof(NestedOptions.DecimalNumber)]);
+        Assert.Equal("!", config[nameof(NestedOptions.Character)]);
+        Assert.Equal("Hello World", config[nameof(NestedOptions.Text)]);
+        Assert.Equal("1000-10-10T10:10:10.0000000Z", config[nameof(NestedOptions.DateAndTime)]);
+        Assert.Equal("2000-02-02T00:00:00.0000000+03:00", config[nameof(NestedOptions.OffsetDateAndTime)]);
+        Assert.Null(config[nameof(NestedOptions.Ignored3)]);
+
+        section = config.GetSection(nameof(NestedOptions.UShortCollection));
+        Assert.Equal(1, section.GetChildren().Count(x => x.Value != null));
+        Assert.Equal("1", section["0"]);
+
+        config = config.GetSection(nameof(NestedOptions.AnotherLevel));
+        Assert.Equal("11.22:33:44", config[nameof(ReallyNestedOptions.Duration)]);
+        Assert.Equal("a5980f6d-abe4-4495-a972-8b9844962d28", config[nameof(ReallyNestedOptions.Id)]);
+        Assert.Equal("https://www.bing.com", config[nameof(ReallyNestedOptions.Resource)]);
+        Assert.Null(config[nameof(ReallyNestedOptions.Ignored4)]);
+        Assert.Null(config[nameof(ReallyNestedOptions.Ignored5)]);
+
+        section = config.GetSection(nameof(ReallyNestedOptions.IntList));
+        Assert.Equal(4, section.GetChildren().Count(x => x.Value != null));
+        Assert.Equal("10", section["0"]);
+        Assert.Equal("20", section["1"]);
+        Assert.Equal("-30", section["2"]);
+        Assert.Equal("-40", section["3"]);
+    }
+
+    private sealed class ExampleOptions
+    {
+        public static bool Flag { get; set; }
+
+        public static sbyte SByteNumber { get; set; }
+
+        public static byte[] ByteArray { get; set; }
+
+        public static IEnumerable<short> ShortEnumerable { get; set; }
+
+        internal static int Ignored1 { get; set; }
+
+        public uint UIntNumber { get; set; }
+
+        public long LongNumber { get; set; }
+
+        public ulong ULongNumber { get; set; }
+
+        public float FloatNumber { get; set; }
+
+        public double DoubleNumber { get; set; }
+
+        public NestedOptions Nested { get; set; }
+
+        internal string Ignored2 { get; set; }
+    }
+
+    private sealed class NestedOptions
+    {
+        public static IReadOnlyCollection<ushort> UShortCollection { get; set; }
+
+        public static ReallyNestedOptions AnotherLevel { get; set; }
+
+        public decimal DecimalNumber { get; set; }
+
+        public char Character { get; set; }
+
+        public string Text { get; set; }
+
+        public DateTime DateAndTime { get; set; }
+
+        public DateTimeOffset OffsetDateAndTime { get; set; }
+
+        public char Ignored3 => '~';
+    }
+
+    private sealed class ReallyNestedOptions
+    {
+        public IReadOnlyList<int> IntList { get; set; }
+
+        public TimeSpan Duration { get; set; }
+
+        public Guid Id { get; set; }
+
+        public Uri Resource { get; set; }
+
+        public double Ignored4
+        {
+            set
+            {
+                Ignored5 = value;
+            }
+        }
+
+        public double Ignored5;
+    }
+}

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Extensions/JsonSerializerOptionsExtensionsTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Extensions/JsonSerializerOptionsExtensionsTests.cs
@@ -27,10 +27,11 @@ public class JsonSerializerOptionsExtensionsTests
     [Fact]
     public void GivenOptions_WhenConfiguringDefaults_ThenUpdateProperties()
     {
-        Assert.Equal(3, _options.Converters.Count);
+        Assert.Equal(4, _options.Converters.Count);
         Assert.Equal(typeof(ConfigurationJsonConverter), _options.Converters[0].GetType());
-        Assert.Equal(typeof(DicomJsonConverter), _options.Converters[1].GetType());
-        Assert.Equal(typeof(StrictStringEnumConverterFactory), _options.Converters[2].GetType());
+        Assert.Equal(typeof(DicomIdentifierJsonConverter), _options.Converters[1].GetType());
+        Assert.Equal(typeof(DicomJsonConverter), _options.Converters[2].GetType());
+        Assert.Equal(typeof(StrictStringEnumConverterFactory), _options.Converters[3].GetType());
 
         Assert.True(_options.AllowTrailingCommas);
         Assert.Equal(JsonIgnoreCondition.WhenWritingNull, _options.DefaultIgnoreCondition);

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Extensions/JsonSerializerSettingsExtensionsTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Extensions/JsonSerializerSettingsExtensionsTests.cs
@@ -3,16 +3,16 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
+using System.Globalization;
 using Microsoft.Health.Dicom.Core.Extensions;
-using Xunit;
+using Microsoft.Health.Dicom.Core.Features.Model;
+using Microsoft.Health.Dicom.Core.Models.Indexing;
+using Microsoft.Health.Dicom.Core.Serialization.Newtonsoft;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
-using Microsoft.Health.Dicom.Core.Models.Indexing;
-using Microsoft.Health.Dicom.Core.Features.Model;
-using System;
-using System.Globalization;
-using Microsoft.Health.Dicom.Core.Serialization.Newtonsoft;
+using Xunit;
 
 namespace Microsoft.Health.Dicom.Core.UnitTests.Extensions;
 

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Extensions/JsonSerializerSettingsExtensionsTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Extensions/JsonSerializerSettingsExtensionsTests.cs
@@ -1,0 +1,112 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Dicom.Core.Extensions;
+using Xunit;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
+using Microsoft.Health.Dicom.Core.Models.Indexing;
+using Microsoft.Health.Dicom.Core.Features.Model;
+using System;
+using System.Globalization;
+using Microsoft.Health.Dicom.Core.Serialization.Newtonsoft;
+
+namespace Microsoft.Health.Dicom.Core.UnitTests.Extensions;
+
+public class JsonSerializerSettingsExtensionsTests
+{
+    private readonly JsonSerializerSettings _settings;
+
+    public JsonSerializerSettingsExtensionsTests()
+    {
+        _settings = new JsonSerializerSettings();
+        _settings.ConfigureDefaultDicomSettings();
+    }
+
+    [Fact]
+    public void GivenSettings_WhenConfiguringDefaults_ThenUpdateProperties()
+    {
+        Assert.Equal(2, _settings.Converters.Count);
+        Assert.Equal(typeof(ConfigurationJsonConverter), _settings.Converters[0].GetType());
+        Assert.Equal(typeof(StringEnumConverter), _settings.Converters[1].GetType());
+
+        Assert.Equal(DateParseHandling.None, _settings.DateParseHandling);
+        Assert.Equal(TypeNameHandling.None, _settings.TypeNameHandling);
+        Assert.IsType<DefaultContractResolver>(_settings.ContractResolver);
+        Assert.IsType<CamelCaseNamingStrategy>(((DefaultContractResolver)_settings.ContractResolver).NamingStrategy);
+    }
+
+    [Fact]
+    public void GivenOldJson_WhenDeserializingWithNewSettings_ThenPreserveProperties()
+    {
+        const string json =
+@"{
+  ""Completed"": {
+    ""Start"": 1,
+    ""End"": 6
+  },
+  ""CreatedTime"": ""2022-05-09T16:56:48.3050668Z"",
+  ""PercentComplete"": 100,
+  ""ResourceIds"": [
+    ""15"",
+    ""16""
+  ],
+  ""AdditionalProperties"": null,
+  ""QueryTagKeys"": [
+    15,
+    16
+  ],
+  ""Batching"": {
+    ""Size"": 100,
+    ""MaxParallelCount"": 1,
+    ""MaxParallelElements"": 100
+  }
+}";
+
+        ReindexCheckpoint checkpoint = JsonConvert.DeserializeObject<ReindexCheckpoint>(json, _settings);
+        AssertCheckpoint(checkpoint);
+
+        string actual = JsonConvert.SerializeObject(checkpoint, Formatting.Indented, _settings);
+        Assert.Equal(
+@"{
+  ""completed"": {
+    ""start"": 1,
+    ""end"": 6
+  },
+  ""createdTime"": ""2022-05-09T16:56:48.3050668Z"",
+  ""queryTagKeys"": [
+    15,
+    16
+  ],
+  ""batching"": {
+    ""size"": 100,
+    ""maxParallelCount"": 1
+  }
+}",
+            actual);
+
+        checkpoint = JsonConvert.DeserializeObject<ReindexCheckpoint>(actual, _settings);
+        AssertCheckpoint(checkpoint);
+    }
+
+    private static void AssertCheckpoint(ReindexCheckpoint checkpoint)
+    {
+        var createdTime = DateTime.Parse("2022-05-09T16:56:48.3050668Z", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
+        Assert.Null(checkpoint.AdditionalProperties);
+        Assert.Equal(100, checkpoint.Batching.Size);
+        Assert.Equal(1, checkpoint.Batching.MaxParallelCount);
+        Assert.Equal(100, checkpoint.Batching.MaxParallelElements);
+        Assert.Equal(new WatermarkRange(1, 6), checkpoint.Completed);
+        Assert.Equal(createdTime, checkpoint.CreatedTime);
+        Assert.Equal(100, checkpoint.PercentComplete);
+        Assert.Equal(2, checkpoint.QueryTagKeys.Count);
+        Assert.Contains(15, checkpoint.QueryTagKeys);
+        Assert.Contains(16, checkpoint.QueryTagKeys);
+        Assert.Equal(2, checkpoint.ResourceIds.Count);
+        Assert.Contains("15", checkpoint.ResourceIds);
+        Assert.Contains("16", checkpoint.ResourceIds);
+    }
+}

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Microsoft.Health.Dicom.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Microsoft.Health.Dicom.Core.UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -8,6 +8,9 @@
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="fo-dicom" Version="$(FoDicomVersion)" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(SdkPackageVersion)" />

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Serialization/ConfigurationJsonConverterTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Serialization/ConfigurationJsonConverterTests.cs
@@ -58,7 +58,7 @@ public class ConfigurationJsonConverterTests
         Assert.Equal("zero", actual["array:0"]);
         Assert.Equal("one", actual["array:1"]);
         Assert.Equal("two", actual["array:2"]);
-        Assert.Equal("true", actual["object:bool"]);
+        Assert.Equal("True", actual["object:bool"]);
         Assert.Equal("1.2345", actual["object:nested:float"]);
         Assert.Null(actual["object:nested:null"]);
         Assert.Null(actual["object:nested:empty"]);

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Serialization/DicomIdentifierJsonConverterTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Serialization/DicomIdentifierJsonConverterTests.cs
@@ -1,0 +1,42 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Text.Json;
+using Microsoft.Health.Dicom.Core.Models.Common;
+using Microsoft.Health.Dicom.Core.Serialization;
+using Xunit;
+
+namespace Microsoft.Health.Dicom.Core.UnitTests.Serialization;
+
+public class DicomIdentifierJsonConverterTests
+{
+    private readonly JsonSerializerOptions _serializerOptions;
+
+    public DicomIdentifierJsonConverterTests()
+    {
+        _serializerOptions = new JsonSerializerOptions();
+        _serializerOptions.Converters.Add(new DicomIdentifierJsonConverter());
+    }
+
+    [Theory]
+    [InlineData("\"1.2.345\"", "1.2.345", null, null)]
+    [InlineData("\"1.2.345/67.89\"", "1.2.345", "67.89", null)]
+    [InlineData("\"1.2.345/67.89/10.11121314.1516.17.18.1920\"", "1.2.345", "67.89", "10.11121314.1516.17.18.1920")]
+    public void GivenJson_WhenReading_ThenDeserialize(string json, string study, string series, string instance)
+    {
+        DicomIdentifier actual = JsonSerializer.Deserialize<DicomIdentifier>(json, _serializerOptions);
+
+        Assert.Equal(study, actual.StudyInstanceUid);
+        Assert.Equal(series, actual.SeriesInstanceUid);
+        Assert.Equal(instance, actual.SopInstanceUid);
+    }
+
+    [Theory]
+    [InlineData("1.2.345", null, null, "\"1.2.345\"")]
+    [InlineData("1.2.345", "67.89", null, "\"1.2.345/67.89\"")]
+    [InlineData("1.2.345", "67.89", "10.11121314.1516.17.18.1920", "\"1.2.345/67.89/10.11121314.1516.17.18.1920\"")]
+    public void GivenDicomIdentifier_WhenConvertingToString_ThenGetString(string study, string series, string instance, string expected)
+        => Assert.Equal(expected, JsonSerializer.Serialize(new DicomIdentifier(study, series, instance), _serializerOptions));
+}

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Serialization/Newtonsoft/ConfigurationJsonConverterTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Serialization/Newtonsoft/ConfigurationJsonConverterTests.cs
@@ -18,8 +18,98 @@ public class ConfigurationJsonConverterTests
 
     public ConfigurationJsonConverterTests()
     {
-        _serializerSettings = new JsonSerializerSettings { Formatting = Formatting.Indented };
+        _serializerSettings = new JsonSerializerSettings
+        {
+            Formatting = Formatting.Indented,
+            DateFormatHandling = DateFormatHandling.IsoDateFormat,
+            DateParseHandling = DateParseHandling.None,
+            DateTimeZoneHandling = DateTimeZoneHandling.Utc,
+        };
         _serializerSettings.Converters.Add(new ConfigurationJsonConverter(new CamelCaseNamingStrategy()));
+    }
+
+    [Fact]
+    public void GivenJson_WhenReadingWithNoDateParsing_ThenDeserialize()
+    {
+        _serializerSettings.DateParseHandling = DateParseHandling.None;
+
+        const string json = @"{
+  ""date"": ""2022-04-14T23:39:26.7818757Z"",
+  ""dateOffset"": ""2022-05-03T15:35:57.2628853-03:00"",
+}";
+
+        IConfiguration actual = JsonConvert.DeserializeObject<IConfiguration>(json, _serializerSettings);
+
+        Assert.Equal("2022-04-14T23:39:26.7818757Z", actual["date"]);
+        Assert.Equal("2022-05-03T15:35:57.2628853-03:00", actual["dateOffset"]);
+    }
+
+    [Fact]
+    public void GivenJson_WhenReadingWithDateTimeParsing_ThenDeserialize()
+    {
+        _serializerSettings.DateParseHandling = DateParseHandling.DateTime;
+
+        const string json = @"{
+  ""date"": ""2022-04-14T23:39:26.7818757Z"",
+  ""dateOffset"": ""2022-05-03T15:35:57.2628853-03:00"",
+}";
+
+        IConfiguration actual = JsonConvert.DeserializeObject<IConfiguration>(json, _serializerSettings);
+
+        Assert.Equal("2022-04-14T23:39:26.7818757Z", actual["date"]);
+        Assert.Equal("2022-05-03T18:35:57.2628853Z", actual["dateOffset"]);
+    }
+
+    [Fact]
+    public void GivenJson_WhenReadingWithDateTimeOffsetParsing_ThenDeserialize()
+    {
+        _serializerSettings.DateParseHandling = DateParseHandling.DateTimeOffset;
+
+        const string json = @"{
+  ""date"": ""2022-04-14T23:39:26.7818757Z"",
+  ""dateOffset"": ""2022-05-03T15:35:57.2628853-03:00"",
+}";
+
+        IConfiguration actual = JsonConvert.DeserializeObject<IConfiguration>(json, _serializerSettings);
+
+        Assert.Equal("2022-04-14T23:39:26.7818757+00:00", actual["date"]);
+        Assert.Equal("2022-05-03T15:35:57.2628853-03:00", actual["dateOffset"]);
+    }
+
+    [Fact]
+    public void GivenJson_WhenReadingWithDoubleParsing_ThenDeserialize()
+    {
+        _serializerSettings.FloatParseHandling = FloatParseHandling.Double;
+
+        const string json = @"{
+  ""float"": ""12.345"",
+  ""double"": ""-6.78910"",
+  ""decimal"": ""1112.1314151617181920""
+}";
+
+        IConfiguration actual = JsonConvert.DeserializeObject<IConfiguration>(json, _serializerSettings);
+
+        Assert.Equal("12.345", actual["float"]);
+        Assert.Equal("-6.78910", actual["double"]);
+        Assert.Equal("1112.1314151617181920", actual["decimal"]);
+    }
+
+    [Fact]
+    public void GivenJson_WhenReadingWithDecimalParsing_ThenDeserialize()
+    {
+        _serializerSettings.FloatParseHandling = FloatParseHandling.Decimal;
+
+        const string json = @"{
+  ""float"": ""12.345"",
+  ""double"": ""-6.78910"",
+  ""decimal"": ""1112.1314151617181920""
+}";
+
+        IConfiguration actual = JsonConvert.DeserializeObject<IConfiguration>(json, _serializerSettings);
+
+        Assert.Equal("12.345", actual["float"]);
+        Assert.Equal("-6.78910", actual["double"]);
+        Assert.Equal("1112.1314151617181920", actual["decimal"]);
     }
 
     [Fact]
@@ -28,7 +118,6 @@ public class ConfigurationJsonConverterTests
         const string json = @"{
   ""string"": ""hello"",
   ""integer"": 42,
-  ""date"": ""2022-04-14T23:39:26.7818757Z"",
   ""guid"": ""138f3a3f-4de3-46b4-9c59-f4b33adfd50d"",
   ""time"": ""1.23:45:32.1"",
   ""uri"": ""http://example.com/unit/test?foo=bar"",
@@ -52,14 +141,13 @@ public class ConfigurationJsonConverterTests
 
         Assert.Equal("hello", actual["string"]);
         Assert.Equal("42", actual["integer"]);
-        Assert.Equal("2022-04-14T23:39:26.7818757Z", actual["date"]);
         Assert.Equal("138f3a3f-4de3-46b4-9c59-f4b33adfd50d", actual["guid"]);
         Assert.Equal("1.23:45:32.1", actual["time"]);
         Assert.Equal("http://example.com/unit/test?foo=bar", actual["uri"]);
         Assert.Equal("zero", actual["array:0"]);
         Assert.Equal("one", actual["array:1"]);
         Assert.Equal("two", actual["array:2"]);
-        Assert.Equal("true", actual["object:bool"]);
+        Assert.Equal("True", actual["object:bool"]);
         Assert.Equal("1.2345", actual["object:nested:float"]);
         Assert.Null(actual["object:nested:null"]);
         Assert.Null(actual["object:nested:empty"]);
@@ -75,6 +163,7 @@ public class ConfigurationJsonConverterTests
     ""2"": ""two""
   },
   ""date"": ""2022-04-14T23:39:26.7818757Z"",
+  ""dateOffset"": ""2022-05-03T15:35:57.2628853-07:00"",
   ""guid"": ""138f3a3f-4de3-46b4-9c59-f4b33adfd50d"",
   ""integer"": ""42"",
   ""object"": {
@@ -96,6 +185,7 @@ public class ConfigurationJsonConverterTests
                     KeyValuePair.Create("string", "hello"),
                     KeyValuePair.Create("integer", "42"),
                     KeyValuePair.Create("date", "2022-04-14T23:39:26.7818757Z"),
+                    KeyValuePair.Create("dateOffset", "2022-05-03T15:35:57.2628853-07:00"),
                     KeyValuePair.Create("guid", "138f3a3f-4de3-46b4-9c59-f4b33adfd50d"),
                     KeyValuePair.Create("time", "1.23:45:32.1"),
                     KeyValuePair.Create("uri", "http://example.com/unit/test?foo=bar"),

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Serialization/Newtonsoft/ConfigurationJsonConverterTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Serialization/Newtonsoft/ConfigurationJsonConverterTests.cs
@@ -82,9 +82,27 @@ public class ConfigurationJsonConverterTests
         _serializerSettings.FloatParseHandling = FloatParseHandling.Double;
 
         const string json = @"{
-  ""float"": ""12.345"",
-  ""double"": ""-6.78910"",
-  ""decimal"": ""1112.1314151617181920""
+  ""float"": 12.345,
+  ""double"": -6.78910,
+  ""decimal"": 1112.1314151617181920
+}";
+
+        IConfiguration actual = JsonConvert.DeserializeObject<IConfiguration>(json, _serializerSettings);
+
+        Assert.Equal("12.345", actual["float"]);
+        Assert.Equal("-6.7891", actual["double"]);
+        Assert.Equal("1112.1314151617182", actual["decimal"]); // lost precision
+    }
+
+    [Fact]
+    public void GivenJson_WhenReadingWithDecimalParsing_ThenDeserialize()
+    {
+        _serializerSettings.FloatParseHandling = FloatParseHandling.Decimal;
+
+        const string json = @"{
+  ""float"": 12.345,
+  ""double"": -6.78910,
+  ""decimal"": 1112.1314151617181920
 }";
 
         IConfiguration actual = JsonConvert.DeserializeObject<IConfiguration>(json, _serializerSettings);
@@ -95,21 +113,15 @@ public class ConfigurationJsonConverterTests
     }
 
     [Fact]
-    public void GivenJson_WhenReadingWithDecimalParsing_ThenDeserialize()
+    public void GivenOverflowValue_WhenReadingWithDecimalParsing_ThenThrow()
     {
         _serializerSettings.FloatParseHandling = FloatParseHandling.Decimal;
 
         const string json = @"{
-  ""float"": ""12.345"",
-  ""double"": ""-6.78910"",
-  ""decimal"": ""1112.1314151617181920""
+  ""decimal"": 1.7976931348623157E+308
 }";
 
-        IConfiguration actual = JsonConvert.DeserializeObject<IConfiguration>(json, _serializerSettings);
-
-        Assert.Equal("12.345", actual["float"]);
-        Assert.Equal("-6.78910", actual["double"]);
-        Assert.Equal("1112.1314151617181920", actual["decimal"]);
+        Assert.Throws<JsonReaderException>(() => JsonConvert.DeserializeObject<IConfiguration>(json, _serializerSettings));
     }
 
     [Fact]

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
@@ -1192,6 +1192,15 @@ namespace Microsoft.Health.Dicom.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This operation does not support value types..
+        /// </summary>
+        internal static string ValueTypesNotSupported {
+            get {
+                return ResourceManager.GetString("ValueTypesNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The UPS may no longer be updated..
         /// </summary>
         internal static string WorkitemCancelRequestRejected {

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
@@ -503,6 +503,15 @@ namespace Microsoft.Health.Dicom.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Array rank {0} is not supported..
+        /// </summary>
+        internal static string InvalidArrayRank {
+            get {
+                return ResourceManager.GetString("InvalidArrayRank", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid query: specified date range &apos;{0}&apos; is invalid.
         ///The first part date {1} should be lesser than or equal to the second part date {2}..
         /// </summary>
@@ -729,6 +738,15 @@ namespace Microsoft.Health.Dicom.Core {
         internal static string InvalidTransferSyntaxValue {
             get {
                 return ResourceManager.GetString("InvalidTransferSyntaxValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Type &apos;{0}&apos; is not supported..
+        /// </summary>
+        internal static string InvalidTypeBinding {
+            get {
+                return ResourceManager.GetString("InvalidTypeBinding", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
@@ -588,4 +588,12 @@ For details on valid range queries, please refer to Search Matching section in C
   <data name="IndexedDicomTagHasMultipleValues" xml:space="preserve">
     <value>One or more indexed Dicom tag(s) have multiple values, only first value is indexed.</value>
   </data>
+  <data name="InvalidArrayRank" xml:space="preserve">
+    <value>Array rank {0} is not supported.</value>
+    <comment>{0} Array rank</comment>
+  </data>
+  <data name="InvalidTypeBinding" xml:space="preserve">
+    <value>Type '{0}' is not supported.</value>
+    <comment>{0} Type name</comment>
+  </data>
 </root>

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
@@ -596,4 +596,7 @@ For details on valid range queries, please refer to Search Matching section in C
     <value>Type '{0}' is not supported.</value>
     <comment>{0} Type name</comment>
   </data>
+  <data name="ValueTypesNotSupported" xml:space="preserve">
+    <value>This operation does not support value types.</value>
+  </data>
 </root>

--- a/src/Microsoft.Health.Dicom.Core/Extensions/ConfigurationBinderExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Extensions/ConfigurationBinderExtensions.cs
@@ -1,0 +1,138 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using EnsureThat;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Health.Dicom.Core.Extensions;
+
+internal static class ConfigurationBinderExtensions
+{
+    public static void Set<T>(this IConfiguration configuration, T value) where T : class
+        => Set(configuration, typeof(T), value, null); // TODO: Avoid boxing?
+
+    public static void Set<T>(this IConfiguration configuration, T value, Action<BinderOptions> configureOptions) where T : class
+        => Set(configuration, typeof(T), value, configureOptions);
+
+    public static void Set(this IConfiguration configuration, Type type, object value)
+        => Set(configuration, type, value, null);
+
+    public static void Set(this IConfiguration configuration, Type type, object value, Action<BinderOptions> configureOptions)
+    {
+        EnsureArg.IsNotNull(configuration, nameof(configuration));
+        EnsureArg.IsNotNull(type, nameof(type));
+        EnsureArg.IsNotNull(value, nameof(value));
+
+        var options = new BinderOptions();
+        configureOptions?.Invoke(options);
+
+        // TODO: Cache a dynamic method to perform the reflection only once. The Get methods are not cached,
+        //       so it is not unreasonable to leave this as-is
+
+        // TODO: Support copying from IConfiguration/IConfigurationSection
+
+        // TODO: Support value types and primitives
+        if (type.IsValueType)
+            throw new InvalidOperationException();
+
+        CopyToConfiguration(configuration, type, value, options);
+    }
+
+    private static void CopyToConfiguration(IConfiguration configuration, Type type, object value, BinderOptions options)
+    {
+        if (value == null)
+            return;
+
+        if (IsLiteralType(type))
+        {
+            if (configuration is not IConfigurationSection section)
+                throw new InvalidOperationException(
+                        string.Format(CultureInfo.CurrentCulture, DicomCoreResource.InvalidTypeBinding, type.Name));
+
+            // Special-case DateTime types to use round-trip
+            if (type == typeof(DateTime) || type == typeof(DateTimeOffset))
+            {
+                section.Value = ((IFormattable)value).ToString("O", CultureInfo.InvariantCulture);
+            }
+            else
+            {
+                TypeConverter converter = TypeDescriptor.GetConverter(type);
+                section.Value = converter.ConvertToInvariantString(value);
+            }
+        }
+        else if (type.IsArray || IsArrayLike(type))
+        {
+            Type elementType;
+            if (type.IsArray)
+            {
+                elementType = type.GetElementType();
+                if (type.IsArray && type.GetArrayRank() > 1)
+                {
+                    throw new InvalidOperationException(
+                        string.Format(CultureInfo.CurrentCulture, DicomCoreResource.InvalidArrayRank, type.GetArrayRank()));
+                }
+            }
+            else
+            {
+                elementType = type.GetGenericArguments()[0];
+            }
+
+            int i = 0;
+            foreach (object element in (IEnumerable)value)
+            {
+                CopyToConfiguration(configuration.GetSection(i.ToString(CultureInfo.InvariantCulture)), elementType, element, options);
+                i++;
+            }
+        }
+        else
+        {
+            BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public;
+            if (options.BindNonPublicProperties)
+                bindingFlags |= BindingFlags.NonPublic;
+
+            foreach (PropertyInfo p in type.GetProperties(bindingFlags).Where(x => x.CanWrite && x.CanRead))
+                CopyToConfiguration(configuration.GetSection(p.Name), p.PropertyType, p.GetValue(value), options);
+        }
+    }
+
+    private static bool IsLiteralType(Type type)
+        => type == typeof(bool)
+        || type == typeof(sbyte)
+        || type == typeof(byte)
+        || type == typeof(short)
+        || type == typeof(ushort)
+        || type == typeof(int)
+        || type == typeof(uint)
+        || type == typeof(long)
+        || type == typeof(ulong)
+        || type == typeof(float)
+        || type == typeof(double)
+        || type == typeof(decimal)
+        || type == typeof(char)
+        || type == typeof(string)
+        || type == typeof(DateTime)
+        || type == typeof(DateTimeOffset)
+        || type == typeof(TimeSpan)
+        || type == typeof(Guid)
+        || type == typeof(Uri);
+
+    private static bool IsArrayLike(Type type)
+    {
+        if (!type.IsInterface || !type.IsConstructedGenericType)
+            return false;
+
+        Type genericTypeDefinition = type.GetGenericTypeDefinition();
+        return genericTypeDefinition == typeof(IEnumerable<>)
+            || genericTypeDefinition == typeof(IReadOnlyCollection<>)
+            || genericTypeDefinition == typeof(IReadOnlyList<>);
+    }
+}

--- a/src/Microsoft.Health.Dicom.Core/Extensions/ConfigurationBinderExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Extensions/ConfigurationBinderExtensions.cs
@@ -42,7 +42,7 @@ internal static class ConfigurationBinderExtensions
 
         // TODO: Support value types and primitives
         if (type.IsValueType)
-            throw new InvalidOperationException();
+            throw new InvalidOperationException(DicomCoreResource.ValueTypesNotSupported);
 
         CopyToConfiguration(configuration, type, value, options);
     }
@@ -75,7 +75,7 @@ internal static class ConfigurationBinderExtensions
             if (type.IsArray)
             {
                 elementType = type.GetElementType();
-                if (type.IsArray && type.GetArrayRank() > 1)
+                if (type.GetArrayRank() > 1)
                 {
                     throw new InvalidOperationException(
                         string.Format(CultureInfo.CurrentCulture, DicomCoreResource.InvalidArrayRank, type.GetArrayRank()));

--- a/src/Microsoft.Health.Dicom.Core/Extensions/JsonSerializerOptionsExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Extensions/JsonSerializerOptionsExtensions.cs
@@ -29,6 +29,7 @@ public static class JsonSerializerOptionsExtensions
 
         options.Converters.Clear();
         options.Converters.Add(new ConfigurationJsonConverter());
+        options.Converters.Add(new DicomIdentifierJsonConverter());
         options.Converters.Add(new DicomJsonConverter(writeTagsAsKeywords: false, autoValidate: false));
         options.Converters.Add(new StrictStringEnumConverterFactory());
 

--- a/src/Microsoft.Health.Dicom.Core/Microsoft.Health.Dicom.Core.csproj
+++ b/src/Microsoft.Health.Dicom.Core/Microsoft.Health.Dicom.Core.csproj
@@ -16,6 +16,8 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(SdkPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="$(SdkPackageVersion)" />

--- a/src/Microsoft.Health.Dicom.Core/Models/Indexing/ReindexCheckpoint.cs
+++ b/src/Microsoft.Health.Dicom.Core/Models/Indexing/ReindexCheckpoint.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.Linq;
 using Microsoft.Health.Dicom.Core.Features.Model;
 using Microsoft.Health.Operations;
+using Newtonsoft.Json;
 
 namespace Microsoft.Health.Dicom.Core.Models.Indexing;
 
@@ -18,6 +19,7 @@ internal class ReindexCheckpoint : ReindexInput, IOperationCheckpoint
 
     public DateTime? CreatedTime { get; set; }
 
+    [JsonIgnore]
     public int? PercentComplete
     {
         get
@@ -32,7 +34,9 @@ internal class ReindexCheckpoint : ReindexInput, IOperationCheckpoint
         }
     }
 
+    [JsonIgnore]
     public IReadOnlyCollection<string> ResourceIds => QueryTagKeys?.Select(x => x.ToString(CultureInfo.InvariantCulture)).ToList();
 
+    [JsonIgnore]
     public IReadOnlyDictionary<string, string> AdditionalProperties => null;
 }

--- a/src/Microsoft.Health.Dicom.Core/Models/Operations/BatchingOptions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Models/Operations/BatchingOptions.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.ComponentModel.DataAnnotations;
+using Newtonsoft.Json;
 
 namespace Microsoft.Health.Dicom.Core.Models.Operations;
 
@@ -40,5 +41,6 @@ public sealed class BatchingOptions
     /// The value of the <see cref="Size"/> property multiplied by the
     /// value of the <see cref="MaxParallelCount"/> property.
     /// </value>
+    [JsonIgnore]
     public int MaxParallelElements => Size * MaxParallelCount;
 }

--- a/src/Microsoft.Health.Dicom.Core/Serialization/ConfigurationJsonConverter.cs
+++ b/src/Microsoft.Health.Dicom.Core/Serialization/ConfigurationJsonConverter.cs
@@ -66,6 +66,8 @@ internal sealed class ConfigurationJsonConverter : JsonConverter<IConfiguration>
                 break;
             case JsonValueKind.False:
             case JsonValueKind.True:
+                yield return KeyValuePair.Create(path, element.GetBoolean().ToString());
+                break;
             case JsonValueKind.Number:
                 yield return KeyValuePair.Create(path, element.GetRawText());
                 break;

--- a/src/Microsoft.Health.Dicom.Core/Serialization/DicomIdentifierJsonConverter.cs
+++ b/src/Microsoft.Health.Dicom.Core/Serialization/DicomIdentifierJsonConverter.cs
@@ -1,0 +1,21 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using EnsureThat;
+using Microsoft.Health.Dicom.Core.Models.Common;
+
+namespace Microsoft.Health.Dicom.Core.Serialization;
+
+internal sealed class DicomIdentifierJsonConverter : JsonConverter<DicomIdentifier>
+{
+    public override DicomIdentifier Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        => DicomIdentifier.Parse(reader.GetString());
+
+    public override void Write(Utf8JsonWriter writer, DicomIdentifier value, JsonSerializerOptions options)
+        => EnsureArg.IsNotNull(writer, nameof(writer)).WriteStringValue(value.ToString());
+}

--- a/src/Microsoft.Health.Dicom.Core/Serialization/Newtonsoft/ConfigurationJsonConverter.cs
+++ b/src/Microsoft.Health.Dicom.Core/Serialization/Newtonsoft/ConfigurationJsonConverter.cs
@@ -5,7 +5,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using EnsureThat;
@@ -34,29 +34,31 @@ internal sealed class ConfigurationJsonConverter : JsonConverter<IConfiguration>
             builder.AddConfiguration(existingValue);
 
         return builder
-            .AddInMemoryCollection(EnumeratePairs(serializer.Deserialize<JObject>(reader)))
+            .AddInMemoryCollection(EnumeratePairs(serializer.Deserialize<JObject>(reader), serializer))
             .Build();
     }
 
     public override void WriteJson(JsonWriter writer, IConfiguration value, JsonSerializer serializer)
         => WriteConfiguration(writer, value);
 
-    private static IEnumerable<KeyValuePair<string, string>> EnumeratePairs(JObject config)
-        => EnumeratePairs(string.Empty, config);
+    private static IEnumerable<KeyValuePair<string, string>> EnumeratePairs(JObject config, JsonSerializer serializer)
+        => EnumeratePairs(string.Empty, config, serializer);
 
-    [SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "Boolean types in JSON are lowercase.")]
-    private static IEnumerable<KeyValuePair<string, string>> EnumeratePairs(string path, JToken token)
+    private static IEnumerable<KeyValuePair<string, string>> EnumeratePairs(string path, JToken token, JsonSerializer serializer)
     {
         if (token is JObject section)
         {
-            foreach (KeyValuePair<string, string> p in section.Properties().SelectMany(x => EnumeratePairs(GetPath(path, x.Name), x.Value)))
+            foreach (KeyValuePair<string, string> p in section.Properties().SelectMany(x => EnumeratePairs(GetPath(path, x.Name), x.Value, serializer)))
             {
                 yield return p;
             }
         }
         else if (token is JArray a)
         {
-            foreach (KeyValuePair<string, string> p in a.Children().SelectMany((x, i) => EnumeratePairs(GetPath(path, i.ToString(CultureInfo.InvariantCulture)), x)))
+            IEnumerable<KeyValuePair<string, string>> elements = a.Children()
+                .SelectMany((x, i) => EnumeratePairs(GetPath(path, i.ToString(CultureInfo.InvariantCulture)), x, serializer));
+
+            foreach (KeyValuePair<string, string> p in elements)
             {
                 yield return p;
             }
@@ -67,18 +69,28 @@ internal sealed class ConfigurationJsonConverter : JsonConverter<IConfiguration>
             {
                 // Newtonsoft by default parses the values and does not provide a means of retrieving the raw string values.
                 // What this ultimately means is that the representation may look different if read as a string from the
-                // configuration or if re-written to JSON (E.g. DateTimes will use the "O" format).
+                // configuration or if re-written to JSON (E.g. DateTimes will use the round trip format).
                 // We could circumvent this by parsing this with JRaw types or manually enumerating the JSON.
                 yield return token.Type switch
                 {
-                    JTokenType.Boolean => KeyValuePair.Create(path, token.Value<bool>().ToString().ToLowerInvariant()), // bool type returns "True"/"False" for ToString()
-                    JTokenType.Date => KeyValuePair.Create(path, token.Value<DateTime>().ToString("O", CultureInfo.InvariantCulture)),
-                    JTokenType.Float => KeyValuePair.Create(path, token.Value<float>().ToString(CultureInfo.InvariantCulture)),
-                    JTokenType.Guid => KeyValuePair.Create(path, token.Value<Guid>().ToString("D", CultureInfo.InvariantCulture)),
-                    JTokenType.Integer => KeyValuePair.Create(path, token.Value<int>().ToString(CultureInfo.InvariantCulture)),
-                    JTokenType.String => KeyValuePair.Create(path, token.Value<string>()),
-                    JTokenType.TimeSpan => KeyValuePair.Create(path, token.Value<TimeSpan>().ToString("c", CultureInfo.InvariantCulture)),
-                    JTokenType.Uri => KeyValuePair.Create(path, token.Value<Uri>().ToString()), // URL may be relative. TODO: Should we try to use AbsoluteUri when possible?
+                    JTokenType.Boolean => KeyValuePair.Create(path, ConvertToString<bool>(value)),
+                    JTokenType.Date =>
+                        KeyValuePair.Create(
+                            path,
+                            serializer.DateParseHandling == DateParseHandling.DateTime
+                                ? value.Value<DateTime>().ToString("O", CultureInfo.InvariantCulture)
+                                : value.Value<DateTimeOffset>().ToString("O", CultureInfo.InvariantCulture)),
+                    JTokenType.Float =>
+                        KeyValuePair.Create(
+                            path,
+                            serializer.FloatParseHandling == FloatParseHandling.Double
+                                ? ConvertToString<double>(value)
+                                : ConvertToString<decimal>(value)),
+                    JTokenType.Guid => KeyValuePair.Create(path, ConvertToString<Guid>(value)),
+                    JTokenType.Integer => KeyValuePair.Create(path, ConvertToString<long>(value)),
+                    JTokenType.String => KeyValuePair.Create(path, value.Value<string>()),
+                    JTokenType.TimeSpan => KeyValuePair.Create(path, ConvertToString<TimeSpan>(value)),
+                    JTokenType.Uri => KeyValuePair.Create(path, ConvertToString<Uri>(value)),
                     _ => throw new JsonException(string.Format(CultureInfo.CurrentCulture, DicomCoreResource.InvalidJsonToken, token.Type))
                 };
             }
@@ -108,4 +120,7 @@ internal sealed class ConfigurationJsonConverter : JsonConverter<IConfiguration>
 
     private static string GetPath(string current, string key)
         => string.IsNullOrEmpty(current) ? key : current + ':' + key;
+
+    private static string ConvertToString<T>(JValue value)
+        => TypeDescriptor.GetConverter(typeof(T)).ConvertToInvariantString(value.Value<T>());
 }

--- a/src/Microsoft.Health.Dicom.Functions.Client/Registration/DicomServerBuilderFunctionClientRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Functions.Client/Registration/DicomServerBuilderFunctionClientRegistrationExtensions.cs
@@ -9,10 +9,12 @@ using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Core.Features.Operations;
 using Microsoft.Health.Dicom.Core.Registration;
 using Microsoft.Health.Dicom.Functions.Client.DurableTask;
 using Microsoft.Health.Operations.Functions.DurableTask;
+using Newtonsoft.Json;
 
 namespace Microsoft.Health.Dicom.Functions.Client;
 
@@ -54,7 +56,8 @@ public static class DicomServerBuilderFunctionClientRegistrationExtensions
             .GetSection(DicomFunctionOptions.SectionName)
             .GetSection(nameof(DicomFunctionOptions.DurableTask))
             .Bind(x));
-        services.Replace(ServiceDescriptor.Singleton<IMessageSerializerSettingsFactory, DurableTaskSerializerSettingsFactory>());
+        services.Configure<JsonSerializerSettings>(o => o.ConfigureDefaultDicomSettings());
+        services.Replace(ServiceDescriptor.Singleton<IMessageSerializerSettingsFactory, MessageSerializerSettingsFactory>());
         services.TryAddScoped<IDicomOperationsClient, DicomAzureFunctionsClient>();
 
         return dicomServerBuilder;

--- a/src/Microsoft.Health.Dicom.Functions/Indexing/ReindexDurableFunction.Orchestration.cs
+++ b/src/Microsoft.Health.Dicom.Functions/Indexing/ReindexDurableFunction.Orchestration.cs
@@ -90,6 +90,7 @@ public partial class ReindexDurableFunction
                 context.ContinueAsNew(
                     new ReindexCheckpoint
                     {
+                        Batching = input.Batching,
                         Completed = completed,
                         CreatedTime = input.CreatedTime ?? await context.GetCreatedTimeAsync(_options.RetryOptions),
                         QueryTagKeys = queryTagKeys,

--- a/src/Microsoft.Health.Dicom.Functions/Registration/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Functions/Registration/ServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ using Microsoft.Health.Operations.Functions.DurableTask;
 using Microsoft.Health.Operations.Functions.Management;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.IO;
+using Newtonsoft.Json;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -160,7 +161,8 @@ public static class ServiceCollectionExtensions
     {
         EnsureArg.IsNotNull(services, nameof(services));
 
-        return services.Replace(ServiceDescriptor.Singleton<IMessageSerializerSettingsFactory, DurableTaskSerializerSettingsFactory>());
+        services.Configure<JsonSerializerSettings>(o => o.ConfigureDefaultDicomSettings());
+        return services.Replace(ServiceDescriptor.Singleton<IMessageSerializerSettingsFactory, MessageSerializerSettingsFactory>());
     }
 
     private sealed class FellowOakExtensionConfiguration : IExtensionConfigProvider

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Microsoft.Health.Dicom.Web.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Microsoft.Health.Dicom.Web.Tests.E2E.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -15,6 +15,8 @@
     <PackageReference Include="fo-dicom" Version="$(FoDicomVersion)" />
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(SdkPackageVersion)" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.AzureStorage" Version="1.11.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.9.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Health.Api" Version="$(HealthcareSharedPackageVersion)" />
     <PackageReference Include="Microsoft.Health.Client" Version="$(HealthcareSharedPackageVersion)" />


### PR DESCRIPTION
## Description
- Add new `Set` method to mirror the `Get` method implemented by the Configuration Binder
- Add new `JsonConverter` for `DicomIdentifier`
- Refactor how strings are generated for the `IConfiguration` `JsonConverter`
- Load Json.NET serialization settings from options instead of Durable Task defaults

## Related issues
Addresses [AB#90232](https://microsofthealth.visualstudio.com/Health/_workitems/edit/90232)
Addresses [AB#91160](https://microsofthealth.visualstudio.com/Health/_workitems/edit/91160)

## Testing
New unit tests
