### PR TITLE
Handle workitem request body deserialization as part of the request pipeline.

### DIFF
--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Controllers/WorkitemController.AddTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Controllers/WorkitemController.AddTests.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -56,7 +56,7 @@ public sealed class WorkitemControllerAddTests
                 Arg.Is(_controller.HttpContext.RequestAborted))
             .Returns(new AddWorkitemResponse(WorkitemResponseStatus.Failure, new Uri("https://www.microsoft.com")));
 
-        ObjectResult result = await _controller.AddAsync() as ObjectResult;
+        ObjectResult result = await _controller.AddAsync(null) as ObjectResult;
 
         Assert.IsType<ObjectResult>(result);
         Assert.Equal(HttpStatusCode.BadRequest, (HttpStatusCode)result.StatusCode);
@@ -72,7 +72,7 @@ public sealed class WorkitemControllerAddTests
                 Arg.Is(_controller.HttpContext.RequestAborted))
             .Returns(new AddWorkitemResponse(WorkitemResponseStatus.Conflict, new Uri("https://www.microsoft.com")));
 
-        ObjectResult result = await _controller.AddAsync() as ObjectResult;
+        ObjectResult result = await _controller.AddAsync(null) as ObjectResult;
 
         Assert.IsType<ObjectResult>(result);
         Assert.Equal(HttpStatusCode.Conflict, (HttpStatusCode)result.StatusCode);
@@ -90,7 +90,7 @@ public sealed class WorkitemControllerAddTests
                 Arg.Is(_controller.HttpContext.RequestAborted))
             .Returns(new AddWorkitemResponse(WorkitemResponseStatus.Success, new Uri(url)));
 
-        ObjectResult result = await _controller.AddAsync() as ObjectResult;
+        ObjectResult result = await _controller.AddAsync(null) as ObjectResult;
 
         Assert.IsType<ObjectResult>(result);
         Assert.Equal(HttpStatusCode.Created, (HttpStatusCode)result.StatusCode);

--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Controllers/WorkitemController.UpdateTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Controllers/WorkitemController.UpdateTests.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -56,7 +56,7 @@ public sealed class WorkitemControllerUpdateTests
                 Arg.Is(_controller.HttpContext.RequestAborted))
             .Returns(new UpdateWorkitemResponse(WorkitemResponseStatus.Failure, new Uri("https://www.microsoft.com")));
 
-        ObjectResult result = await _controller.UpdateAsync(_id) as ObjectResult;
+        ObjectResult result = await _controller.UpdateAsync(_id, null) as ObjectResult;
 
         Assert.IsType<ObjectResult>(result);
         Assert.Equal(HttpStatusCode.BadRequest, (HttpStatusCode)result.StatusCode);
@@ -72,7 +72,7 @@ public sealed class WorkitemControllerUpdateTests
                 Arg.Is(_controller.HttpContext.RequestAborted))
             .Returns(new UpdateWorkitemResponse(WorkitemResponseStatus.Conflict, new Uri("https://www.microsoft.com")));
 
-        ObjectResult result = await _controller.UpdateAsync(_id) as ObjectResult;
+        ObjectResult result = await _controller.UpdateAsync(_id, null) as ObjectResult;
 
         Assert.IsType<ObjectResult>(result);
         Assert.Equal(HttpStatusCode.Conflict, (HttpStatusCode)result.StatusCode);
@@ -90,7 +90,7 @@ public sealed class WorkitemControllerUpdateTests
                 Arg.Is(_controller.HttpContext.RequestAborted))
             .Returns(new UpdateWorkitemResponse(WorkitemResponseStatus.Success, new Uri(url)));
 
-        ObjectResult result = await _controller.UpdateAsync(_id) as ObjectResult;
+        ObjectResult result = await _controller.UpdateAsync(_id, null) as ObjectResult;
 
         Assert.IsType<ObjectResult>(result);
         Assert.Equal(HttpStatusCode.OK, (HttpStatusCode)result.StatusCode);

