### PR TITLE
Fixes to handle Enumerable Dataset in the Request Payload for Change Workitem State API

### DIFF
--- a/src/Microsoft.Health.Dicom.Client/DicomWebClient.Workitem.cs
+++ b/src/Microsoft.Health.Dicom.Client/DicomWebClient.Workitem.cs
@@ -61,17 +61,17 @@ public partial class DicomWebClient : IDicomWebClient
     }
 
     public async Task<DicomWebResponse> ChangeWorkitemStateAsync(
-        DicomDataset dicomDataset,
+        IEnumerable<DicomDataset> dicomDatasets,
         string workitemUid,
         string partitionName = default,
         CancellationToken cancellationToken = default)
     {
-        EnsureArg.IsNotNull(dicomDataset, nameof(dicomDataset));
+        EnsureArg.IsNotNull(dicomDatasets, nameof(dicomDatasets));
         EnsureArg.IsNotEmptyOrWhiteSpace(workitemUid, nameof(workitemUid));
 
         var uri = GenerateChangeWorkitemStateRequestUri(workitemUid, partitionName);
 
-        return await Request(uri, dicomDataset, HttpMethod.Put, cancellationToken)
+        return await Request(uri, dicomDatasets, HttpMethod.Put, cancellationToken)
             .ConfigureAwait(false);
     }
 

--- a/src/Microsoft.Health.Dicom.Client/IDicomWebClient.Workitem.cs
+++ b/src/Microsoft.Health.Dicom.Client/IDicomWebClient.Workitem.cs
@@ -20,5 +20,5 @@ public partial interface IDicomWebClient
 
     Task<DicomWebResponse<DicomDataset>> RetrieveWorkitemAsync(string workitemUid, string partitionName = default, CancellationToken cancellationToken = default);
 
-    Task<DicomWebResponse> ChangeWorkitemStateAsync(DicomDataset dicomDataset, string workitemUid, string partitionName = default, CancellationToken cancellationToken = default);
+    Task<DicomWebResponse> ChangeWorkitemStateAsync(IEnumerable<DicomDataset> dicomDatasets, string workitemUid, string partitionName = default, CancellationToken cancellationToken = default);
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Workitem/ChangeWorkitemStateRequestHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Workitem/ChangeWorkitemStateRequestHandler.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -43,12 +45,12 @@ public class ChangeWorkitemStateRequestHandler : BaseHandler, IRequestHandler<Ch
 
         request.Validate();
 
-        var changeStateDataset = await _workitemSerializer
-            .DeserializeAsync<DicomDataset>(request.RequestBody, request.RequestContentType)
+        var changeStateDatasets = await _workitemSerializer
+            .DeserializeAsync<IEnumerable<DicomDataset>>(request.RequestBody, request.RequestContentType)
             .ConfigureAwait(false);
 
         return await _workItemService
-            .ProcessChangeStateAsync(changeStateDataset, request.WorkitemInstanceUid, cancellationToken)
+            .ProcessChangeStateAsync(changeStateDatasets.FirstOrDefault(), request.WorkitemInstanceUid, cancellationToken)
             .ConfigureAwait(false);
     }
 }

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Common/DicomInstancesManager.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Common/DicomInstancesManager.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -141,7 +142,7 @@ internal class DicomInstancesManager : IAsyncDisposable
         EnsureArg.IsNotEmptyOrWhiteSpace(workitemUid, nameof(workitemUid));
 
         return await _dicomWebClient
-            .ChangeWorkitemStateAsync(requestDataset, workitemUid, partitionName, cancellationToken)
+            .ChangeWorkitemStateAsync(Enumerable.Repeat(requestDataset, 1), workitemUid, partitionName, cancellationToken)
             .ConfigureAwait(false);
     }
 }

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/WorkItemTransactionTests.ChangeState.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/WorkItemTransactionTests.ChangeState.cs
@@ -33,7 +33,7 @@ public partial class WorkItemTransactionTests
             {DicomTag.ProcedureStepState, ProcedureStepStateConstants.InProgress },
         };
 
-        using var changeStateResponse = await _client.ChangeWorkitemStateAsync(changeStateDicomDataset, workitemUid)
+        using var changeStateResponse = await _client.ChangeWorkitemStateAsync(Enumerable.Repeat(changeStateDicomDataset, 1), workitemUid)
             .ConfigureAwait(false);
         Assert.True(changeStateResponse.IsSuccessStatusCode);
 


### PR DESCRIPTION
## Description
Fix to handle Enumerable DicomDataset in the request payload for Change Workitem State.

## Related issues
Addresses [[AB#87271](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/87271)]

## Testing
All existing tests pass.
