### PR TITLE
Allow Dicom Cast to communicate with private endpoint

### DIFF
--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Configurations/DicomWebConfiguration.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Configurations/DicomWebConfiguration.cs
@@ -18,8 +18,12 @@ public class DicomWebConfiguration
     public Uri Endpoint { get; set; }
 
     /// <summary>
-    /// The private endpoint to use to talk to dicom (this url will not be used when generating links in fhir)
+    /// The optional private endpoint to use to talk to dicom
     /// </summary>
+    /// <remarks>
+    /// If this  url is specified then it will be used to talk to dicom, but it will not be used when specifying the url in the fhir objects.
+    /// The value of <see cref="Endpoint" /> will still be used to generate links to dicom objects in fhir.
+    /// </remarks>
     public Uri PrivateEndpoint { get; set; }
 
     /// <summary>

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Configurations/DicomWebConfiguration.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Configurations/DicomWebConfiguration.cs
@@ -18,6 +18,11 @@ public class DicomWebConfiguration
     public Uri Endpoint { get; set; }
 
     /// <summary>
+    /// The private endpoint to use to talk to dicom (this url will not be used when generating links in fhir)
+    /// </summary>
+    public Uri PrivateEndpoint { get; set; }
+
+    /// <summary>
     /// Authentication settings for DICOMWeb.
     /// </summary>
     public AuthenticationConfiguration Authentication { get; set; }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Modules/DicomModule.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Modules/DicomModule.cs
@@ -41,6 +41,10 @@ public class DicomModule : IStartupModule
         services.AddHttpClient<IDicomWebClient, DicomWebClient>(sp =>
             {
                 sp.BaseAddress = dicomWebConfiguration.Endpoint;
+                if (dicomWebConfiguration.PrivateEndpoint != null)
+                {
+                    sp.BaseAddress = dicomWebConfiguration.PrivateEndpoint;
+                }
             })
             .AddAuthenticationHandler(services, dicomWebConfigurationSection.GetSection(AuthenticationConfiguration.SectionName), DicomWebConfigurationSectionName);
 

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Modules/DicomModule.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Modules/DicomModule.cs
@@ -32,19 +32,13 @@ public class DicomModule : IStartupModule
     {
         EnsureArg.IsNotNull(services, nameof(services));
 
-        var dicomWebConfiguration = new DicomWebConfiguration();
         IConfigurationSection dicomWebConfigurationSection = _configuration.GetSection(DicomWebConfigurationSectionName);
-        dicomWebConfigurationSection.Bind(dicomWebConfiguration);
+        services.AddOptions<DicomWebConfiguration>().Bind(dicomWebConfigurationSection);
 
-        services.AddSingleton(Options.Create(dicomWebConfiguration));
-
-        services.AddHttpClient<IDicomWebClient, DicomWebClient>(sp =>
+        services.AddHttpClient<IDicomWebClient, DicomWebClient>((sp, client) =>
             {
-                sp.BaseAddress = dicomWebConfiguration.Endpoint;
-                if (dicomWebConfiguration.PrivateEndpoint != null)
-                {
-                    sp.BaseAddress = dicomWebConfiguration.PrivateEndpoint;
-                }
+                DicomWebConfiguration config = sp.GetRequiredService<IOptions<DicomWebConfiguration>>().Value;
+                client.BaseAddress = config.PrivateEndpoint == null ? config.Endpoint : config.PrivateEndpoint;
             })
             .AddAuthenticationHandler(services, dicomWebConfigurationSection.GetSection(AuthenticationConfiguration.SectionName), DicomWebConfigurationSectionName);
 

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Hosting/appsettings.Development.json
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Hosting/appsettings.Development.json
@@ -10,12 +10,13 @@
             "Microsoft.Health": "Information"
         }
     },
