### PR TITLE
Adding a configuration setting to log usage of the old blob format.

### DIFF
--- a/src/Microsoft.Health.Dicom.Core/Configs/BlobMigrationConfiguration.cs
+++ b/src/Microsoft.Health.Dicom.Core/Configs/BlobMigrationConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -23,6 +23,11 @@ public class BlobMigrationConfiguration
     /// Gets or sets flag to start delete old format blobs
     /// </summary>
     public bool StartDelete { get; set; }
+
+    /// <summary>
+    /// Gets or sets a flag to log usage of the old blob format
+    /// </summary>
+    public bool LogOldFormatUsage { get; set; }
 
     /// <summary>
     /// Gets or sets the copy files operation id


### PR DESCRIPTION
## Description
When enabled, this setting will log usage of the old blob format to assist in understanding the extent and completion of a blob format migration. There is minor code duplication in the logging methods, but until / unless we refactor these clients, that seems like the most pragmatic approach.

## Related issues
Addresses [AB#93278](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/93278)

## Testing

#### New format with logging enabled
![image](https://user-images.githubusercontent.com/88204686/186509707-ebdebb33-2725-42a4-acea-99a389a61779.png)

#### Old format with logging disabled
![image](https://user-images.githubusercontent.com/88204686/186509971-8a07f09a-2e2e-4803-ac17-2be7cdf6d2c0.png)

#### Old format with logging enabled
![image](https://user-images.githubusercontent.com/88204686/186508857-048bd3d8-501a-40ca-9ff5-b29ca4726488.png)
 
