### PR TITLE
[AB#91678] Fix for Retrieve workitem throwing null reference exception when workitem metadata is null

### DIFF
--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Workitem/WorkitemServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Workitem/WorkitemServiceTests.cs
@@ -605,6 +605,24 @@ public sealed class WorkitemServiceTests
         Assert.False(dataset.Contains(DicomTag.SOPInstanceUID));
     }
 
+    [Fact]
+    public async Task GivenNoWorkitem_ProcessRetrieveAsync_ReturnsNotFoundResponseStatus()
+    {
+        var workitemInstanceUid = DicomUID.Generate().UID;
+
+        _orchestrator
+            .GetWorkitemMetadataAsync(Arg.Is<string>(uid => string.Equals(workitemInstanceUid, uid)), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(null as WorkitemMetadataStoreEntry));
+
+        var response = await _target.ProcessRetrieveAsync(workitemInstanceUid, CancellationToken.None);
+
+        _responseBuilder
+            .Received()
+            .AddFailure(
+                Arg.Is<ushort>(fc => fc == FailureReasonCodes.UpsInstanceNotFound),
+                Arg.Is<string>(msg => msg == string.Format(DicomCoreResource.WorkitemInstanceNotFound, workitemInstanceUid)));
+    }
+
     private QueryParameters CreateParameters(
         Dictionary<string, string> filters,
         QueryResource resourceType,

--- a/src/Microsoft.Health.Dicom.Core/Features/Workitem/WorkitemService.Retrieve.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Workitem/WorkitemService.Retrieve.cs
@@ -34,7 +34,7 @@ public partial class WorkitemService
             {
                 _responseBuilder.AddFailure(
                     FailureReasonCodes.UpsInstanceNotFound,
-                    string.Format(DicomCoreResource.WorkitemInstanceNotFound, workitemMetadata.WorkitemUid));
+                    string.Format(DicomCoreResource.WorkitemInstanceNotFound, workitemInstanceUid));
 
                 return _responseBuilder.BuildRetrieveWorkitemResponse();
             }

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/WorkitemTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/WorkitemTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FellowOakDicom;
+using Microsoft.Health.Dicom.Core.Exceptions;
 using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 using Microsoft.Health.Dicom.Core.Features.Partition;
@@ -128,6 +129,16 @@ public class WorkitemTests : IClassFixture<SqlDataStoreTestsFixture>
         var workitemQueryTags = await _fixture.IndexWorkitemStore.GetWorkitemQueryTagsAsync(CancellationToken.None);
 
         Assert.NotEmpty(workitemQueryTags);
+    }
+
+    [Fact]
+    public async Task GivenGetWorkitemMetadataAsync_WhenWorkitemNotFound_ThenThrowsException()
+    {
+        var workitemUid = DicomUID.Generate().UID;
+
+        await Assert.ThrowsAsync<ItemNotFoundException>(() => _fixture.IndexWorkitemStore
+                .GetWorkitemMetadataAsync(DefaultPartition.Key, workitemUid, CancellationToken.None))
+            .ConfigureAwait(false);
     }
 
     [Fact]


### PR DESCRIPTION
## Description
Fixed the Retrieve workitem throwing null reference exception when workitem metadata is null issue.

## Related issues
Addresses [AB#91678].

## Testing
Added unit test and integration test coverage