-    "DicomWeb": {
-        "Endpoint": "https://localhost:63838",
-        "Authentication": {
-            "Enabled": false
-        }
-    },
+  "DicomWeb": {
+    "Endpoint": "https://localhost:63838",
+    "PrivateEndpoint": "",
+    "Authentication": {
+      "Enabled": false
+    }
+  },
     "Fhir": {
         "Endpoint": "https://localhost:44348",
         "Authentication": {

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Hosting/appsettings.Development.json
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Hosting/appsettings.Development.json
@@ -1,30 +1,29 @@
 {
-    "Logging": {
-        "Console": {
-            "IncludeScopes": true
-        },
-        "LogLevel": {
-            "Default": "Information",
-            "Microsoft": "Warning",
-            "Microsoft.Hosting.Lifetime": "Information",
-            "Microsoft.Health": "Information"
-        }
+  "Logging": {
+    "Console": {
+      "IncludeScopes": true
     },
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Microsoft.Health": "Information"
+    }
+  },
   "DicomWeb": {
     "Endpoint": "https://localhost:63838",
-    "PrivateEndpoint": "",
     "Authentication": {
       "Enabled": false
     }
   },
-    "Fhir": {
-        "Endpoint": "https://localhost:44348",
-        "Authentication": {
-            "Enabled": false
-        }
-    },
-    "DicomCastWorker": {
-      "PollInterval": "00:00:05"
-
+  "Fhir": {
+    "Endpoint": "https://localhost:44348",
+    "Authentication": {
+      "Enabled": false
     }
+  },
+  "DicomCastWorker": {
+    "PollInterval": "00:00:05"
+
+  }
 }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Hosting/appsettings.json
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Hosting/appsettings.json
@@ -1,49 +1,50 @@
 {
-    "Logging": {
-        "LogLevel": {
-            "Default": "Information",
-            "Microsoft": "Warning",
-            "Microsoft.Health": "Information",
-            "Microsoft.Hosting.Lifetime": "Information",
-            "System": "Warning"
-        },
-        "ApplicationInsights": {
-            "LogLevel": {
-                "Default": "Information",
-                "Microsoft.Health": "Information",
-                "Microsoft": "Warning",
-                "System": "Warning"
-            }
-        }
-    },
-    "DicomWeb": {
-        "Endpoint": "",
-        "Authentication": {
-            "Enabled": false
-        }
-    },
-    "Fhir": {
-        "Endpoint": "",
-        "Authentication": {
-            "Enabled": false
-        }
-    },
-    "DicomCastWorker": {
-        "PollInterval": "00:01:00",
-        "PollIntervalDuringCatchup": "00:00:00"
-    },
-    "DicomCast": {
-        "Features": {
-            "EnforceValidationOfTagValues": false,
-            "GenerateObservations": true
-        }
-    },
-    "RetryConfiguration": {
-        "TotalRetryDuration" :  "00:10:00"
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Health": "Information",
+      "Microsoft.Hosting.Lifetime": "Information",
+      "System": "Warning"
     },
     "ApplicationInsights": {
-        "InstrumentationKey": ""
-    },
+      "LogLevel": {
+        "Default": "Information",
+        "Microsoft.Health": "Information",
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
+    }
+  },
+  "DicomWeb": {
+    "Endpoint": "",
+    "PrivateEndpoint": "",
+    "Authentication": {
+      "Enabled": false
+    }
+  },
+  "Fhir": {
+    "Endpoint": "",
+    "Authentication": {
+      "Enabled": false
+    }
+  },
+  "DicomCastWorker": {
+    "PollInterval": "00:01:00",
+    "PollIntervalDuringCatchup": "00:00:00"
+  },
+  "DicomCast": {
+    "Features": {
+      "EnforceValidationOfTagValues": false,
+      "GenerateObservations": true
+    }
+  },
+  "RetryConfiguration": {
+    "TotalRetryDuration": "00:10:00"
+  },
+  "ApplicationInsights": {
+    "InstrumentationKey": ""
+  },
   "TableStore": {
     "TableNamePrefix": "",
     "ConnectionString": null

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Hosting/appsettings.json
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Hosting/appsettings.json
@@ -18,7 +18,6 @@
   },
   "DicomWeb": {
     "Endpoint": "",
-    "PrivateEndpoint": "",
     "Authentication": {
       "Enabled": false
     }


### PR DESCRIPTION
## Description
Allows dicomcast to talk to dicom through a private endpoint in PaaS solution while still using public endpoint when creating fhir resources.

## Related issues
[AB#91414](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/91414)

## Testing
After a long hard fought war with health-PaaS this was tested end to end in a personal cluster using a personal resource provider. 
Validated that it talked to private dicom endpoint and that fhir urls still had public endpoints
