### PR TITLE
Add additional config options to SchemaManager

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -51,6 +51,7 @@
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(SdkPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="$(SdkPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(SdkPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(SdkPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="$(SdkPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="6.0.7" />

--- a/src/Microsoft.Health.Dicom.SchemaManager.Console/Microsoft.Health.Dicom.SchemaManager.Console.csproj
+++ b/src/Microsoft.Health.Dicom.SchemaManager.Console/Microsoft.Health.Dicom.SchemaManager.Console.csproj
@@ -8,7 +8,20 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Hosting" />
+      <PackageReference Include="Microsoft.Extensions.Configuration" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    </ItemGroup>
+  
+    <ItemGroup>
       <ProjectReference Include="..\Microsoft.Health.Dicom.SchemaManager\Microsoft.Health.Dicom.SchemaManager.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Remove="appsettings.json" />
+      <Content Include="appsettings.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
     </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Health.Dicom.SchemaManager.Console/Program.cs
+++ b/src/Microsoft.Health.Dicom.SchemaManager.Console/Program.cs
@@ -4,17 +4,25 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.CommandLine.Parsing;
-using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Health.Dicom.SchemaManager;
 
 internal class Program
 {
     public static async Task<int> Main(string[] args)
     {
-        ServiceCollection serviceCollection = SchemaManagerServiceCollectionBuilder.Build(args);
+        IHost host = Host.CreateDefaultBuilder()
+            .ConfigureAppConfiguration(builder =>
+            {
+                builder.AddSchemaCommandLine(args);
+            })
+            .ConfigureServices((context, collection) =>
+            {
+                collection.AddSchemaManager(context.Configuration);
+            })
+            .Build();
 
-        var serviceProvider = serviceCollection.BuildServiceProvider();
-        Parser parser = SchemaManagerParser.Build(serviceProvider);
+        Parser parser = SchemaManagerParser.Build(host.Services);
 
         return await parser.InvokeAsync(args).ConfigureAwait(false);
     }

--- a/src/Microsoft.Health.Dicom.SchemaManager.Console/Properties/launchSettings.json
+++ b/src/Microsoft.Health.Dicom.SchemaManager.Console/Properties/launchSettings.json
@@ -2,7 +2,10 @@
   "profiles": {
     "Microsoft.Health.Dicom.SchemaManager": {
       "commandName": "Project",
-      "commandLineArgs": "apply --connection-string \"server=(local);Initial Catalog=DICOM3;TrustServerCertificate=True;Integrated Security=True\" --version 20"
+      "commandLineArgs": "apply --connection-string \"server=(local);Initial Catalog=DICOM3;TrustServerCertificate=True;Integrated Security=True\" --version 20",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
     }
   }
 }

--- a/src/Microsoft.Health.Dicom.SchemaManager.Console/appsettings.json
+++ b/src/Microsoft.Health.Dicom.SchemaManager.Console/appsettings.json
@@ -1,0 +1,9 @@
+﻿{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Debug",
+            "System": "Information",
+            "Microsoft": "Information"
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.SchemaManager/CommandCollectionExtensions.cs
+++ b/src/Microsoft.Health.Dicom.SchemaManager/CommandCollectionExtensions.cs
@@ -43,7 +43,7 @@ public static class CommandCollectionExtensions
         return services;
     }
 
-    public static IServiceCollection SetCommandLineOptions(this IServiceCollection services, string[] args)
+    public static IConfigurationBuilder AddSchemaCommandLine(this IConfigurationBuilder configurationBuilder, string[] args)
     {
         var switchMappings = new Dictionary<string, string>()
         {
@@ -63,12 +63,13 @@ public static class CommandCollectionExtensions
             { OptionAliases.Version, OptionAliases.Version },
         };
 
-        var builder = new ConfigurationBuilder();
+        configurationBuilder.AddCommandLine(args, switchMappings);
 
-        builder.AddCommandLine(args, switchMappings);
+        return configurationBuilder;
+    }
 
-        IConfigurationRoot config = builder.Build();
-
+    public static IServiceCollection SetCommandLineOptions(this IServiceCollection services, IConfiguration config)
+    {
         services.AddOptions<CommandLineOptions>().Configure(x =>
         {
             x.ConnectionString = config[OptionAliases.ConnectionString];

--- a/src/Microsoft.Health.Dicom.SchemaManager/SchemaManagerParserBuilder.cs
+++ b/src/Microsoft.Health.Dicom.SchemaManager/SchemaManagerParserBuilder.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Health.Dicom.SchemaManager;
 
 public static class SchemaManagerParser
 {
-    public static Parser Build(ServiceProvider serviceProvider)
+    public static Parser Build(IServiceProvider serviceProvider)
     {
         var commandLineBuilder = new CommandLineBuilder();
 

--- a/src/Microsoft.Health.Dicom.SchemaManager/SchemaManagerServiceCollectionBuilder.cs
+++ b/src/Microsoft.Health.Dicom.SchemaManager/SchemaManagerServiceCollectionBuilder.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using MediatR;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -17,13 +18,11 @@ namespace Microsoft.Health.Dicom.SchemaManager;
 
 public static class SchemaManagerServiceCollectionBuilder
 {
-    public static ServiceCollection Build(string[] args)
+    public static IServiceCollection AddSchemaManager(this IServiceCollection services, IConfiguration config)
     {
-        var services = new ServiceCollection();
-
         services.AddCliCommands();
 
-        services.SetCommandLineOptions(args);
+        services.SetCommandLineOptions(config);
 
         services.AddOptions<SqlServerDataStoreConfiguration>().Configure<IOptions<CommandLineOptions>>((s, c) =>
         {


### PR DESCRIPTION
## Description
This PR adds the ability to have different configuration providers for Schema Manager. Additionally it refactors the extensions provided to allow it to be used in way to add additional service providers.

## Related issues
Addresses [AB#93339](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/93339).

## Testing
Manually tested in OSS and downstream.
