### PR TITLE
Adding a new prop to track the Application Insights package version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <ApplicationInsightsPackageVersion>2.21.0</ApplicationInsightsPackageVersion>
     <Authors>Microsoft Health Team</Authors>
     <Company>Microsoft Corporation</Company>
     <Copyright>Copyright © Microsoft Corporation. All rights reserved.</Copyright>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,9 +20,9 @@
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
     <PackageVersion Include="MediatR" Version="9.0.0" />
     <PackageVersion Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.21.0" />
-    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
-    <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.20.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights" Version="$(ApplicationInsightsPackageVersion)" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="$(ApplicationInsightsPackageVersion)" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="$(ApplicationInsightsPackageVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.7" />
     <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
@@ -57,7 +57,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="6.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(SdkPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(SdkPackageVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.20.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="$(ApplicationInsightsPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$(SdkPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="$(SdkPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(SdkPackageVersion)" />

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Hosting/Program.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Hosting/Program.cs
@@ -53,7 +53,8 @@ public static class Program
     }
 
     /// <summary>
-    /// Adds ApplicationInsights for telemetry and logging.
+    /// Adds ApplicationInsights for telemetry and logging. We need to migrate to Application Insights
+    /// connection strings: https://github.com/microsoft/ApplicationInsights-dotnet/issues/2560
     /// </summary>
     private static void AddApplicationInsightsTelemetry(IServiceCollection services, IConfiguration configuration)
     {
@@ -61,8 +62,10 @@ public static class Program
 
         if (!string.IsNullOrWhiteSpace(instrumentationKey))
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             services.AddApplicationInsightsTelemetryWorkerService(instrumentationKey);
             services.AddLogging(loggingBuilder => loggingBuilder.AddApplicationInsights(instrumentationKey));
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Hosting/Program.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Hosting/Program.cs
@@ -7,7 +7,6 @@ using System;
 using Azure.Extensions.AspNetCore.Configuration.Secrets;
 using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
-using Microsoft.ApplicationInsights.WorkerService;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -64,11 +63,11 @@ public static class Program
         {
             var connectionString = $"InstrumentationKey={instrumentationKey}";
 
-            services.AddApplicationInsightsTelemetryWorkerService(applicationInsightsServiceOptions => applicationInsightsServiceOptions.ConnectionString = connectionString);
+            services.AddApplicationInsightsTelemetryWorkerService(aiServiceOptions => aiServiceOptions.ConnectionString = connectionString);
             services.AddLogging(
                 loggingBuilder => loggingBuilder.AddApplicationInsights(
-                    telemetryConfiguration => telemetryConfiguration.ConnectionString = connectionString,
-                    applicationInsightsLoggerOptions => { }
+                    telemetryConfig => telemetryConfig.ConnectionString = connectionString,
+                    aiLoggerOptions => { }
                 ));
         }
     }

--- a/src/Microsoft.Health.Dicom.Web/Startup.cs
+++ b/src/Microsoft.Health.Dicom.Web/Startup.cs
@@ -52,7 +52,8 @@ public class Startup
     }
 
     /// <summary>
-    /// Adds ApplicationInsights for telemetry and logging.
+    /// Adds ApplicationInsights for telemetry and logging. We need to migrate to Application Insights
+    /// connection strings: https://github.com/microsoft/ApplicationInsights-dotnet/issues/2560
     /// </summary>
     private void AddApplicationInsightsTelemetry(IServiceCollection services)
     {
@@ -60,7 +61,9 @@ public class Startup
 
         if (!string.IsNullOrWhiteSpace(instrumentationKey))
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             services.AddApplicationInsightsTelemetry(instrumentationKey);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Web/Startup.cs
+++ b/src/Microsoft.Health.Dicom.Web/Startup.cs
@@ -52,8 +52,7 @@ public class Startup
     }
 
     /// <summary>
-    /// Adds ApplicationInsights for telemetry and logging. We need to migrate to Application Insights
-    /// connection strings: https://github.com/microsoft/ApplicationInsights-dotnet/issues/2560
+    /// Adds ApplicationInsights for telemetry and logging.
     /// </summary>
     private void AddApplicationInsightsTelemetry(IServiceCollection services)
     {
@@ -61,9 +60,9 @@ public class Startup
 
         if (!string.IsNullOrWhiteSpace(instrumentationKey))
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            services.AddApplicationInsightsTelemetry(instrumentationKey);
-#pragma warning restore CS0618 // Type or member is obsolete
+            var connectionString = $"InstrumentationKey={instrumentationKey}";
+
+            services.AddApplicationInsightsTelemetry(aiOptions => aiOptions.ConnectionString = connectionString);
         }
     }
 }


### PR DESCRIPTION
…shared across multiple libraries. This version of Application Insights marks instrumentation key as obsolete - we will build connection strings with the instrumentation key in Dicom and DicomCast: https://github.com/microsoft/ApplicationInsights-dotnet/issues/2560

Tracked via [AB#93836](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/93836)

Tested by sending telemetry to Application Insights via the new configuration.