### PR TITLE
Create schema manager console in separate project

### DIFF
--- a/Microsoft.Health.Dicom.sln
+++ b/Microsoft.Health.Dicom.sln
@@ -62,6 +62,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Dicom.Sche
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Dicom.SchemaManager.UnitTests", "src\Microsoft.Health.Dicom.SchemaManager.UnitTests\Microsoft.Health.Dicom.SchemaManager.UnitTests.csproj", "{C8BB8AF3-DCD1-49A4-A082-9152686AD222}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Dicom.SchemaManager.Console", "src\Microsoft.Health.Dicom.SchemaManager.Console\Microsoft.Health.Dicom.SchemaManager.Console.csproj", "{7AE5FC7B-CE2D-4B5A-B8BB-9B673469EA88}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -160,6 +162,10 @@ Global
 		{C8BB8AF3-DCD1-49A4-A082-9152686AD222}.Debug|x64.Build.0 = Debug|x64
 		{C8BB8AF3-DCD1-49A4-A082-9152686AD222}.Release|x64.ActiveCfg = Release|x64
 		{C8BB8AF3-DCD1-49A4-A082-9152686AD222}.Release|x64.Build.0 = Release|x64
+		{7AE5FC7B-CE2D-4B5A-B8BB-9B673469EA88}.Debug|x64.ActiveCfg = Debug|x64
+		{7AE5FC7B-CE2D-4B5A-B8BB-9B673469EA88}.Debug|x64.Build.0 = Debug|x64
+		{7AE5FC7B-CE2D-4B5A-B8BB-9B673469EA88}.Release|x64.ActiveCfg = Release|x64
+		{7AE5FC7B-CE2D-4B5A-B8BB-9B673469EA88}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -187,6 +193,7 @@ Global
 		{E2BD0627-CC6C-40D4-B875-00654FD059CF} = {176641B3-297C-4E04-A83D-8F80F80485E8}
 		{5A517D8F-9DBB-4123-99C6-01686BCA4AC7} = {176641B3-297C-4E04-A83D-8F80F80485E8}
 		{C8BB8AF3-DCD1-49A4-A082-9152686AD222} = {176641B3-297C-4E04-A83D-8F80F80485E8}
+		{7AE5FC7B-CE2D-4B5A-B8BB-9B673469EA88} = {176641B3-297C-4E04-A83D-8F80F80485E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		RESX_SortFileContentOnSave = True

--- a/src/Microsoft.Health.Dicom.SchemaManager.Console/Microsoft.Health.Dicom.SchemaManager.Console.csproj
+++ b/src/Microsoft.Health.Dicom.SchemaManager.Console/Microsoft.Health.Dicom.SchemaManager.Console.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Microsoft.Health.Dicom.SchemaManager\Microsoft.Health.Dicom.SchemaManager.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Microsoft.Health.Dicom.SchemaManager.Console/Program.cs
+++ b/src/Microsoft.Health.Dicom.SchemaManager.Console/Program.cs
@@ -1,0 +1,21 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.CommandLine.Parsing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Health.Dicom.SchemaManager;
+
+internal class Program
+{
+    public static async Task<int> Main(string[] args)
+    {
+        ServiceCollection serviceCollection = SchemaManagerServiceCollectionBuilder.Build(args);
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        Parser parser = SchemaManagerParser.Build(serviceProvider);
+
+        return await parser.InvokeAsync(args).ConfigureAwait(false);
+    }
+}

--- a/src/Microsoft.Health.Dicom.SchemaManager.Console/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Health.Dicom.SchemaManager.Console/Properties/AssemblyInfo.cs
@@ -1,0 +1,9 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Resources;
+
+[assembly: NeutralResourcesLanguage("en-us")]
+[assembly: CLSCompliant(false)]

--- a/src/Microsoft.Health.Dicom.SchemaManager.Console/Properties/launchSettings.json
+++ b/src/Microsoft.Health.Dicom.SchemaManager.Console/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Microsoft.Health.Dicom.SchemaManager": {
+      "commandName": "Project",
+      "commandLineArgs": "apply --connection-string \"server=(local);Initial Catalog=DICOM3;TrustServerCertificate=True;Integrated Security=True\" --version 20"
+    }
+  }
+}

--- a/src/Microsoft.Health.Dicom.SchemaManager/CommandCollectionExtensions.cs
+++ b/src/Microsoft.Health.Dicom.SchemaManager/CommandCollectionExtensions.cs
@@ -6,6 +6,7 @@
 using System.CommandLine;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Health.SqlServer.Configs;
 
 namespace Microsoft.Health.Dicom.SchemaManager;
 
