### PR TITLE
Flush metrics

### DIFF
--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/DicomCastWorker.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Features/Worker/DicomCastWorker.cs
@@ -132,5 +132,9 @@ public class DicomCastWorker : IDicomCastWorker
             // Please refer to .net core issue on github for more details: "Exceptions in BackgroundService ExecuteAsync are (sometimes) hidden" https://github.com/dotnet/extensions/issues/2363
             _hostApplicationLifetime.StopApplication();
         }
+        finally
+        {
+            _telemetryClient.Flush();
+        }
     }
 }


### PR DESCRIPTION
## Description
Flush the metrics when appliation crashes

## Related issues
Addresses [issue #93947](https://microsofthealth.visualstudio.com/Health/_backlogs/backlog/Medical%20Imaging/Epics/?workitem=93947)

## Testing
Tested in test environment.
