### PR TITLE
Remove remaining UIDs and partition names from logs

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Features/Filters/PopulateDataPartitionFilterAttribute.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Filters/PopulateDataPartitionFilterAttribute.cs
@@ -80,7 +80,7 @@ public sealed class PopulateDataPartitionFilterAttribute : ActionFilterAttribute
             }
             else
             {
-                throw new DataPartitionsNotFoundException(partitionName);
+                throw new DataPartitionsNotFoundException();
             }
         }
 

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Exceptions/InvalidIdentifierExceptionTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Exceptions/InvalidIdentifierExceptionTests.cs
@@ -14,8 +14,7 @@ public class InvalidIdentifierExceptionTests
     public void GivenInvalidIdentifierException_WhenGetMessage_ShouldReturnExpected()
     {
         var name = "tagname";
-        var value = "tagvalue";
-        var exception = new InvalidIdentifierException(name, value);
-        Assert.Equal($"Dicom element '{name}' with value '{value}' failed validation for VR 'UI': DICOM Identifier is invalid. Value length should not exceed the maximum length of 64 characters. Value should contain characters in '0'-'9' and '.'. Each component must start with non-zero number.", exception.Message);
+        var exception = new InvalidIdentifierException(name);
+        Assert.Equal($"Dicom element '{name}' failed validation for VR 'UI': DICOM Identifier is invalid. Value length should not exceed the maximum length of 64 characters. Value should contain characters in '0'-'9' and '.'. Each component must start with non-zero number.", exception.Message);
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Health.Dicom.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specified PartitionName &apos;{0}&apos; does not exist..
+        ///   Looks up a localized string similar to Specified PartitionName does not exist..
         /// </summary>
         internal static string DataPartitionNotFound {
             get {
@@ -201,15 +201,6 @@ namespace Microsoft.Health.Dicom.Core {
         internal static string DicomElementValidationFailed {
             get {
                 return ResourceManager.GetString("DicomElementValidationFailed", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Dicom element &apos;{0}&apos; with value &apos;{1}&apos; failed validation for VR &apos;{2}&apos;: {3}.
-        /// </summary>
-        internal static string DicomElementValidationFailedWithValue {
-            get {
-                return ResourceManager.GetString("DicomElementValidationFailedWithValue", resourceCulture);
             }
         }
         
@@ -694,7 +685,7 @@ namespace Microsoft.Health.Dicom.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The specified PartitionName value &apos;{0}&apos; is invalid. .
+        ///   Looks up a localized string similar to The specified PartitionName is invalid. .
         /// </summary>
         internal static string InvalidPartitionName {
             get {
@@ -823,7 +814,7 @@ namespace Microsoft.Health.Dicom.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The StudyInstanceUid &apos;{0}&apos; in the payload does not match the specified StudyInstanceUid &apos;{1}&apos;..
+        ///   Looks up a localized string similar to The StudyInstanceUid in the payload does not match the specified StudyInstanceUid..
         /// </summary>
         internal static string MismatchStudyInstanceUid {
             get {
@@ -1156,7 +1147,7 @@ namespace Microsoft.Health.Dicom.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; DicomTag is not expected for &apos;{1}&apos; operation. [WorkitemInstanceUID &apos;{2}&apos;].
+        ///   Looks up a localized string similar to &apos;{0}&apos; DicomTag is not expected for &apos;{1}&apos; operation..
         /// </summary>
         internal static string UnexpectedTag {
             get {

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
@@ -136,7 +136,7 @@
   </data>
   <data name="DuplicatedUidsNotAllowed" xml:space="preserve">
     <value>The values for StudyInstanceUID, SeriesInstanceUID, SOPInstanceUID must be unique.</value>
-    <comment>StudyInstanceUID, SeriesInstanceUID, and SOPInstanceUID are defined by the spec and does not need to be translated. {NumberedPlaceholder="StudyInstanceUID", "SeriesInstanceUID", "SOPInstanceUID"}</comment>
+    <comment>StudyInstanceUID, SeriesInstanceUID, and SOPInstanceUID are defined by the spec and does not need to be translated.</comment>
   </data>
   <data name="DuplicateAttribute" xml:space="preserve">
     <value>Invalid query: attribute '{0}' has been specified more than once using different ID formats. Each attribute is only allowed to be specified once.</value>
@@ -202,8 +202,8 @@ The first part date {1} should be lesser than or equal to the second part date {
     <value>The specified item cannot be found.</value>
   </data>
   <data name="MismatchStudyInstanceUid" xml:space="preserve">
-    <value>The StudyInstanceUid '{0}' in the payload does not match the specified StudyInstanceUid '{1}'.</value>
-    <comment>{0} and {1} are both StudyInstanceUid. StudyInstanceUID is defined by the spec and does not need to be translated. {NumberedPlaceholder="StudyInstanceUID"}.</comment>
+    <value>The StudyInstanceUid in the payload does not match the specified StudyInstanceUid.</value>
+    <comment>StudyInstanceUID is defined by the spec and does not need to be translated.</comment>
   </data>
   <data name="MissingRequestBody" xml:space="preserve">
     <value>The request body is missing.</value>
@@ -378,10 +378,6 @@ The first part date {1} should be lesser than or equal to the second part date {
   <data name="ExtendedQueryTagsOutOfDate" xml:space="preserve">
     <value>One or more extended query tags have been modified.</value>
   </data>
-  <data name="DicomElementValidationFailedWithValue" xml:space="preserve">
-    <value>Dicom element '{0}' with value '{1}' failed validation for VR '{2}': {3}</value>
-    <comment>Dicom element {0} of value {1} of VR {2}. {3} has more detailed message on why.</comment>
-  </data>
   <data name="ErrorMessageMultiValues" xml:space="preserve">
     <value>Dicom element has multiple values. Indexing is only supported on single value element.</value>
   </data>
@@ -452,8 +448,7 @@ Both parts in the range cannot be empty.
 For details on valid range queries, please refer to Search Matching section in Conformance Statement (https://github.com/microsoft/dicom-server/blob/main/docs/resources/conformance-statement.md#search-matching).</value>
   </data>
   <data name="InvalidPartitionName" xml:space="preserve">
-    <value>The specified PartitionName value '{0}' is invalid. </value>
-    <comment>{0} PartitionName value.</comment>
+    <value>The specified PartitionName is invalid. </value>
   </data>
   <data name="DataPartitionsFeatureDisabled" xml:space="preserve">
     <value>Data partitions feature is disabled.</value>
@@ -462,8 +457,7 @@ For details on valid range queries, please refer to Search Matching section in C
     <value>PartitionName value is missing in the route segment.</value>
   </data>
   <data name="DataPartitionNotFound" xml:space="preserve">
-    <value>Specified PartitionName '{0}' does not exist.</value>
-    <comment>{0} PartitionName value.</comment>
+    <value>Specified PartitionName does not exist.</value>
   </data>
   <data name="DataPartitionFeatureCannotBeDisabled" xml:space="preserve">
     <value>Data partitions feature cannot be disabled while existing data has already been partitioned.</value>
@@ -500,8 +494,8 @@ For details on valid range queries, please refer to Search Matching section in C
     <comment>{0} String Value. {1} DicomTag.</comment>
   </data>
   <data name="UnexpectedTag" xml:space="preserve">
-    <value>'{0}' DicomTag is not expected for '{1}' operation. [WorkitemInstanceUID '{2}']</value>
-    <comment>{0} Dicom Tag. {1} Action/Operation. {2} WorkitemInstanceUID.</comment>
+    <value>'{0}' DicomTag is not expected for '{1}' operation.</value>
+    <comment>{0} Dicom Tag. {1} Action/Operation.</comment>
   </data>
   <data name="InvalidTransactionUID" xml:space="preserve">
     <value>Invalid TransactionUID for the specified Workitem Instance UID.</value>

--- a/src/Microsoft.Health.Dicom.Core/Exceptions/DataPartitionsNotFoundException.cs
+++ b/src/Microsoft.Health.Dicom.Core/Exceptions/DataPartitionsNotFoundException.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Health.Dicom.Core.Exceptions;
 /// </summary>
 public class DataPartitionsNotFoundException : BadRequestException
 {
-    public DataPartitionsNotFoundException(string partitionName)
-        : base(string.Format(CultureInfo.InvariantCulture, DicomCoreResource.DataPartitionNotFound, partitionName))
+    public DataPartitionsNotFoundException()
+        : base(string.Format(CultureInfo.InvariantCulture, DicomCoreResource.DataPartitionNotFound))
     {
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Exceptions/ElementValidationException.cs
+++ b/src/Microsoft.Health.Dicom.Core/Exceptions/ElementValidationException.cs
@@ -13,23 +13,14 @@ namespace Microsoft.Health.Dicom.Core.Exceptions;
 public class ElementValidationException : ValidationException
 {
     public ElementValidationException(string name, DicomVR vr, ValidationErrorCode errorCode)
-        : this(name, vr, null, errorCode)
-    { }
-
-    public ElementValidationException(string name, DicomVR vr, string value, ValidationErrorCode errorCode)
-        : this(name, vr, value, errorCode, errorCode.GetMessage())
+        : this(name, vr, errorCode, errorCode.GetMessage())
     { }
 
     public ElementValidationException(string name, DicomVR vr, ValidationErrorCode errorCode, string message)
-        : this(name, vr, null, errorCode, message)
-    { }
-
-    public ElementValidationException(string name, DicomVR vr, string value, ValidationErrorCode errorCode, string message)
         : base(message)
     {
         Name = EnsureArg.IsNotNull(name, nameof(name));
         VR = EnsureArg.IsNotNull(vr, nameof(vr));
-        Value = value;
         ErrorCode = EnsureArg.EnumIsDefined(errorCode, nameof(errorCode));
     }
 
@@ -37,11 +28,7 @@ public class ElementValidationException : ValidationException
 
     public DicomVR VR { get; }
 
-    public string Value { get; }
-
     public ValidationErrorCode ErrorCode { get; }
 
-    public override string Message => Value == null
-        ? string.Format(DicomCoreResource.DicomElementValidationFailed, Name, VR.Code, base.Message)
-        : string.Format(DicomCoreResource.DicomElementValidationFailedWithValue, Name, Value, VR.Code, base.Message);
+    public override string Message => string.Format(DicomCoreResource.DicomElementValidationFailed, Name, VR.Code, base.Message);
 }

--- a/src/Microsoft.Health.Dicom.Core/Exceptions/InvalidIdentifierException.cs
+++ b/src/Microsoft.Health.Dicom.Core/Exceptions/InvalidIdentifierException.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Health.Dicom.Core.Exceptions;
 
 public class InvalidIdentifierException : ElementValidationException
 {
-    public InvalidIdentifierException(string name, string value)
-        : base(name, DicomVR.UI, value, ValidationErrorCode.UidIsInvalid, DicomCoreResource.ErrorMessageUidIsInvalid)
+    public InvalidIdentifierException(string name)
+        : base(name, DicomVR.UI, ValidationErrorCode.UidIsInvalid, DicomCoreResource.ErrorMessageUidIsInvalid)
     {
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Exceptions/InvalidPartitionNameException.cs
+++ b/src/Microsoft.Health.Dicom.Core/Exceptions/InvalidPartitionNameException.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Health.Dicom.Core.Exceptions;
 /// </summary>
 public class InvalidPartitionNameException : ValidationException
 {
-    public InvalidPartitionNameException(string value)
-        : base(string.Format(DicomCoreResource.InvalidPartitionName, value))
+    public InvalidPartitionNameException()
+        : base(DicomCoreResource.InvalidPartitionName)
     {
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Store/StoreDatasetValidator.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Store/StoreDatasetValidator.cs
@@ -93,11 +93,7 @@ public class StoreDatasetValidator : IStoreDatasetValidator
         {
             throw new DatasetValidationException(
                 FailureReasonCodes.MismatchStudyInstanceUid,
-                string.Format(
-                    CultureInfo.InvariantCulture,
-                    DicomCoreResource.MismatchStudyInstanceUid,
-                    studyInstanceUid,
-                    requiredStudyInstanceUid));
+                DicomCoreResource.MismatchStudyInstanceUid);
         }
 
         string EnsureRequiredTagIsPresent(DicomTag dicomTag)

--- a/src/Microsoft.Health.Dicom.Core/Features/Validation/DateValidation.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Validation/DateValidation.cs
@@ -26,7 +26,7 @@ internal class DateValidation : IElementValidation
 
         if (!DateTime.TryParseExact(value, DateFormatDA, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out _))
         {
-            throw new ElementValidationException(name, DicomVR.DA, value, ValidationErrorCode.DateIsInvalid);
+            throw new ElementValidationException(name, DicomVR.DA, ValidationErrorCode.DateIsInvalid);
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Validation/ElementMaxLengthValidation.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Validation/ElementMaxLengthValidation.cs
@@ -37,7 +37,6 @@ internal class ElementMaxLengthValidation : IElementValidation
             throw new ElementValidationException(
                 name,
                 vr,
-                value,
                 ValidationErrorCode.ExceedMaxLength,
                 string.Format(CultureInfo.CurrentCulture, DicomCoreResource.ErrorMessageExceedMaxLength, maxLength));
         }

--- a/src/Microsoft.Health.Dicom.Core/Features/Validation/ElementRequiredLengthValidation.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Validation/ElementRequiredLengthValidation.cs
@@ -84,7 +84,6 @@ internal class ElementRequiredLengthValidation : IElementValidation
             throw new ElementValidationException(
                 name,
                 dicomVR,
-                value,
                 ValidationErrorCode.UnexpectedLength,
                 string.Format(CultureInfo.InvariantCulture, DicomCoreResource.ErrorMessageUnexpectedLength, ExpectedLength));
         }

--- a/src/Microsoft.Health.Dicom.Core/Features/Validation/EncodedStringElementValidation.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Validation/EncodedStringElementValidation.cs
@@ -41,7 +41,7 @@ internal class EncodedStringElementValidation : IElementValidation
         }
         catch (DicomValidationException)
         {
-            throw new ElementValidationException(element.Tag.GetFriendlyName(), element.ValueRepresentation, value, errorCode);
+            throw new ElementValidationException(element.Tag.GetFriendlyName(), element.ValueRepresentation, errorCode);
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Validation/LongStringValidation.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Validation/LongStringValidation.cs
@@ -33,7 +33,7 @@ internal class LongStringValidation : IElementValidation
 
         if (value.Contains('\\', StringComparison.OrdinalIgnoreCase) || ValidationUtils.ContainsControlExceptEsc(value))
         {
-            throw new ElementValidationException(name, DicomVR.LO, value, ValidationErrorCode.InvalidCharacters);
+            throw new ElementValidationException(name, DicomVR.LO, ValidationErrorCode.InvalidCharacters);
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Validation/PartitionNameValidator.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Validation/PartitionNameValidator.cs
@@ -16,12 +16,12 @@ public static class PartitionNameValidator
     {
         if (string.IsNullOrWhiteSpace(value))
         {
-            throw new InvalidPartitionNameException(value);
+            throw new InvalidPartitionNameException();
         }
 
         if (value.Length > 64 || !ValidIdentifierCharactersFormat.IsMatch(value))
         {
-            throw new InvalidPartitionNameException(value);
+            throw new InvalidPartitionNameException();
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Validation/PersonNameValidation.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Validation/PersonNameValidation.cs
@@ -26,7 +26,7 @@ internal class PersonNameValidation : IElementValidation
         string[] groups = value.Split('=');
         if (groups.Length > 3)
         {
-            throw new ElementValidationException(name, DicomVR.PN, value, ValidationErrorCode.PersonNameExceedMaxGroups);
+            throw new ElementValidationException(name, DicomVR.PN, ValidationErrorCode.PersonNameExceedMaxGroups);
         }
 
         foreach (string group in groups)
@@ -38,18 +38,18 @@ internal class PersonNameValidation : IElementValidation
             catch (ElementValidationException ex) when (ex.ErrorCode == ValidationErrorCode.ExceedMaxLength)
             {
                 // Reprocess the exception to make more meaningful message
-                throw new ElementValidationException(name, DicomVR.PN, value, ValidationErrorCode.PersonNameGroupExceedMaxLength);
+                throw new ElementValidationException(name, DicomVR.PN, ValidationErrorCode.PersonNameGroupExceedMaxLength);
             }
 
             if (ValidationUtils.ContainsControlExceptEsc(group))
             {
-                throw new ElementValidationException(name, vr, value, ValidationErrorCode.InvalidCharacters);
+                throw new ElementValidationException(name, vr, ValidationErrorCode.InvalidCharacters);
             }
         }
 
         if (groups.Select(g => g.Split('^').Length).Any(l => l > 5))
         {
-            throw new ElementValidationException(name, DicomVR.PN, value, ValidationErrorCode.PersonNameExceedMaxComponents);
+            throw new ElementValidationException(name, DicomVR.PN, ValidationErrorCode.PersonNameExceedMaxComponents);
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Validation/UidValidation.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Validation/UidValidation.cs
@@ -48,7 +48,7 @@ internal class UidValidation : IElementValidation
     {
         if (!IsValid(value, allowEmpty))
         {
-            throw new InvalidIdentifierException(name, value);
+            throw new InvalidIdentifierException(name);
         }
     }
 }


### PR DESCRIPTION
## Description
Remove remaining UIDs and partition names from logs which will not be redacted through PaaS solution.

## Related issues
AB#[92521](https://microsofthealth.visualstudio.com/Health/_workitems/edit/92521).

## Testing
All the tests are passing.

Query that can later be used to verify if this pull request solved the problem:
```
LinuxTraceTelemetry
| where TIMESTAMP > ago(3d)
|where cloud_RoleName == "dicom"
|where message !contains "404"
|where message !contains "403"
| distinct message
```
