### PR TITLE
Support single part frame get

### DIFF
--- a/docs/resources/conformance-statement.md
+++ b/docs/resources/conformance-statement.md
@@ -208,6 +208,7 @@ The following `Accept` headers are supported for retrieving frames:
 - `multipart/related; type="application/octet-stream"; transfer-syntax=1.2.840.10008.1.2.1`
 - `multipart/related; type="image/jp2";` (when transfer-syntax is not specified, 1.2.840.10008.1.2.4.90 is used as default)
 - `multipart/related; type="image/jp2";transfer-syntax=1.2.840.10008.1.2.4.90`
+- `application/octet-stream; transfer-syntax=*` for single frame retrieval
 
 ### Retrieve Transfer Syntax
 

--- a/src/Microsoft.Health.Dicom.Api/Controllers/RetrieveController.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/RetrieveController.cs
@@ -179,7 +179,7 @@ public class RetrieveController : ControllerBase
         return CreateResult(response);
     }
 
-    [Produces(KnownContentTypes.MultipartRelated)]
+    [Produces(KnownContentTypes.ApplicationDicom, KnownContentTypes.MultipartRelated)]
     [ProducesResponseType((int)HttpStatusCode.OK)]
     [ProducesResponseType(typeof(string), (int)HttpStatusCode.BadRequest)]
     [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]

--- a/src/Microsoft.Health.Dicom.Client/IDicomWebClient.Retrieve.cs
+++ b/src/Microsoft.Health.Dicom.Client/IDicomWebClient.Retrieve.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Health.Dicom.Client;
 
 public partial interface IDicomWebClient
 {
+    Task<DicomWebResponse<Stream>> RetrieveSingleFrameAsync(string studyInstanceUid, string seriesInstanceUid, string sopInstanceUid, int frame, string partitionName = default, CancellationToken cancellationToken = default);
     Task<DicomWebAsyncEnumerableResponse<Stream>> RetrieveFramesAsync(string studyInstanceUid, string seriesInstanceUid, string sopInstanceUid, int[] frames = default, string mediaType = DicomWebConstants.ApplicationOctetStreamMediaType, string dicomTransferSyntax = DicomWebConstants.OriginalDicomTransferSyntax, string partitionName = default, CancellationToken cancellationToken = default);
     Task<DicomWebResponse<DicomFile>> RetrieveInstanceAsync(string studyInstanceUid, string seriesInstanceUid, string sopInstanceUid, string dicomTransferSyntax = DicomWebConstants.OriginalDicomTransferSyntax, string partitionName = default, CancellationToken cancellationToken = default);
     Task<DicomWebAsyncEnumerableResponse<DicomDataset>> RetrieveInstanceMetadataAsync(string studyInstanceUid, string seriesInstanceUid, string sopInstanceUid, string ifNoneMatch = default, string partitionName = default, CancellationToken cancellationToken = default);

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveResourceServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveResourceServiceTests.cs
@@ -454,6 +454,23 @@ public class RetrieveResourceServiceTests
         }
     }
 
