### PR TITLE
Revert "Change to IO.Hashing"

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -901,4 +901,28 @@ This repository incorporates material as listed below or described in the code.
   > WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   > See the License for the specific language governing permissions and
   > limitations under the License.
-  
+
+## HashDepot 2.0.3
+* Component Source:   https://github.com/ssg/HashDepot
+* Component Copyright and License:  
+  > The MIT License (MIT)
+
+  > Copyright (c) 2015-2021 Sedat Kapanoglu
+
+  > Permission is hereby granted, free of charge, to any person obtaining a copy
+  > of this software and associated documentation files (the "Software"), to deal
+  > in the Software without restriction, including without limitation the rights
+  > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  > copies of the Software, and to permit persons to whom the Software is
+  > furnished to do so, subject to the following conditions:
+  > 
+  > The above copyright notice and this permission notice shall be included in all
+  > copies or substantial portions of the Software.
+  > 
+  > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  > AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  > LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  > SOFTWARE.

--- a/src/Microsoft.Health.Dicom.Blob/Microsoft.Health.Dicom.Blob.csproj
+++ b/src/Microsoft.Health.Dicom.Blob/Microsoft.Health.Dicom.Blob.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Azure blob storage utilities for Microsoft's DICOMweb APIs.</Description>
@@ -12,6 +12,7 @@
     <PackageReference Include="Azure.Storage.Common" Version="12.11.0" />
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="fo-dicom" Version="$(FoDicomVersion)" />
+    <PackageReference Include="HashDepot" Version="2.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(SdkPackageVersion)" />
@@ -26,7 +27,6 @@
     <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="$(HealthcareSharedPackageVersion)" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
     <PackageReference Include="Scrutor" Version="4.1.0" />
-    <PackageReference Include="System.IO.Hashing" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Health.Dicom.Blob/Utilities/HashingHelper.cs
+++ b/src/Microsoft.Health.Dicom.Blob/Utilities/HashingHelper.cs
@@ -3,10 +3,9 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
-using System.IO.Hashing;
 using System.Text;
 using EnsureThat;
+using HashDepot;
 
 namespace Microsoft.Health.Dicom.Blob.Utilities;
 internal static class HashingHelper
@@ -22,7 +21,7 @@ internal static class HashingHelper
         EnsureArg.IsNotDefault(value, nameof(value));
 
         byte[] buffer = Encoding.UTF8.GetBytes(value.ToString());
-        string hash = BitConverter.ToUInt32(XxHash32.Hash(buffer)).ToString();
+        var hash = XXHash.Hash64(buffer).ToString();
 
         // If the hashLength is greater than the hash, assigning the length of the hash and not throw error
         hashLength = hashLength > hash.Length ? hash.Length : hashLength;


### PR DESCRIPTION
This reverts commit 795d2d5854e4975b59c557a47cada34a3baeeae0.

## Description
Reverting the hashing change since it will break the compat. The methods are not returning the same value.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.
