### PR TITLE
Update DICOM Schema Manager to run with empty DB

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <FhirServerPackageVersion>2.0.55</FhirServerPackageVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <HealthcareSharedPackageVersion>6.1.62</HealthcareSharedPackageVersion>
+    <HealthcareSharedPackageVersion>6.1.64</HealthcareSharedPackageVersion>
     <HighEntropyVA>true</HighEntropyVA>
     <Hl7FhirPackageVersion>4.0.0</Hl7FhirPackageVersion>
     <LangVersion>Latest</LangVersion>

--- a/Microsoft.Health.Dicom.sln
+++ b/Microsoft.Health.Dicom.sln
@@ -10,6 +10,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Packages.props = Directory.Packages.props
 		GitVersion.yml = GitVersion.yml
 		global.json = global.json
+		nuget.config = nuget.config
 	EndProjectSection
 EndProject
 Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "docker\docker-compose.dcproj", "{336B1FB4-EEF8-4E11-BDD5-818983D4E1CD}"

--- a/src/Microsoft.Health.Dicom.SchemaManager/DicomBaseSchemaRunner.cs
+++ b/src/Microsoft.Health.Dicom.SchemaManager/DicomBaseSchemaRunner.cs
@@ -1,0 +1,42 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using EnsureThat;
+using Microsoft.Extensions.Logging;
+using Microsoft.Health.SqlServer.Features.Schema.Manager;
+using Microsoft.Health.SqlServer.Features.Schema.Manager.Exceptions;
+
+namespace Microsoft.Health.Dicom.SchemaManager;
+
+public class DicomBaseSchemaRunner : IBaseSchemaRunner
+{
+    private readonly BaseSchemaRunner _baseSchemaRunner;
+    private readonly ILogger<BaseSchemaRunner> _logger;
+
+    public DicomBaseSchemaRunner(BaseSchemaRunner baseSchemaRunner,
+        ILogger<BaseSchemaRunner> logger)
+    {
+        _baseSchemaRunner = EnsureArg.IsNotNull(baseSchemaRunner, nameof(baseSchemaRunner));
+        _logger = EnsureArg.IsNotNull(logger, nameof(logger));
+    }
+
+    public async Task EnsureBaseSchemaExistsAsync(CancellationToken cancellationToken)
+    {
+        await _baseSchemaRunner.EnsureBaseSchemaExistsAsync(cancellationToken);
+    }
+
+    public async Task EnsureInstanceSchemaRecordExistsAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _baseSchemaRunner.EnsureInstanceSchemaRecordExistsAsync(cancellationToken);
+        }
+        catch (SchemaManagerException ex) when (ex.Message.Equals("The current version information could not be fetched from the service. Please try again.", StringComparison.Ordinal))
+        {
+            // TODO: Throw a more exact error message type in the baseSchemaRunner
+            _logger.LogInformation("There was no current information found, this is a new DB.");
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.SchemaManager/DicomBaseSchemaRunner.cs
+++ b/src/Microsoft.Health.Dicom.SchemaManager/DicomBaseSchemaRunner.cs
@@ -33,9 +33,8 @@ public class DicomBaseSchemaRunner : IBaseSchemaRunner
         {
             await _baseSchemaRunner.EnsureInstanceSchemaRecordExistsAsync(cancellationToken);
         }
-        catch (SchemaManagerException ex) when (ex.Message.Equals("The current version information could not be fetched from the service. Please try again.", StringComparison.Ordinal))
+        catch (InstanceSchemaNotFoundException)
         {
-            // TODO: Throw a more exact error message type in the baseSchemaRunner
             _logger.LogInformation("There was no current information found, this is a new DB.");
         }
     }

--- a/src/Microsoft.Health.Dicom.SchemaManager/DicomSchemaClient.cs
+++ b/src/Microsoft.Health.Dicom.SchemaManager/DicomSchemaClient.cs
@@ -4,8 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.ObjectModel;
-using EnsureThat;
-using Microsoft.Extensions.Options;
 using Microsoft.Health.Dicom.SqlServer.Features.Schema;
 using Microsoft.Health.SqlServer.Features.Exceptions;
 using Microsoft.Health.SqlServer.Features.Schema;
@@ -20,18 +18,15 @@ public class DicomSchemaClient : ISchemaClient
     private readonly IScriptProvider _scriptProvider;
     private readonly ISchemaDataStore _schemaDataStore;
     private readonly ISchemaManagerDataStore _schemaManagerDataStore;
-    private readonly IOptions<CommandLineOptions> _commandLineOptions;
 
     public DicomSchemaClient(
         IScriptProvider scriptProvider,
         ISchemaDataStore schemaDataStore,
-        ISchemaManagerDataStore schemaManagerDataStore,
-        IOptions<CommandLineOptions> commandLineOptions)
+        ISchemaManagerDataStore schemaManagerDataStore)
     {
         _scriptProvider = scriptProvider;
         _schemaDataStore = schemaDataStore;
         _schemaManagerDataStore = schemaManagerDataStore;
-        _commandLineOptions = EnsureArg.IsNotNull(commandLineOptions, nameof(commandLineOptions));
     }
 
     public async Task<List<AvailableVersion>> GetAvailabilityAsync(CancellationToken cancellationToken = default)

--- a/src/Microsoft.Health.Dicom.SchemaManager/DicomSchemaClient.cs
+++ b/src/Microsoft.Health.Dicom.SchemaManager/DicomSchemaClient.cs
@@ -57,9 +57,8 @@ public class DicomSchemaClient : ISchemaClient
         {
             compatibleVersions = await _schemaDataStore.GetLatestCompatibleVersionsAsync(cancellationToken);
         }
-        catch (SqlRecordNotFoundException ex) when (ex.Message.Equals("The compatibility information was not found.", StringComparison.Ordinal))
+        catch (CompatibleVersionsNotFoundException)
         {
-            // TODO: Throw a more exact error message type in the schemaDataStore
             compatibleVersions = new CompatibleVersions(0, SchemaVersionConstants.Max);
         }
 

--- a/src/Microsoft.Health.Dicom.SchemaManager/SchemaManagerServiceCollectionBuilder.cs
+++ b/src/Microsoft.Health.Dicom.SchemaManager/SchemaManagerServiceCollectionBuilder.cs
@@ -40,7 +40,8 @@ public static class SchemaManagerServiceCollectionBuilder
 
         services.AddSqlServerManagement<SchemaVersion>();
 
-        services.AddSingleton<IBaseSchemaRunner, BaseSchemaRunner>();
+        services.AddSingleton<BaseSchemaRunner>();
+        services.AddSingleton<IBaseSchemaRunner, DicomBaseSchemaRunner>();
 
         services.AddMediatR(typeof(SchemaUpgradedNotification).Assembly);
 


### PR DESCRIPTION
## Description
Previously there was a dependency on a copy of the DICOM service to be running when the Schema Manager was executing. This PR updates this to capture specific exceptions that are thrown when there is no instance running when the schema manager is running. The assumption is that if there is no instance registered with the DB then it is safe to pursue the upgrade to the specified version.

## Related issues
Addresses [AB#93113](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/93113).

## Testing
Manual testing with local instances and also downstream testing.
