### PR TITLE
Added NoWarn for SchemaManager System.CommandLine dependency.

### DIFF
--- a/src/Microsoft.Health.Dicom.SchemaManager/Microsoft.Health.Dicom.SchemaManager.csproj
+++ b/src/Microsoft.Health.Dicom.SchemaManager/Microsoft.Health.Dicom.SchemaManager.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This fixes an error introduced with the new DICOM SchemaManager project due to its dependency on the preview-only NuGet package System.CommandLine.