### PR TITLE
Option to disable JwtBearer Authentication so that can use MISE on Paas

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Modules/SecurityModule.cs
+++ b/src/Microsoft.Health.Dicom.Api/Modules/SecurityModule.cs
@@ -41,25 +41,28 @@ public class SecurityModule : IStartupModule
 
         if (_securityConfiguration.Enabled)
         {
-            string[] validAudiences = GetValidAudiences();
-            string challengeAudience = validAudiences?.FirstOrDefault();
+            if (!_securityConfiguration.Authentication.DisableJwtBearer)
+            {
+                string[] validAudiences = GetValidAudiences();
+                string challengeAudience = validAudiences?.FirstOrDefault();
 
-            services.AddAuthentication(options =>
-            {
-                options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-                options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
-                options.DefaultScheme = JwtBearerDefaults.AuthenticationScheme;
-            })
-            .AddJwtBearer(options =>
-            {
-                options.Authority = _securityConfiguration.Authentication.Authority;
-                options.RequireHttpsMetadata = true;
-                options.Challenge = $"Bearer authorization_uri=\"{_securityConfiguration.Authentication.Authority}\", resource_id=\"{challengeAudience}\", realm=\"{challengeAudience}\"";
-                options.TokenValidationParameters = new TokenValidationParameters
+                services.AddAuthentication(options =>
                 {
-                    ValidAudiences = validAudiences,
-                };
-            });
+                    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+                    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+                    options.DefaultScheme = JwtBearerDefaults.AuthenticationScheme;
+                })
+                .AddJwtBearer(options =>
+                {
+                    options.Authority = _securityConfiguration.Authentication.Authority;
+                    options.RequireHttpsMetadata = true;
+                    options.Challenge = $"Bearer authorization_uri=\"{_securityConfiguration.Authentication.Authority}\", resource_id=\"{challengeAudience}\", realm=\"{challengeAudience}\"";
+                    options.TokenValidationParameters = new TokenValidationParameters
+                    {
+                        ValidAudiences = validAudiences,
+                    };
+                });
+            }
 
             services.AddControllers(mvcOptions =>
             {

--- a/src/Microsoft.Health.Dicom.Core/Configs/AuthenticationConfiguration.cs
+++ b/src/Microsoft.Health.Dicom.Core/Configs/AuthenticationConfiguration.cs
@@ -14,4 +14,14 @@ public class AuthenticationConfiguration
     public IEnumerable<string> Audiences { get; set; }
 
     public string Authority { get; set; }
+
+    /// <summary>
+    /// Gets or sets the clientID used by MISE.
+    /// </summary>
+    public string ClientId { get; set; }
+
+    /// <summary>
+    /// True to disable JwtBearer Authentication so that could use MISE, false otherwise.
+    /// </summary>
+    public bool DisableJwtBearer { get; set; }
 }


### PR DESCRIPTION
## Description
Option to disable JwtBearer Authentication so that can use MISE on Paas

## Related issues
Addresses AB#92570.

## Testing
All automated tests pass
