### PR TITLE
Handle InvalidSchemaVersionException

### DIFF
--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Features/BackgroundServices/DeletedInstanceCleanupWorkerTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Features/BackgroundServices/DeletedInstanceCleanupWorkerTests.cs
@@ -47,6 +47,12 @@ public class DeletedInstanceCleanupWorkerTests
     [InlineData(21, 3)]
     public async Task GivenANumberOfDeletedEntriesAndBatchSize_WhenCallingExecute_ThenDeleteShouldBeCalledCorrectNumberOfTimes(int numberOfDeletedInstances, int expectedDeleteCount)
     {
+        _deleteService.CleanupDeletedInstancesAsync().ReturnsForAnyArgs(
+            x => GenerateCleanupDeletedInstancesAsyncResponse());
+
+        await _deletedInstanceCleanupWorker.ExecuteAsync(_cancellationTokenSource.Token);
+        await _deleteService.ReceivedWithAnyArgs(expectedDeleteCount).CleanupDeletedInstancesAsync();
+
         (bool, int) GenerateCleanupDeletedInstancesAsyncResponse()
         {
             var returnValue = Math.Min(numberOfDeletedInstances, BatchSize);
@@ -59,12 +65,6 @@ public class DeletedInstanceCleanupWorkerTests
 
             return (true, returnValue);
         }
-
-        _deleteService.CleanupDeletedInstancesAsync().ReturnsForAnyArgs(
-            x => GenerateCleanupDeletedInstancesAsyncResponse());
-
-        await _deletedInstanceCleanupWorker.ExecuteAsync(_cancellationTokenSource.Token);
-        await _deleteService.ReceivedWithAnyArgs(expectedDeleteCount).CleanupDeletedInstancesAsync();
     }
 
     [Fact]
@@ -72,6 +72,12 @@ public class DeletedInstanceCleanupWorkerTests
     {
         int iterations = 3;
         int count = 0;
+        _deleteService.CleanupDeletedInstancesAsync().ReturnsForAnyArgs(
+            x => GenerateCleanupDeletedInstancesAsyncResponse());
+
+        await _deletedInstanceCleanupWorker.ExecuteAsync(_cancellationTokenSource.Token);
+        await _deleteService.ReceivedWithAnyArgs(4).CleanupDeletedInstancesAsync();
+
         (bool, int) GenerateCleanupDeletedInstancesAsyncResponse()
         {
             if (count < iterations)
@@ -84,10 +90,5 @@ public class DeletedInstanceCleanupWorkerTests
 
             return (true, 1);
         }
-        _deleteService.CleanupDeletedInstancesAsync().ReturnsForAnyArgs(
-            x => GenerateCleanupDeletedInstancesAsyncResponse());
-
-        await _deletedInstanceCleanupWorker.ExecuteAsync(_cancellationTokenSource.Token);
-        await _deleteService.ReceivedWithAnyArgs(4).CleanupDeletedInstancesAsync();
     }
 }

--- a/src/Microsoft.Health.Dicom.Api/Features/BackgroundServices/DeletedInstanceCleanupWorker.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/BackgroundServices/DeletedInstanceCleanupWorker.cs
@@ -10,6 +10,7 @@ using EnsureThat;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Dicom.Core.Configs;
+using Microsoft.Health.Dicom.Core.Exceptions;
 using Microsoft.Health.Dicom.Core.Features.Delete;
 
 namespace Microsoft.Health.Dicom.Api.Features.BackgroundServices;
@@ -48,6 +49,10 @@ public class DeletedInstanceCleanupWorker
                     (success, retrievedInstanceCount) = await _deleteService.CleanupDeletedInstancesAsync(stoppingToken);
                 }
                 while (success && retrievedInstanceCount == _batchSize);
+            }
+            catch (DataStoreNotReadyException)
+            {
+                _logger.LogInformation("The data store is not currently ready. Processing will continue after the next wait period.");
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {

--- a/src/Microsoft.Health.Dicom.Core/Exceptions/DataStoreNotReadyException.cs
+++ b/src/Microsoft.Health.Dicom.Core/Exceptions/DataStoreNotReadyException.cs
@@ -3,14 +3,19 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using Microsoft.Health.Dicom.Core.Exceptions;
+using System;
 
-namespace Microsoft.Health.Dicom.SqlServer.Exceptions;
+namespace Microsoft.Health.Dicom.Core.Exceptions;
 
-internal class InvalidSchemaVersionException : DataStoreNotReadyException
+public class DataStoreNotReadyException : DataStoreException
 {
-    public InvalidSchemaVersionException(string message)
+    public DataStoreNotReadyException(string message)
         : base(message)
+    {
+    }
+
+    public DataStoreNotReadyException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/HealthCheck/BackgroundServiceHealthCheck.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/HealthCheck/BackgroundServiceHealthCheck.cs
@@ -57,10 +57,8 @@ public class BackgroundServiceHealthCheck : IHealthCheck
             _telemetryClient.GetMetric("Oldest-Requested-Deletion").TrackValue((await oldestWaitingToBeDeleted).ToUnixTimeSeconds());
             _telemetryClient.GetMetric("Count-Deletions-Max-Retry").TrackValue(await numReachedMaxedRetry);
         }
-        catch (DataStoreException e) // This is expected when service is starting up without schema initialization
+        catch (DataStoreNotReadyException)
         {
-            _logger.LogError(e, "The service is unhealthy.");
-
             return HealthCheckResult.Unhealthy("Unhealthy service.");
         }
 

--- a/src/Microsoft.Health.Dicom.SqlServer/Exceptions/InvalidSchemaVersionException.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Exceptions/InvalidSchemaVersionException.cs
@@ -7,7 +7,7 @@ using Microsoft.Health.Dicom.Core.Exceptions;
 
 namespace Microsoft.Health.Dicom.SqlServer.Exceptions;
 
-internal class InvalidSchemaVersionException : DataStoreNotReadyException
+internal class InvalidSchemaVersionException : DataStoreException
 {
     public InvalidSchemaVersionException(string message)
         : base(message)


### PR DESCRIPTION
## Description
This PR changes how we handle `InvalidSchemaVersionException` in two different cases. Each one is a case where the service doesn't yet know what the current schema version is on startup and we should be resilient to this.

- `DeletedInstanceCleanupWorker` - If this is the case, we should ignore this exception and continue to process on our normal cadence
- `BackgroundServiceHealthCheck` - Return an unhealthy result since this exception would constitute that we're unhealthy.

## Related issues
Addresses [AB#90262](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/90262).

## Testing
Unit test added for cleanup worker.