+    [Fact]
+    public async Task GetFrames_WithSinglePartAcceptOnMultipleFrames_Throws()
+    {
+        // arrange
+        string requestedTransferSyntax = "*";
+
+        List<InstanceMetadata> versionedInstanceIdentifiers = SetupInstanceIdentifiersList(ResourceType.Frames);
+        var framesToRequest = new List<int> { 1, 2 };
+        var retrieveResourceRequest = new RetrieveResourceRequest(_studyInstanceUid, _firstSeriesInstanceUid, _sopInstanceUid, framesToRequest, new[] { AcceptHeaderHelpers.CreateAcceptHeaderForGetFrame(requestedTransferSyntax, KnownContentTypes.ApplicationOctetStream, null, PayloadTypes.SinglePart) });
+
+        // act and assert
+        await Assert.ThrowsAsync<BadRequestException>(() =>
+            _retrieveResourceService.GetInstanceResourceAsync(
+               retrieveResourceRequest,
+               DefaultCancellationToken));
+    }
+
     [Theory]
     [InlineData("*", "1.2.840.10008.1.2.1", "*")] // this is the bug in old files, that is fixed for new files
     [InlineData("1.2.840.10008.1.2.1", "1.2.840.10008.1.2.1", "1.2.840.10008.1.2.1")]

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
@@ -1084,6 +1084,15 @@ namespace Microsoft.Health.Dicom.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The accept header is supported for single frame retrieval, use multi-part accept header instead..
+        /// </summary>
+        internal static string SinglePartSupportedForSingleFrame {
+            get {
+                return ResourceManager.GetString("SinglePartSupportedForSingleFrame", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The specified study cannot be found..
         /// </summary>
         internal static string StudyInstanceNotFound {

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
@@ -621,4 +621,7 @@ For details on valid range queries, please refer to Search Matching section in C
   <data name="UpdateWorkitemInstanceConflictFailure" xml:space="preserve">
     <value>The submitted request is inconsistent with the current state of the Workitem.</value>
   </data>
+  <data name="SinglePartSupportedForSingleFrame" xml:space="preserve">
+    <value>The accept header is supported for single frame retrieval, use multi-part accept header instead.</value>
+  </data>
 </root>

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveResourceService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveResourceService.cs
@@ -157,6 +157,12 @@ public class RetrieveResourceService : IRetrieveResourceService
         bool isSinglePart,
         CancellationToken cancellationToken)
     {
+
+        if (isSinglePart && message.Frames.Count() > 1)
+        {
+            throw new BadRequestException(DicomCoreResource.SinglePartSupportedForSingleFrame);
+        }
+
         _dicomRequestContextAccessor.RequestContext.PartCount = message.Frames.Count();
 
         // only caching frames which are required to provide all 3 UIDs and more immutable

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveTransferSyntaxHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveTransferSyntaxHandler.cs
@@ -95,7 +95,7 @@ public class RetrieveTransferSyntaxHandler : IRetrieveTransferSyntaxHandler
     {
         return new AcceptHeaderDescriptors(
          new AcceptHeaderDescriptor(
-             payloadType: PayloadTypes.MultipartRelated,
+             payloadType: PayloadTypes.SinglePartOrMultipartRelated,
              mediaType: KnownContentTypes.ApplicationOctetStream,
              isTransferSyntaxMandatory: false,
              transferSyntaxWhenMissing: DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID,

--- a/src/Microsoft.Health.Dicom.Tests.Common/AcceptHeaderHelpers.cs
+++ b/src/Microsoft.Health.Dicom.Tests.Common/AcceptHeaderHelpers.cs
@@ -38,11 +38,11 @@ public static class AcceptHeaderHelpers
            quality: quality);
     }
 
-    public static AcceptHeader CreateAcceptHeaderForGetFrame(string transferSyntax = "*", string mediaType = KnownContentTypes.ApplicationOctetStream, double? quality = null)
+    public static AcceptHeader CreateAcceptHeaderForGetFrame(string transferSyntax = "*", string mediaType = KnownContentTypes.ApplicationOctetStream, double? quality = null, PayloadTypes payloadType = PayloadTypes.MultipartRelated)
     {
         return CreateAcceptHeader(
           transferSyntax: transferSyntax,
-          payloadType: PayloadTypes.MultipartRelated,
+          payloadType: payloadType,
           mediaType: mediaType,
           quality: quality);
     }

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Frame.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Frame.cs
@@ -63,18 +63,6 @@ public partial class RetrieveTransactionResourceTests
         }
     }
 
-    [Theory]
-    [MemberData(nameof(GetUnsupportedAcceptHeadersForFrames))]
-    public async Task GivenUnsupportedAcceptHeaders_WhenRetrieveFrame_ThenServerShouldReturnNotAcceptable(bool singlePart, string mediaType, string transferSyntax)
-    {
-        var requestUri = new Uri(DicomApiVersions.Latest + string.Format(DicomWebConstants.BaseRetrieveFramesUriFormat, TestUidGenerator.Generate(), TestUidGenerator.Generate(), TestUidGenerator.Generate(), string.Join("%2C", new int[] { 1 })), UriKind.Relative);
-
-        using HttpRequestMessage request = new HttpRequestMessageBuilder().Build(requestUri, singlePart: singlePart, mediaType, transferSyntax);
-        using HttpResponseMessage response = await _client.HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
-
-        Assert.Equal(HttpStatusCode.NotAcceptable, response.StatusCode);
-    }
-
     [Fact]
     public async Task GivenUnsupportedTransferSyntax_WhenRetrieveFrameWithOriginalTransferSyntax_ThenOriginalContentReturned()
     {

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Frame.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Frame.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
 using FellowOakDicom;
 using FellowOakDicom.Imaging;

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Frame.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Frame.cs
@@ -161,6 +161,27 @@ public partial class RetrieveTransactionResourceTests
     }
 
     [Fact]
+    public async Task GivenInstanceWithFrames_WhenRetrieveSinglePartOneFrame_ThenServerShouldReturnExpectedContent()
+    {
+        string studyInstanceUid = TestUidGenerator.Generate();
+
+        DicomFile dicomFile1 = Samples.CreateRandomDicomFileWithPixelData(studyInstanceUid, frames: 3);
+        DicomPixelData pixelData = DicomPixelData.Create(dicomFile1.Dataset);
+        InstanceIdentifier dicomInstance = dicomFile1.Dataset.ToInstanceIdentifier();
+
+        await _instancesManager.StoreAsync(new[] { dicomFile1 });
+
+        using DicomWebResponse<Stream> response = await _client.RetrieveSingleFrameAsync(
+            dicomInstance.StudyInstanceUid,
+            dicomInstance.SeriesInstanceUid,
+            dicomInstance.SopInstanceUid,
+            1);
+        Stream frameStream = await response.GetValueAsync();
+        Assert.NotNull(frameStream);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
     public async Task GivenNonExistingFrames_WhenRetrieveFrame_ThenServerShouldReturnNotFound()
     {
         (InstanceIdentifier identifier, DicomFile file) = await CreateAndStoreDicomFile(2);


### PR DESCRIPTION
## Description
Add support allow single part get on frame
Accept: application/octet-stream; transfer-syntax=*

## Related issues
[AB#93653](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/93653)

## Testing
New E2E and unit test added