--- a/src/Microsoft.Health.Dicom.Api/Controllers/WorkitemController.Cancel.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/WorkitemController.Cancel.cs
@@ -1,10 +1,13 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using FellowOakDicom;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Api.Features.Audit;
@@ -35,6 +38,7 @@ public partial class WorkitemController
     /// 
     /// </remarks>
     /// <param name="workitemInstanceUid">The workitem Uid</param>
+    /// <param name="dicomDatasets">The DICOM dataset payload in the body.</param>
     /// <returns>Returns a string status report.</returns>
     [HttpPost]
     [Produces(KnownContentTypes.ApplicationDicomJson)]
@@ -47,13 +51,13 @@ public partial class WorkitemController
     [VersionedPartitionRoute(KnownRoutes.CancelWorkitemInstancesRoute, Name = KnownRouteNames.PartitionedCancelWorkitemInstance)]
     [VersionedRoute(KnownRoutes.CancelWorkitemInstancesRoute, Name = KnownRouteNames.CancelWorkitemInstance)]
     [AuditEventType(AuditEventSubType.CancelWorkitem)]
-    public async Task<IActionResult> CancelAsync(string workitemInstanceUid)
+    public async Task<IActionResult> CancelAsync(string workitemInstanceUid, [FromBody] IReadOnlyCollection<DicomDataset> dicomDatasets)
     {
         _logger.LogInformation("DICOM Web Cancel Workitem Transaction request received, with Workitem instance UID {WorkitemInstanceUid}",
             workitemInstanceUid ?? string.Empty);
 
         var response = await _mediator.CancelWorkitemAsync(
-                Request.Body,
+                dicomDatasets?.FirstOrDefault(),
                 Request.ContentType,
                 workitemInstanceUid,
                 HttpContext.RequestAborted)

--- a/src/Microsoft.Health.Dicom.Api/Controllers/WorkitemController.ChangeState.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/WorkitemController.ChangeState.cs
@@ -1,10 +1,13 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using FellowOakDicom;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Health.Api.Features.Audit;
 using Microsoft.Health.Dicom.Api.Extensions;
@@ -32,11 +35,11 @@ public partial class WorkitemController
     [VersionedPartitionRoute(KnownRoutes.ChangeStateWorkitemInstancesRoute, Name = KnownRouteNames.PartitionChangeStateWorkitemInstance)]
     [VersionedRoute(KnownRoutes.ChangeStateWorkitemInstancesRoute, Name = KnownRouteNames.ChangeStateWorkitemInstance)]
     [AuditEventType(AuditEventSubType.ChangeStateWorkitem)]
-    public async Task<IActionResult> ChangeStateAsync(string workitemInstanceUid)
+    public async Task<IActionResult> ChangeStateAsync(string workitemInstanceUid, [FromBody] IReadOnlyCollection<DicomDataset> dicomDatasets)
     {
         var response = await _mediator
                     .ChangeWorkitemStateAsync(
-                        Request.Body,
+                        dicomDatasets?.FirstOrDefault(),
                         Request.ContentType,
                         workitemInstanceUid,
                         cancellationToken: HttpContext.RequestAborted)

--- a/src/Microsoft.Health.Dicom.Api/Controllers/WorkitemController.Update.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/WorkitemController.Update.cs
@@ -1,11 +1,13 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using FellowOakDicom;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Api.Features.Audit;
@@ -39,21 +41,21 @@ public partial class WorkitemController
     [VersionedPartitionRoute(KnownRoutes.UpdateWorkitemInstancesRoute, Name = KnownRouteNames.PartitionedUpdateWorkitemInstance)]
     [VersionedRoute(KnownRoutes.UpdateWorkitemInstancesRoute, Name = KnownRouteNames.UpdateWorkitemInstance)]
     [AuditEventType(AuditEventSubType.UpdateWorkitem)]
-    public async Task<IActionResult> UpdateAsync(string workitemInstanceUid)
+    public async Task<IActionResult> UpdateAsync(string workitemInstanceUid, [FromBody] IReadOnlyCollection<DicomDataset> dicomDatasets)
     {
         // The Transaction UID is passed as the first query parameter 
         string transactionUid = HttpContext.Request.Query.Keys.FirstOrDefault();
 
-        return await PostUpdateAsync(workitemInstanceUid, transactionUid);
+        return await PostUpdateAsync(workitemInstanceUid, transactionUid, dicomDatasets);
     }
 
-    private async Task<IActionResult> PostUpdateAsync(string workitemInstanceUid, string transactionUid)
+    private async Task<IActionResult> PostUpdateAsync(string workitemInstanceUid, string transactionUid, IReadOnlyCollection<DicomDataset> dicomDatasets)
     {
         long fileSize = Request.ContentLength ?? 0;
-        _logger.LogInformation("DICOM Web Update Workitem Transaction request received with file size of {FileSize} bytes.", fileSize);
+        _logger.LogInformation("DICOM Web Update Workitem Transaction request received with {NumberOfDicomDatasets} DICOM dataset.", dicomDatasets?.Count ?? 0);
 
         UpdateWorkitemResponse response = await _mediator.UpdateWorkitemAsync(
-            Request.Body,
+            dicomDatasets?.FirstOrDefault(),
             Request.ContentType,
             workitemInstanceUid,
             transactionUid,

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Workitem/AddWorkitemRequestHandlerTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Workitem/AddWorkitemRequestHandlerTests.cs
@@ -1,10 +1,9 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using FellowOakDicom;
@@ -32,7 +31,7 @@ public sealed class AddWorkitemRequestHandlerTests
     public async Task GivenSupportedContentType_WhenHandled_ThenCorrectStoreResponseShouldBeReturned()
     {
         var workitemInstanceUid = string.Empty;
-        var request = new AddWorkitemRequest(Stream.Null, @"application/json", workitemInstanceUid);
+        var request = new AddWorkitemRequest(new DicomDataset(), @"application/json", workitemInstanceUid);
 
         var response = new AddWorkitemResponse(WorkitemResponseStatus.Success, new Uri(@"https://www.microsoft.com"));
 

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Workitem/WorkitemRequestValidatorExtensionsTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Workitem/WorkitemRequestValidatorExtensionsTests.cs
@@ -1,10 +1,10 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.IO;
+using FellowOakDicom;
 using Microsoft.Health.Dicom.Core.Exceptions;
 using Microsoft.Health.Dicom.Core.Features.Workitem;
 using Microsoft.Health.Dicom.Core.Messages.Workitem;
@@ -25,7 +25,7 @@ public sealed class WorkitemRequestValidatorExtensionsTests
     [Fact]
     public void GivenAddWorkitemRequest_WhenWorkitemInstanceUidIsNull_ThenNoExceptionIsThrown()
     {
-        var target = new AddWorkitemRequest(Stream.Null, @"application/json", null);
+        var target = new AddWorkitemRequest(new DicomDataset(), @"application/json", null);
 
         target.Validate();
     }
@@ -33,7 +33,7 @@ public sealed class WorkitemRequestValidatorExtensionsTests
     [Fact]
     public void GivenAddWorkitemRequest_WhenWorkitemInstanceUidIsLongerThan64Chars_ThenInvalidIdentifierExceptionIsThrown()
     {
-        var target = new AddWorkitemRequest(Stream.Null, @"application/json", Guid.NewGuid().ToString());
+        var target = new AddWorkitemRequest(new DicomDataset(), @"application/json", Guid.NewGuid().ToString());
 
         Assert.Throws<InvalidIdentifierException>(() => target.Validate());
     }
@@ -41,7 +41,7 @@ public sealed class WorkitemRequestValidatorExtensionsTests
     [Fact]
     public void GivenAddWorkitemRequest_WhenWorkitemInstanceUidIsInvalid_ThenInvalidIdentifierExceptionIsThrown()
     {
-        var target = new AddWorkitemRequest(Stream.Null, @"application/json", @"12346.8234234.abc.234");
+        var target = new AddWorkitemRequest(new DicomDataset(), @"application/json", @"12346.8234234.abc.234");
 
         Assert.Throws<InvalidIdentifierException>(() => target.Validate());
     }
@@ -49,7 +49,7 @@ public sealed class WorkitemRequestValidatorExtensionsTests
     [Fact]
     public void GivenAddWorkitemRequest_WhenWorkitemInstanceUidIsValid_ThenNoExceptionIsThrown()
     {
-        var target = new AddWorkitemRequest(Stream.Null, @"application/json", @"12346.8234234.234");
+        var target = new AddWorkitemRequest(new DicomDataset(), @"application/json", @"12346.8234234.234");
 
         target.Validate();
     }

--- a/src/Microsoft.Health.Dicom.Core/Extensions/DicomMediatorExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Extensions/DicomMediatorExtensions.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -9,6 +9,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
+using FellowOakDicom;
 using MediatR;
 using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 using Microsoft.Health.Dicom.Core.Features.Query;
@@ -230,17 +231,19 @@ public static class DicomMediatorExtensions
     }
 
     public static Task<AddWorkitemResponse> AddWorkitemAsync(
-        this IMediator mediator, Stream requestBody, string requestContentType, string workitemInstanceUid, CancellationToken cancellationToken)
+        this IMediator mediator, DicomDataset dicomDataSet, string requestContentType, string workitemInstanceUid, CancellationToken cancellationToken)
     {
         EnsureArg.IsNotNull(mediator, nameof(mediator));
-        return mediator.Send(new AddWorkitemRequest(requestBody, requestContentType, workitemInstanceUid), cancellationToken);
+
+        return mediator.Send(new AddWorkitemRequest(dicomDataSet, requestContentType, workitemInstanceUid), cancellationToken);
     }
 
     public static Task<CancelWorkitemResponse> CancelWorkitemAsync(
-        this IMediator mediator, Stream requestBody, string requestContentType, string workitemUid, CancellationToken cancellationToken)
+        this IMediator mediator, DicomDataset dicomDataSet, string requestContentType, string workitemUid, CancellationToken cancellationToken)
     {
         EnsureArg.IsNotNull(mediator, nameof(mediator));
-        return mediator.Send(new CancelWorkitemRequest(requestBody, requestContentType, workitemUid), cancellationToken);
+
+        return mediator.Send(new CancelWorkitemRequest(dicomDataSet, requestContentType, workitemUid), cancellationToken);
     }
 
     public static Task<QueryWorkitemResourceResponse> QueryWorkitemsAsync(
@@ -255,18 +258,16 @@ public static class DicomMediatorExtensions
 
     public static Task<ChangeWorkitemStateResponse> ChangeWorkitemStateAsync(
         this IMediator mediator,
-        Stream requestBody,
+        DicomDataset dicomDataSet,
         string requestContentType,
         string workitemUid,
         CancellationToken cancellationToken = default)
     {
         EnsureArg.IsNotNull(mediator, nameof(mediator));
-        EnsureArg.IsNotNull(requestBody, nameof(requestBody));
         EnsureArg.IsNotEmptyOrWhiteSpace(workitemUid, nameof(workitemUid));
 
         return mediator.Send(
-            new ChangeWorkitemStateRequest(requestBody, requestContentType, workitemUid),
-            cancellationToken);
+            new ChangeWorkitemStateRequest(dicomDataSet, requestContentType, workitemUid), cancellationToken);
     }
 
     public static Task<RetrieveWorkitemResponse> RetrieveWorkitemAsync(
@@ -281,13 +282,17 @@ public static class DicomMediatorExtensions
     }
 
     public static Task<UpdateWorkitemResponse> UpdateWorkitemAsync(
-        this IMediator mediator, Stream requestBody, string requestContentType, string workitemInstanceUid, string transactionUid = default, CancellationToken cancellationToken = default)
+        this IMediator mediator,
+        DicomDataset dicomDataset,
+        string requestContentType,
+        string workitemInstanceUid,
+        string transactionUid = default,
+        CancellationToken cancellationToken = default)
     {
         EnsureArg.IsNotNull(mediator, nameof(mediator));
-        EnsureArg.IsNotNull(requestBody, nameof(requestBody));
         EnsureArg.IsNotEmptyOrWhiteSpace(workitemInstanceUid, nameof(workitemInstanceUid));
 
         // Not validating transaction Uid as it can be null if the procedure step state is in SCHEDULED state.
-        return mediator.Send(new UpdateWorkitemRequest(requestBody, requestContentType, workitemInstanceUid, transactionUid), cancellationToken);
+        return mediator.Send(new UpdateWorkitemRequest(dicomDataset, requestContentType, workitemInstanceUid, transactionUid), cancellationToken);
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Workitem/AddWorkitemRequestHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Workitem/AddWorkitemRequestHandler.cs
@@ -1,14 +1,11 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
-using FellowOakDicom;
 using MediatR;
 using Microsoft.Health.Core.Features.Security.Authorization;
 using Microsoft.Health.Dicom.Core.Exceptions;
@@ -47,12 +44,8 @@ public class AddWorkitemRequestHandler : BaseHandler, IRequestHandler<AddWorkite
 
         request.Validate();
 
-        var workitems = await _workitemSerializer
-            .DeserializeAsync<IEnumerable<DicomDataset>>(request.RequestBody, request.RequestContentType)
-            .ConfigureAwait(false);
-
         return await _workItemService
-            .ProcessAddAsync(workitems.FirstOrDefault(), request.WorkitemInstanceUid, cancellationToken)
+            .ProcessAddAsync(request.DicomDataset, request.WorkitemInstanceUid, cancellationToken)
             .ConfigureAwait(false);
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Workitem/CancelWorkitemRequestHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Workitem/CancelWorkitemRequestHandler.cs
@@ -1,14 +1,11 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
-using FellowOakDicom;
 using MediatR;
 using Microsoft.Health.Core.Features.Security.Authorization;
 using Microsoft.Health.Dicom.Core.Exceptions;
@@ -45,12 +42,8 @@ public class CancelWorkitemRequestHandler : BaseHandler, IRequestHandler<CancelW
 
         request.Validate();
 
-        var workitems = await _workitemSerializer
-            .DeserializeAsync<IEnumerable<DicomDataset>>(request.RequestBody, request.RequestContentType)
-            .ConfigureAwait(false);
-
         return await _workItemService
-            .ProcessCancelAsync(workitems.FirstOrDefault(), request.WorkitemInstanceUid, cancellationToken)
+            .ProcessCancelAsync(request.DicomDataset, request.WorkitemInstanceUid, cancellationToken)
             .ConfigureAwait(false);
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Workitem/ChangeWorkitemStateRequestHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Workitem/ChangeWorkitemStateRequestHandler.cs
@@ -1,14 +1,11 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
-using FellowOakDicom;
 using MediatR;
 using Microsoft.Health.Core.Features.Security.Authorization;
 using Microsoft.Health.Dicom.Core.Exceptions;
@@ -45,12 +42,8 @@ public class ChangeWorkitemStateRequestHandler : BaseHandler, IRequestHandler<Ch
 
         request.Validate();
 
-        var changeStateDataset = await _workitemSerializer
-            .DeserializeAsync<IEnumerable<DicomDataset>>(request.RequestBody, request.RequestContentType)
-            .ConfigureAwait(false);
-
         return await _workItemService
-            .ProcessChangeStateAsync(changeStateDataset.FirstOrDefault(), request.WorkitemInstanceUid, cancellationToken)
+            .ProcessChangeStateAsync(request.DicomDataset, request.WorkitemInstanceUid, cancellationToken)
             .ConfigureAwait(false);
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Workitem/UpdateWorkitemRequestHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Workitem/UpdateWorkitemRequestHandler.cs
@@ -1,14 +1,11 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
-using FellowOakDicom;
 using MediatR;
 using Microsoft.Health.Core.Features.Security.Authorization;
 using Microsoft.Health.Dicom.Core.Exceptions;
@@ -51,12 +48,8 @@ public class UpdateWorkitemRequestHandler : BaseHandler, IRequestHandler<UpdateW
         // If transaction UID is passed, make sure it is also valid.
         request.Validate();
 
-        var workitem = await _workitemSerializer
-            .DeserializeAsync<IEnumerable<DicomDataset>>(request.RequestBody, request.RequestContentType)
-            .ConfigureAwait(false);
-
         return await _workItemService
-            .ProcessUpdateAsync(workitem.FirstOrDefault(), request.WorkitemInstanceUid, request.TransactionUid, cancellationToken)
+            .ProcessUpdateAsync(request.DicomDataset, request.WorkitemInstanceUid, request.TransactionUid, cancellationToken)
             .ConfigureAwait(false);
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Workitem/WorkitemRequestValidatorExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Workitem/WorkitemRequestValidatorExtensions.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -21,7 +21,7 @@ internal static class WorkitemRequestValidatorExtensions
     internal static void Validate(this AddWorkitemRequest request)
     {
         EnsureArg.IsNotNull(request, nameof(request));
-        if (request.RequestBody == null)
+        if (request.DicomDataset == null)
         {
             throw new BadRequestException(DicomCoreResource.MissingRequestBody);
         }
@@ -38,7 +38,7 @@ internal static class WorkitemRequestValidatorExtensions
     internal static void Validate(this UpdateWorkitemRequest request)
     {
         EnsureArg.IsNotNull(request, nameof(request));
-        if (request.RequestBody == null)
+        if (request.DicomDataset == null)
         {
             throw new BadRequestException(DicomCoreResource.MissingRequestBody);
         }
@@ -53,7 +53,7 @@ internal static class WorkitemRequestValidatorExtensions
     {
         EnsureArg.IsNotNull(request, nameof(request));
 
-        if (request.RequestBody == null)
+        if (request.DicomDataset == null)
         {
             throw new BadRequestException(DicomCoreResource.MissingRequestBody);
         }
@@ -65,7 +65,7 @@ internal static class WorkitemRequestValidatorExtensions
     {
         EnsureArg.IsNotNull(request, nameof(request));
 
-        if (request.RequestBody == null)
+        if (request.DicomDataset == null)
         {
             throw new BadRequestException(DicomCoreResource.MissingRequestBody);
         }

--- a/src/Microsoft.Health.Dicom.Core/Messages/WorkItem/AddWorkitemRequest.cs
+++ b/src/Microsoft.Health.Dicom.Core/Messages/WorkItem/AddWorkitemRequest.cs
@@ -1,9 +1,9 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.IO;
+using FellowOakDicom;
 using MediatR;
 
 namespace Microsoft.Health.Dicom.Core.Messages.Workitem;
@@ -11,18 +11,18 @@ namespace Microsoft.Health.Dicom.Core.Messages.Workitem;
 public class AddWorkitemRequest : IRequest<AddWorkitemResponse>
 {
     public AddWorkitemRequest(
-        Stream requestBody,
+        DicomDataset dicomDataset,
         string requestContentType,
         string workItemInstanceUid)
     {
         WorkitemInstanceUid = workItemInstanceUid;
-        RequestBody = requestBody;
+        DicomDataset = dicomDataset;
         RequestContentType = requestContentType;
     }
 
     public string WorkitemInstanceUid { get; }
 
-    public Stream RequestBody { get; }
+    public DicomDataset DicomDataset { get; }
 
     public string RequestContentType { get; }
 }

--- a/src/Microsoft.Health.Dicom.Core/Messages/WorkItem/CancelWorkitemRequest.cs
+++ b/src/Microsoft.Health.Dicom.Core/Messages/WorkItem/CancelWorkitemRequest.cs
@@ -1,9 +1,9 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.IO;
+using FellowOakDicom;
 using MediatR;
 
 namespace Microsoft.Health.Dicom.Core.Messages.Workitem;
@@ -11,18 +11,18 @@ namespace Microsoft.Health.Dicom.Core.Messages.Workitem;
 public class CancelWorkitemRequest : IRequest<CancelWorkitemResponse>
 {
     public CancelWorkitemRequest(
-        Stream requestBody,
+        DicomDataset dicomDataset,
         string requestContentType,
         string workItemInstanceUid)
     {
         WorkitemInstanceUid = workItemInstanceUid;
-        RequestBody = requestBody;
+        DicomDataset = dicomDataset;
         RequestContentType = requestContentType;
     }
 
     public string WorkitemInstanceUid { get; }
 
-    public Stream RequestBody { get; }
+    public DicomDataset DicomDataset { get; }
 
     public string RequestContentType { get; }
 }

--- a/src/Microsoft.Health.Dicom.Core/Messages/WorkItem/ChangeWorkitemStateRequest.cs
+++ b/src/Microsoft.Health.Dicom.Core/Messages/WorkItem/ChangeWorkitemStateRequest.cs
@@ -1,23 +1,23 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.IO;
+using FellowOakDicom;
 using MediatR;
 
 namespace Microsoft.Health.Dicom.Core.Messages.Workitem;
 
 public sealed class ChangeWorkitemStateRequest : IRequest<ChangeWorkitemStateResponse>
 {
-    public ChangeWorkitemStateRequest(Stream requestBody, string requestContentType, string workitemInstanceUid)
+    public ChangeWorkitemStateRequest(DicomDataset dicomDataset, string requestContentType, string workitemInstanceUid)
     {
-        RequestBody = requestBody;
+        DicomDataset = dicomDataset;
         RequestContentType = requestContentType;
         WorkitemInstanceUid = workitemInstanceUid;
     }
 
-    public Stream RequestBody { get; }
+    public DicomDataset DicomDataset { get; }
     public string RequestContentType { get; }
     public string WorkitemInstanceUid { get; }
 }

--- a/src/Microsoft.Health.Dicom.Core/Messages/WorkItem/UpdateWorkitemRequest.cs
+++ b/src/Microsoft.Health.Dicom.Core/Messages/WorkItem/UpdateWorkitemRequest.cs
@@ -1,18 +1,18 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.IO;
+using FellowOakDicom;
 using MediatR;
 
 namespace Microsoft.Health.Dicom.Core.Messages.Workitem;
 
 public sealed class UpdateWorkitemRequest : IRequest<UpdateWorkitemResponse>
 {
-    public UpdateWorkitemRequest(Stream requestBody, string requestContentType, string workitemInstanceUid, string transactionUid)
+    public UpdateWorkitemRequest(DicomDataset dicomDataset, string requestContentType, string workitemInstanceUid, string transactionUid)
     {
-        RequestBody = requestBody;
+        DicomDataset = dicomDataset;
         RequestContentType = requestContentType;
         WorkitemInstanceUid = workitemInstanceUid;
         TransactionUid = transactionUid;
@@ -22,7 +22,7 @@ public sealed class UpdateWorkitemRequest : IRequest<UpdateWorkitemResponse>
 
     public string TransactionUid { get; }
 
-    public Stream RequestBody { get; }
+    public DicomDataset DicomDataset { get; }
 
     public string RequestContentType { get; }
 }


### PR DESCRIPTION
## Description
Removed passing request.body to handlers. And let the workitem datasets be deserialized as part of the request pipeline, and as a [FromBody] parameter in the controller/action-method.

## Related issues
Addresses [AB#93067].

## Testing
Updated Unit and Integration tests.
