### PR TITLE
Fix - Impacting SLA: System.ArgumentNullException

### DIFF
--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/Entries/DicomInstanceEntryReaderManagerTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/Entries/DicomInstanceEntryReaderManagerTests.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -32,9 +32,12 @@ public class DicomInstanceEntryReaderManagerTests
             _dicomInstanceEntryReaderManager.FindReader(DefaultContentType));
     }
 
-    [Fact]
-    public void GivenANotSupportedContentType_WhenFindReaderIsCalled_ThenNullShouldBeReturned()
+    [Theory]
+    [InlineData("invalid")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void GivenANotSupportedContentType_WhenFindReaderIsCalled_ThenNullShouldBeReturned(string contentType)
     {
-        Assert.Null(_dicomInstanceEntryReaderManager.FindReader("unsupported"));
+        Assert.Null(_dicomInstanceEntryReaderManager.FindReader(contentType));
     }
 }

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/StoreHandlerTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/StoreHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -49,12 +49,15 @@ public class StoreHandlerTests
         await Assert.ThrowsAsync<InvalidIdentifierException>(() => _storeHandler.Handle(storeRequest, CancellationToken.None));
     }
 
-    [Fact]
-    public async Task GivenUnsupportedContentType_WhenHandled_ThenUnsupportedMediaTypeExceptionShouldBeThrown()
+    [Theory]
+    [InlineData("invalid")]
+    [InlineData("")]
+    [InlineData(null)]
+    public async Task GivenUnsupportedContentType_WhenHandled_ThenUnsupportedMediaTypeExceptionShouldBeThrown(string requestContentType)
     {
         _dicomInstanceEntryReaderManager.FindReader(default).ReturnsForAnyArgs((IDicomInstanceEntryReader)null);
 
-        var storeRequest = new StoreRequest(Stream.Null, "invalid");
+        var storeRequest = new StoreRequest(Stream.Null, requestContentType);
 
         await Assert.ThrowsAsync<UnsupportedMediaTypeException>(() => _storeHandler.Handle(storeRequest, CancellationToken.None));
     }

--- a/src/Microsoft.Health.Dicom.Core/Features/Store/Entries/DicomInstanceEntryReaderManager.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Store/Entries/DicomInstanceEntryReaderManager.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -26,8 +26,6 @@ public class DicomInstanceEntryReaderManager : IDicomInstanceEntryReaderManager
     /// <inheritdoc />
     public IDicomInstanceEntryReader FindReader(string contentType)
     {
-        EnsureArg.IsNotNull(contentType, nameof(contentType));
-
         return _dicomInstanceEntryReaders.FirstOrDefault(reader => reader.CanRead(contentType));
     }
 }


### PR DESCRIPTION
## Description
Fixed SLA impacting issue where customer's request without content-type header somehow made it to the service. This was resulting in a 5xx error because of the EnsureArg check in place.

I have removed this check and also updated the Handler and Reader tests such that we validate the possible input values for content-type header.

After this change, instead of 5xx status code, user should receive a 415 result code indicating that the media type is unsupported.

## Related issues
AB#94228.

## Testing
- Updated handler and receiver tests.
- All existing tests are passing.
