### PR TITLE
Update Serialization to be Async Where Possible

### DIFF
--- a/src/Microsoft.Health.Dicom.Blob/Features/Storage/BlobMetadataStore.cs
+++ b/src/Microsoft.Health.Dicom.Blob/Features/Storage/BlobMetadataStore.cs
@@ -85,25 +85,20 @@ public class BlobMetadataStore : IMetadataStore
 
         try
         {
-            await using (Stream stream = _recyclableMemoryStreamManager.GetStream(StoreInstanceMetadataStreamTagName))
-            await using (Utf8JsonWriter utf8Writer = new Utf8JsonWriter(stream))
-            {
-                // TODO: Use SerializeAsync in .NET 6
-                JsonSerializer.Serialize(utf8Writer, dicomDatasetWithoutBulkData, _jsonSerializerOptions);
-                await utf8Writer.FlushAsync(cancellationToken);
+            await using Stream stream = _recyclableMemoryStreamManager.GetStream(StoreInstanceMetadataStreamTagName);
+            await JsonSerializer.SerializeAsync(stream, dicomDatasetWithoutBulkData, _jsonSerializerOptions, cancellationToken);
 
-                foreach (var blob in blobClients)
-                {
-                    stream.Seek(0, SeekOrigin.Begin);
-                    await blob.UploadAsync(
-                        stream,
-                        new BlobHttpHeaders { ContentType = KnownContentTypes.ApplicationJson },
-                        metadata: null,
-                        conditions: null,
-                        accessTier: null,
-                        progressHandler: null,
-                        cancellationToken);
-                }
+            foreach (BlockBlobClient blob in blobClients)
+            {
+                stream.Seek(0, SeekOrigin.Begin);
+                await blob.UploadAsync(
+                    stream,
+                    new BlobHttpHeaders { ContentType = KnownContentTypes.ApplicationJsonUtf8 },
+                    metadata: null,
+                    conditions: null,
+                    accessTier: null,
+                    progressHandler: null,
+                    cancellationToken);
             }
         }
         catch (Exception ex)
@@ -129,10 +124,11 @@ public class BlobMetadataStore : IMetadataStore
 
         return ExecuteAsync(async t =>
         {
+            // TODO: When the JsonConverter for DicomDataset does not need to Seek, we can use DownloadStreaming instead
             BlobDownloadResult result = await blobClient.DownloadContentAsync(t);
 
-            // DICOM metadata file includes UTF-8 encoding with BOM and there is a bug with the BinaryData.ToObjectFromJson method as seen in this issue: https://github.com/dotnet/runtime/issues/71447
-            // So passing as stream which will remove the UTF-8 BOM.
+            // DICOM metadata file includes UTF-8 encoding with BOM and there is a bug with the
+            // BinaryData.ToObjectFromJson method as seen in this issue: https://github.com/dotnet/runtime/issues/71447
             return await JsonSerializer.DeserializeAsync<DicomDataset>(result.Content.ToStream(), _jsonSerializerOptions, t);
         }, cancellationToken);
     }
@@ -159,25 +155,19 @@ public class BlobMetadataStore : IMetadataStore
 
         try
         {
-            await using (Stream stream = _recyclableMemoryStreamManager.GetStream(StoreInstanceFramesRangeTagName))
-            await using (Utf8JsonWriter utf8Writer = new Utf8JsonWriter(stream))
-            {
-                JsonSerializer.Serialize(utf8Writer, framesRange, _jsonSerializerOptions);
-                await utf8Writer.FlushAsync(cancellationToken);
-                stream.Seek(0, SeekOrigin.Begin);
+            // TOOD: Stream directly to blob storage
+            await using Stream stream = _recyclableMemoryStreamManager.GetStream(StoreInstanceFramesRangeTagName);
+            await JsonSerializer.SerializeAsync(stream, framesRange, _jsonSerializerOptions, cancellationToken);
 
-                await blobClient.UploadAsync(
-                    stream,
-                    new BlobHttpHeaders()
-                    {
-                        ContentType = KnownContentTypes.ApplicationJson,
-                    },
-                    metadata: null,
-                    conditions: null,
-                    accessTier: null,
-                    progressHandler: null,
-                    cancellationToken);
-            }
+            stream.Seek(0, SeekOrigin.Begin);
+            await blobClient.UploadAsync(
+                stream,
+                new BlobHttpHeaders { ContentType = KnownContentTypes.ApplicationJsonUtf8 },
+                metadata: null,
+                conditions: null,
+                accessTier: null,
+                progressHandler: null,
+                cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/Microsoft.Health.Dicom.Client/DicomWebClient.ExtendedQueryTag.cs
+++ b/src/Microsoft.Health.Dicom.Client/DicomWebClient.ExtendedQueryTag.cs
@@ -7,6 +7,8 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,7 +27,7 @@ public partial class DicomWebClient : IDicomWebClient
         using var request = new HttpRequestMessage(HttpMethod.Post, uri);
         {
             request.Content = new StringContent(jsonString);
-            request.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(DicomWebConstants.ApplicationJsonMediaType);
+            request.Content.Headers.ContentType = new MediaTypeHeaderValue(DicomWebConstants.ApplicationJsonMediaType) { CharSet = Encoding.UTF8.WebName };
         }
 
         HttpResponseMessage response = await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
@@ -102,7 +104,7 @@ public partial class DicomWebClient : IDicomWebClient
         using var request = new HttpRequestMessage(HttpMethod.Patch, uri);
         {
             request.Content = new StringContent(jsonString);
-            request.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(DicomWebConstants.ApplicationJsonMediaType);
+            request.Content.Headers.ContentType = new MediaTypeHeaderValue(DicomWebConstants.ApplicationJsonMediaType) { CharSet = Encoding.UTF8.WebName };
         }
 
         HttpResponseMessage response = await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);

--- a/src/Microsoft.Health.Dicom.Client/DicomWebClient.Workitem.cs
+++ b/src/Microsoft.Health.Dicom.Client/DicomWebClient.Workitem.cs
@@ -6,6 +6,8 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -119,7 +121,7 @@ public partial class DicomWebClient : IDicomWebClient
         using var request = new HttpRequestMessage(httpMethod, uri);
         {
             request.Content = new StringContent(jsonString);
-            request.Content.Headers.ContentType = DicomWebConstants.MediaTypeApplicationDicomJson;
+            request.Content.Headers.ContentType = new MediaTypeHeaderValue(DicomWebConstants.ApplicationJsonMediaType) { CharSet = Encoding.UTF8.WebName };
         }
 
         request.Headers.Accept.Add(DicomWebConstants.MediaTypeApplicationDicomJson);

--- a/src/Microsoft.Health.Dicom.Core/Web/KnownContentTypes.cs
+++ b/src/Microsoft.Health.Dicom.Core/Web/KnownContentTypes.cs
@@ -11,6 +11,7 @@ public static class KnownContentTypes
     public const string ApplicationDicomJson = "application/dicom+json";
     public const string ApplicationOctetStream = "application/octet-stream";
     public const string ApplicationJson = "application/json";
+    public const string ApplicationJsonUtf8 = "application/json; charset=utf-8";
     public const string ImageJpeg = "image/jpeg";
     public const string ImagePng = "image/png";
     public const string MultipartRelated = "multipart/related";


### PR DESCRIPTION
## Description
- Use async overloads for serialization methods
- Pass explicit `charset` blob `Content-Type` header
- Avoid extra buffering where possible

## Related issues
N/A

## Testing
Pipeline
