### PR TITLE
Implement DicomBaseSchemaRunner Class

### DIFF
--- a/src/Microsoft.Health.Dicom.SchemaManager/DicomBaseSchemaRunner.cs
+++ b/src/Microsoft.Health.Dicom.SchemaManager/DicomBaseSchemaRunner.cs
@@ -1,0 +1,21 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.SqlServer.Features.Schema.Manager;
+
+namespace Microsoft.Health.Dicom.SchemaManager;
+
+public class DicomBaseSchemaRunner : IBaseSchemaRunner
+{
+    public Task EnsureBaseSchemaExistsAsync(CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task EnsureInstanceSchemaRecordExistsAsync(CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Microsoft.Health.Dicom.SchemaManager/SchemaManagerServiceCollectionBuilder.cs
+++ b/src/Microsoft.Health.Dicom.SchemaManager/SchemaManagerServiceCollectionBuilder.cs
@@ -44,6 +44,7 @@ public static class SchemaManagerServiceCollectionBuilder
 
         services.AddMediatR(typeof(SchemaUpgradedNotification).Assembly);
 
+        services.AddSingleton<IBaseSchemaRunner, DicomBaseSchemaRunner>();
         services.AddSingleton<ISchemaClient, DicomSchemaClient>();
         services.AddSingleton<ISchemaManager, SqlSchemaManager>();
         services.AddLogging(configure => configure.AddConsole());


### PR DESCRIPTION
In order to resolve the issue where SchemaManager is run against an empty Dicom database, we will need to implement a custom BaseSchemaRunner class.