@@ -71,6 +72,17 @@ public static class CommandCollectionExtensions
         services.AddOptions<CommandLineOptions>().Configure(x =>
         {
             x.ConnectionString = config[OptionAliases.ConnectionString];
+
+            x.ManagedIdentityClientId = config[OptionAliases.ManagedIdentityClientId];
+
+            string? authenticationTypeValue = config[OptionAliases.AuthenticationType];
+            if (!string.IsNullOrWhiteSpace(authenticationTypeValue))
+            {
+                if (Enum.TryParse(authenticationTypeValue, true, out SqlServerAuthenticationType sqlServerAuthenticationType))
+                {
+                    x.AuthenticationType = sqlServerAuthenticationType;
+                }
+            }
         });
 
         return services;

--- a/src/Microsoft.Health.Dicom.SchemaManager/Microsoft.Health.Dicom.SchemaManager.csproj
+++ b/src/Microsoft.Health.Dicom.SchemaManager/Microsoft.Health.Dicom.SchemaManager.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/Microsoft.Health.Dicom.SchemaManager/Properties/launchSettings.json
+++ b/src/Microsoft.Health.Dicom.SchemaManager/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "Microsoft.Health.Dicom.SchemaManager": {
-      "commandName": "Project",
-      "commandLineArgs": "apply --connection-string \"server=(local);Initial Catalog=DICOM;TrustServerCertificate=True;Integrated Security=True\" --version 22"
-    }
-  }
-}

--- a/src/Microsoft.Health.Dicom.SchemaManager/SchemaManagerParserBuilder.cs
+++ b/src/Microsoft.Health.Dicom.SchemaManager/SchemaManagerParserBuilder.cs
@@ -1,0 +1,26 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.Parsing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Health.Dicom.SchemaManager;
+
+public static class SchemaManagerParser
+{
+    public static Parser Build(ServiceProvider serviceProvider)
+    {
+        var commandLineBuilder = new CommandLineBuilder();
+
+        foreach (Command command in serviceProvider.GetServices<Command>())
+        {
+            commandLineBuilder.Command.AddCommand(command);
+        }
+
+        return commandLineBuilder.UseDefaults().Build();
+    }
+}

--- a/src/Microsoft.Health.Dicom.SchemaManager/SchemaManagerServiceCollectionBuilder.cs
+++ b/src/Microsoft.Health.Dicom.SchemaManager/SchemaManagerServiceCollectionBuilder.cs
@@ -3,43 +3,21 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.CommandLine;
-using System.CommandLine.Builder;
-using System.CommandLine.Parsing;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.Health.Dicom.SchemaManager;
 using Microsoft.Health.Dicom.SqlServer.Features.Schema;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Schema.Manager;
 using Microsoft.Health.SqlServer.Features.Schema.Messages.Notifications;
 using Microsoft.Health.SqlServer.Registration;
 
-internal class Program
+namespace Microsoft.Health.Dicom.SchemaManager;
+
+public static class SchemaManagerServiceCollectionBuilder
 {
-    public static async Task<int> Main(string[] args)
-    {
-        ServiceProvider serviceProvider = BuildServiceProvider(args);
-        Parser parser = BuildParser(serviceProvider);
-
-        return await parser.InvokeAsync(args).ConfigureAwait(false);
-    }
-
-    private static Parser BuildParser(ServiceProvider serviceProvider)
-    {
-        var commandLineBuilder = new CommandLineBuilder();
-
-        foreach (Command command in serviceProvider.GetServices<Command>())
-        {
-            commandLineBuilder.Command.AddCommand(command);
-        }
-
-        return commandLineBuilder.UseDefaults().Build();
-    }
-
-    private static ServiceProvider BuildServiceProvider(string[] args)
+    public static ServiceCollection Build(string[] args)
     {
         var services = new ServiceCollection();
 
@@ -69,6 +47,6 @@ internal class Program
         services.AddSingleton<ISchemaClient, DicomSchemaClient>();
         services.AddSingleton<ISchemaManager, SqlSchemaManager>();
         services.AddLogging(configure => configure.AddConsole());
-        return services.BuildServiceProvider();
+        return services;
     }
 }


### PR DESCRIPTION
## Description
Creates a separate console project for schema manager for easier downstream overloading of services.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.
