### PR TITLE
Making partition name and cancellation token optional across client

### DIFF
--- a/src/Microsoft.Health.Dicom.Client/DicomWebClient.ChangeFeed.cs
+++ b/src/Microsoft.Health.Dicom.Client/DicomWebClient.ChangeFeed.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Health.Dicom.Client;
 
 public partial class DicomWebClient : IDicomWebClient
 {
-    public async Task<DicomWebAsyncEnumerableResponse<ChangeFeedEntry>> GetChangeFeed(string queryString, CancellationToken cancellationToken)
+    public async Task<DicomWebAsyncEnumerableResponse<ChangeFeedEntry>> GetChangeFeed(string queryString, CancellationToken cancellationToken = default)
     {
         using var request = new HttpRequestMessage(
             HttpMethod.Get,
@@ -29,7 +29,7 @@ public partial class DicomWebClient : IDicomWebClient
             DeserializeAsAsyncEnumerable<ChangeFeedEntry>(response.Content));
     }
 
-    public async Task<DicomWebResponse<ChangeFeedEntry>> GetChangeFeedLatest(string queryString, CancellationToken cancellationToken)
+    public async Task<DicomWebResponse<ChangeFeedEntry>> GetChangeFeedLatest(string queryString, CancellationToken cancellationToken = default)
     {
         using var request = new HttpRequestMessage(
             HttpMethod.Get,

--- a/src/Microsoft.Health.Dicom.Client/DicomWebClient.ExtendedQueryTag.cs
+++ b/src/Microsoft.Health.Dicom.Client/DicomWebClient.ExtendedQueryTag.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Health.Dicom.Client;
 
 public partial class DicomWebClient : IDicomWebClient
 {
-    public async Task<DicomWebResponse<DicomOperationReference>> AddExtendedQueryTagAsync(IEnumerable<AddExtendedQueryTagEntry> tagEntries, CancellationToken cancellationToken)
+    public async Task<DicomWebResponse<DicomOperationReference>> AddExtendedQueryTagAsync(IEnumerable<AddExtendedQueryTagEntry> tagEntries, CancellationToken cancellationToken = default)
     {
         EnsureArg.IsNotNull(tagEntries, nameof(tagEntries));
         string jsonString = JsonSerializer.Serialize(tagEntries, JsonSerializerOptions);
@@ -33,7 +33,7 @@ public partial class DicomWebClient : IDicomWebClient
         return new DicomWebResponse<DicomOperationReference>(response, ValueFactory<DicomOperationReference>);
     }
 
-    public async Task<DicomWebResponse> DeleteExtendedQueryTagAsync(string tagPath, CancellationToken cancellationToken)
+    public async Task<DicomWebResponse> DeleteExtendedQueryTagAsync(string tagPath, CancellationToken cancellationToken = default)
     {
         EnsureArg.IsNotNullOrWhiteSpace(tagPath, nameof(tagPath));
 
@@ -48,7 +48,7 @@ public partial class DicomWebClient : IDicomWebClient
         return new DicomWebResponse(response);
     }
 
-    public async Task<DicomWebResponse<IReadOnlyList<GetExtendedQueryTagEntry>>> GetExtendedQueryTagsAsync(int limit, int offset, CancellationToken cancellationToken)
+    public async Task<DicomWebResponse<IReadOnlyList<GetExtendedQueryTagEntry>>> GetExtendedQueryTagsAsync(int limit, int offset, CancellationToken cancellationToken = default)
     {
         EnsureArg.IsGte(limit, 1, nameof(limit));
         EnsureArg.IsGte(offset, 0, nameof(offset));
@@ -72,7 +72,7 @@ public partial class DicomWebClient : IDicomWebClient
         return new DicomWebResponse<GetExtendedQueryTagEntry>(response, ValueFactory<GetExtendedQueryTagEntry>);
     }
 
-    public async Task<DicomWebResponse<IReadOnlyList<ExtendedQueryTagError>>> GetExtendedQueryTagErrorsAsync(string tagPath, int limit, int offset, CancellationToken cancellationToken)
+    public async Task<DicomWebResponse<IReadOnlyList<ExtendedQueryTagError>>> GetExtendedQueryTagErrorsAsync(string tagPath, int limit, int offset, CancellationToken cancellationToken = default)
     {
         EnsureArg.IsNotNullOrWhiteSpace(tagPath, nameof(tagPath));
         EnsureArg.IsGte(limit, 1, nameof(limit));
@@ -91,7 +91,7 @@ public partial class DicomWebClient : IDicomWebClient
         return new DicomWebResponse<IReadOnlyList<ExtendedQueryTagError>>(response, ValueFactory<IReadOnlyList<ExtendedQueryTagError>>);
     }
 
-    public async Task<DicomWebResponse<GetExtendedQueryTagEntry>> UpdateExtendedQueryTagAsync(string tagPath, UpdateExtendedQueryTagEntry newValue, CancellationToken cancellationToken)
+    public async Task<DicomWebResponse<GetExtendedQueryTagEntry>> UpdateExtendedQueryTagAsync(string tagPath, UpdateExtendedQueryTagEntry newValue, CancellationToken cancellationToken = default)
     {
         EnsureArg.IsNotNullOrWhiteSpace(tagPath, nameof(tagPath));
         EnsureArg.IsNotNull(newValue, nameof(newValue));

--- a/src/Microsoft.Health.Dicom.Client/DicomWebClient.Operation.cs
+++ b/src/Microsoft.Health.Dicom.Client/DicomWebClient.Operation.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Health.Dicom.Client;
 
 public partial class DicomWebClient : IDicomWebClient
 {
-    public async Task<DicomWebResponse<OperationState<DicomOperation>>> GetOperationStateAsync(Guid operationId, CancellationToken cancellationToken)
+    public async Task<DicomWebResponse<OperationState<DicomOperation>>> GetOperationStateAsync(Guid operationId, CancellationToken cancellationToken = default)
     {
         var uri = new Uri($"/{_apiVersion}{DicomWebConstants.BaseOperationUri}/{operationId.ToString(OperationId.FormatSpecifier)}", UriKind.Relative);
         using var request = new HttpRequestMessage(HttpMethod.Get, uri);

--- a/src/Microsoft.Health.Dicom.Client/DicomWebClient.Partition.cs
+++ b/src/Microsoft.Health.Dicom.Client/DicomWebClient.Partition.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Health.Dicom.Client;
 
 public partial class DicomWebClient : IDicomWebClient
 {
-    public async Task<DicomWebResponse<IEnumerable<PartitionEntry>>> GetPartitionsAsync(CancellationToken cancellationToken)
+    public async Task<DicomWebResponse<IEnumerable<PartitionEntry>>> GetPartitionsAsync(CancellationToken cancellationToken = default)
     {
         using var request = new HttpRequestMessage(
             HttpMethod.Get,

--- a/src/Microsoft.Health.Dicom.Client/DicomWebClient.Store.cs
+++ b/src/Microsoft.Health.Dicom.Client/DicomWebClient.Store.cs
@@ -21,8 +21,8 @@ public partial class DicomWebClient : IDicomWebClient
     public async Task<DicomWebResponse<DicomDataset>> StoreAsync(
         IEnumerable<DicomFile> dicomFiles,
         string studyInstanceUid,
-        string partitionName,
-        CancellationToken cancellationToken)
+        string partitionName = default,
+        CancellationToken cancellationToken = default)
     {
         EnsureArg.IsNotNull(dicomFiles, nameof(dicomFiles));
 
@@ -56,8 +56,8 @@ public partial class DicomWebClient : IDicomWebClient
     public async Task<DicomWebResponse<DicomDataset>> StoreAsync(
         IEnumerable<Stream> streams,
         string studyInstanceUid,
-        string partitionName,
-        CancellationToken cancellationToken)
+        string partitionName = default,
+        CancellationToken cancellationToken = default)
     {
         EnsureArg.IsNotNull(streams, nameof(streams));
 
@@ -71,8 +71,8 @@ public partial class DicomWebClient : IDicomWebClient
     public async Task<DicomWebResponse<DicomDataset>> StoreAsync(
         Stream stream,
         string studyInstanceUid,
-        string partitionName,
-        CancellationToken cancellationToken)
+        string partitionName = default,
+        CancellationToken cancellationToken = default)
     {
         EnsureArg.IsNotNull(stream, nameof(stream));
 
@@ -88,8 +88,8 @@ public partial class DicomWebClient : IDicomWebClient
     public async Task<DicomWebResponse<DicomDataset>> StoreAsync(
         DicomFile dicomFile,
         string studyInstanceUid,
-        string partitionName,
-        CancellationToken cancellationToken)
+        string partitionName = default,
+        CancellationToken cancellationToken = default)
     {
         EnsureArg.IsNotNull(dicomFile, nameof(dicomFile));
 
@@ -107,8 +107,8 @@ public partial class DicomWebClient : IDicomWebClient
 
     public async Task<DicomWebResponse<DicomDataset>> StoreAsync(
         HttpContent content,
-        string partitionName,
-        CancellationToken cancellationToken)
+        string partitionName = default,
+        CancellationToken cancellationToken = default)
     {
         return await StoreAsync(
             GenerateStoreRequestUri(partitionName),
@@ -117,7 +117,7 @@ public partial class DicomWebClient : IDicomWebClient
             .ConfigureAwait(false);
     }
 
-    private async Task<DicomWebResponse<DicomDataset>> StoreAsync(Uri requestUri, HttpContent content, CancellationToken cancellationToken)
+    private async Task<DicomWebResponse<DicomDataset>> StoreAsync(Uri requestUri, HttpContent content, CancellationToken cancellationToken = default)
     {
         EnsureArg.IsNotNull(requestUri, nameof(requestUri));
         EnsureArg.IsNotNull(content, nameof(content));

--- a/src/Microsoft.Health.Dicom.Client/DicomWebClient.Workitem.cs
+++ b/src/Microsoft.Health.Dicom.Client/DicomWebClient.Workitem.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Health.Dicom.Client;
 
 public partial class DicomWebClient : IDicomWebClient
 {
-    public async Task<DicomWebResponse> AddWorkitemAsync(IEnumerable<DicomDataset> dicomDatasets, string workitemUid, string partitionName, CancellationToken cancellationToken)
+    public async Task<DicomWebResponse> AddWorkitemAsync(IEnumerable<DicomDataset> dicomDatasets, string workitemUid, string partitionName = default, CancellationToken cancellationToken = default)
     {
         EnsureArg.IsNotNull(dicomDatasets, nameof(dicomDatasets));
         EnsureArg.IsNotEmptyOrWhiteSpace(workitemUid, nameof(workitemUid));


### PR DESCRIPTION
## Description
Some client methods required partition, which should never be the case. While here I also made all cancellation tokens optional.

## Related issues
Addresses [AB#92838](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/92838)

## Testing
All tests pass.
