### PR TITLE
Fix CVE-2022-30187 for Uploader Function

### DIFF
--- a/tools/uploader-function/src/DicomUploaderFunction/DicomUploaderFunction.csproj
+++ b/tools/uploader-function/src/DicomUploaderFunction/DicomUploaderFunction.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" PrivateAssets="All" />
     <PackageReference Include="Ensure.That" />
     <PackageReference Include="fo-dicom" />
     <PackageReference Include="Microsoft.AspNetCore.Http" PrivateAssets="All" />


### PR DESCRIPTION
## Description
- Use latest blob storage SDK to resolve CVE-2022-30187 in uploader function

## Related issues
N/A

## Testing
Existing tests
