### PR TITLE
Fix file size being zero when request is not buffered.

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Controllers/StoreController.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/StoreController.cs
@@ -82,8 +82,7 @@ public class StoreController : ControllerBase
 
     private async Task<IActionResult> PostAsync(string studyInstanceUid)
     {
-        long fileSize = Request.ContentLength ?? 0;
-        _logger.LogInformation("DICOM Web Store Transaction request received, with study instance UID {StudyInstanceUid} and file size of {FileSize} bytes", studyInstanceUid, fileSize);
+        _logger.LogInformation("DICOM Web Store Transaction request received, with study instance UID {StudyInstanceUid}", studyInstanceUid);
 
         StoreResponse storeResponse = await _mediator.StoreDicomResourcesAsync(
             Request.Body,

--- a/src/Microsoft.Health.Dicom.Core/Features/Store/StoreOrchestrator.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Store/StoreOrchestrator.cs
@@ -98,6 +98,8 @@ public class StoreOrchestrator : IStoreOrchestrator
     {
         Stream stream = await dicomInstanceEntry.GetStreamAsync(cancellationToken);
 
+        _logger.LogInformation("Storing an DICOM instance of {FileSize} bytes", stream.Length);
+
         await _fileStore.StoreFileAsync(
             versionedInstanceIdentifier,
             stream,


### PR DESCRIPTION


## Description
Move file size log from controller to the service, by the time request reaches the service it is converted into a seekableStream that is fully buffered and has the fileSize.

## Related issues
AB#93502

## Testing
NA. Log changes
