### PR TITLE
Add Durable Task Health Check

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,7 +13,6 @@ services:
       BlobStore__ConnectionString: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
       DicomFunctions__DurableTask__ConnectionName: "AzureWebJobsStorage"
       DicomFunctions__Indexing__Batching__MaxParallelCount: "1"
-      DicomServer__Features__EnableExport: "true"
       SqlServer__AllowDatabaseCreation: "true"
       SqlServer__ConnectionString: "Server=tcp:sql,1433;Initial Catalog=Dicom;Persist Security Info=False;User ID=sa;Password=${SAPASSWORD:-L0ca1P@ssw0rd};MultipleActiveResultSets=False;Connection Timeout=30;TrustServerCertificate=true"
       SqlServer__Initialize: "true"

--- a/docs/how-to-guides/export-data.md
+++ b/docs/how-to-guides/export-data.md
@@ -102,7 +102,16 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-    
+    "operationId": "df1ff476b83a4a3eaf11b1eac2e5ac56",
+    "type": "export",
+    "createdTime": "2022-09-08T16:40:36.2627618Z",
+    "lastUpdatedTime": "2022-09-08T16:41:01.2776644Z",
+    "status": "completed",
+    "results": {
+        "errorHref": "<blob uri>/export/4853cda8c05c44e497d2bc071f8e92c4/Errors.log",
+        "exported": 1000,
+        "skipped": 3
+    }
 }
 ```
 

--- a/docs/how-to-guides/export-data.md
+++ b/docs/how-to-guides/export-data.md
@@ -108,7 +108,7 @@ Content-Type: application/json
     "lastUpdatedTime": "2022-09-08T16:41:01.2776644Z",
     "status": "completed",
     "results": {
-        "errorHref": "<blob uri>/export/4853cda8c05c44e497d2bc071f8e92c4/Errors.log",
+        "errorHref": "<container uri>/4853cda8c05c44e497d2bc071f8e92c4/Errors.log",
         "exported": 1000,
         "skipped": 3
     }

--- a/docs/how-to-guides/export-data.md
+++ b/docs/how-to-guides/export-data.md
@@ -11,7 +11,11 @@ The below example requests the export of the following DICOM resources to the bl
 - All instances within the series whose Study Instance UID is `12.3` and Series Instance UID is `4.5.678`
 - The instance whose Study Instance UID is `123.456`, Series Instance UID is `7.8`, and SOP Instance UID is `9.1011.12`
 
-```json
+```http
+POST /export HTTP/1.1
+Accept: */*
+Content-Type: application/json
+
 {
     "sources": {
         "type": "identifiers",
@@ -80,10 +84,25 @@ If the storage account requires authentication, a [SAS token](https://docs.micro
 
 Upon successfully starting an export operation, the export API returns a `202` status code. The body of the response contains a reference to the operation, while the value of the `Location` header is the URL for the export operation's status (the same as `href` in the body).
 
-```json
+```http
+HTTP/1.1 202 Accepted
+Content-Type: application/json
+
 {
     "id": "df1ff476b83a4a3eaf11b1eac2e5ac56",
     "href": "<base url>/<version>/operations/df1ff476b83a4a3eaf11b1eac2e5ac56"
+}
+```
+
+### Operation Status
+The above `href` URL can be polled for the current status of the export operation until completion. A terminal state is signified by a `200` status instead of `202`.
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    
 }
 ```
 

--- a/samples/templates/default-azuredeploy.json
+++ b/samples/templates/default-azuredeploy.json
@@ -201,7 +201,6 @@
             "SqlServer__Initialize": "true",
             "DicomFunctions__DurableTask__ConnectionName": "AzureWebJobsStorage",
             "DicomServer__Features__EnableOhifViewer": "[parameters('deployOhifViewer')]",
-            "DicomServer__Features__EnableExport": "true",
             "DicomServer__Security__Enabled": "[variables('securityAuthenticationEnabled')]",
             "DicomServer__Security__Authentication__Authority": "[parameters('securityAuthenticationAuthority')]",
             "DicomServer__Security__Authentication__Audience": "[parameters('securityAuthenticationAudience')]",

--- a/src/Microsoft.Health.Dicom.Functions.Client.UnitTests/HealthChecks/DurableTaskHealthCheckTests.cs
+++ b/src/Microsoft.Health.Dicom.Functions.Client.UnitTests/HealthChecks/DurableTaskHealthCheckTests.cs
@@ -1,0 +1,80 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Health.Core.Internal;
+using Microsoft.Health.Dicom.Functions.Client.HealthChecks;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Microsoft.Health.Dicom.Functions.Client.UnitTests.HealthChecks;
+
+public class DurableTaskHealthCheckTests
+{
+    private readonly IDurableClient _durableClient;
+    private readonly DurableTaskHealthCheck _healthCheck;
+
+    public DurableTaskHealthCheckTests()
+    {
+        IDurableClientFactory durableClientFactory = Substitute.For<IDurableClientFactory>();
+        _durableClient = Substitute.For<IDurableClient>();
+        durableClientFactory.CreateClient().Returns(_durableClient);
+        _healthCheck = new DurableTaskHealthCheck(durableClientFactory, NullLogger<DurableTaskHealthCheck>.Instance);
+    }
+
+    [Fact]
+    public async Task GivenHealthCheck_WhenStorageIsUnavailable_ThenThrowException()
+    {
+        DateTime now = DateTime.UtcNow;
+        ClockResolver.UtcNowFunc = () => now;
+        using var tokenSource = new CancellationTokenSource();
+
+        _durableClient
+            .ListInstancesAsync(
+                Arg.Is<OrchestrationStatusQueryCondition>(x => x.CreatedTimeFrom == now && x.CreatedTimeTo == now.AddMinutes(1) && x.PageSize == 1),
+                tokenSource.Token)
+            .Throws<IOException>();
+
+        await Assert.ThrowsAsync<IOException>(() => _healthCheck.CheckHealthAsync(new HealthCheckContext(), tokenSource.Token));
+
+        await _durableClient
+            .Received(1)
+            .ListInstancesAsync(
+                Arg.Is<OrchestrationStatusQueryCondition>(x => x.CreatedTimeFrom == now && x.CreatedTimeTo == now.AddMinutes(1) && x.PageSize == 1),
+                tokenSource.Token);
+    }
+
+    [Fact]
+    public async Task GivenHealthCheck_WhenStorageIsAvailable_ThenReturnHealthy()
+    {
+        DateTime now = DateTime.UtcNow;
+        ClockResolver.UtcNowFunc = () => now;
+        using var tokenSource = new CancellationTokenSource();
+
+        _durableClient
+            .ListInstancesAsync(
+                Arg.Is<OrchestrationStatusQueryCondition>(x => x.CreatedTimeFrom == now && x.CreatedTimeTo == now.AddMinutes(1) && x.PageSize == 1),
+                tokenSource.Token)
+            .Returns(new OrchestrationStatusQueryResult { DurableOrchestrationState = new DurableOrchestrationStatus[] { new DurableOrchestrationStatus() } });
+
+        HealthCheckResult actual = await _healthCheck.CheckHealthAsync(new HealthCheckContext(), tokenSource.Token);
+
+        await _durableClient
+            .Received(1)
+            .ListInstancesAsync(
+                Arg.Is<OrchestrationStatusQueryCondition>(x => x.CreatedTimeFrom == now && x.CreatedTimeTo == now.AddMinutes(1) && x.PageSize == 1),
+                tokenSource.Token);
+
+        Assert.Equal(HealthStatus.Healthy, actual.Status);
+    }
+}

--- a/src/Microsoft.Health.Dicom.Functions.Client.UnitTests/Microsoft.Health.Dicom.Functions.Client.UnitTests.csproj
+++ b/src/Microsoft.Health.Dicom.Functions.Client.UnitTests/Microsoft.Health.Dicom.Functions.Client.UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -6,9 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Microsoft.Health.Core" />
     <PackageReference Include="Microsoft.Health.Operations" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />

--- a/src/Microsoft.Health.Dicom.Functions.Client/HealthChecks/DurableTaskHealthCheck.cs
+++ b/src/Microsoft.Health.Dicom.Functions.Client/HealthChecks/DurableTaskHealthCheck.cs
@@ -40,10 +40,10 @@ internal sealed class DurableTaskHealthCheck : IHealthCheck
 
     private Task AssertTaskHubConnectionAsync(CancellationToken cancellationToken)
     {
-        // Attempt to query the state the orchestrations. The results of the query do not matter.
-        // We simply want to run a relatively "cheap" query against the table storage to ensure we can connect successfully.
         cancellationToken.ThrowIfCancellationRequested();
 
+        // It does not matter whether GetStatusAsync finds an orchestration. We simply want to run
+        // a relatively "cheap" query against the table storage to ensure that we can connect successfully.
         return _client.GetStatusAsync(
             _guidFactory.Create().ToString(OperationId.FormatSpecifier),
             showHistory: false,

--- a/src/Microsoft.Health.Dicom.Functions.Client/HealthChecks/DurableTaskHealthCheck.cs
+++ b/src/Microsoft.Health.Dicom.Functions.Client/HealthChecks/DurableTaskHealthCheck.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -11,18 +10,21 @@ using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
-using Microsoft.Health.Core;
+using Microsoft.Health.Dicom.Core.Features.Common;
+using Microsoft.Health.Operations;
 
 namespace Microsoft.Health.Dicom.Functions.Client.HealthChecks;
 
 internal sealed class DurableTaskHealthCheck : IHealthCheck
 {
     private readonly IDurableClient _client;
+    private readonly IGuidFactory _guidFactory;
     private readonly ILogger _logger;
 
-    public DurableTaskHealthCheck(IDurableClientFactory factory, ILogger<DurableTaskHealthCheck> logger)
+    public DurableTaskHealthCheck(IDurableClientFactory factory, IGuidFactory guidFactory, ILogger<DurableTaskHealthCheck> logger)
     {
         _client = EnsureArg.IsNotNull(factory, nameof(factory)).CreateClient();
+        _guidFactory = EnsureArg.IsNotNull(guidFactory, nameof(guidFactory));
         _logger = EnsureArg.IsNotNull(logger, nameof(logger));
     }
 
@@ -30,17 +32,22 @@ internal sealed class DurableTaskHealthCheck : IHealthCheck
     {
         EnsureArg.IsNotNull(context, nameof(context));
 
-        DateTime start = Clock.UtcNow.DateTime;
-        await _client.ListInstancesAsync(
-            new OrchestrationStatusQueryCondition
-            {
-                CreatedTimeFrom = start,
-                CreatedTimeTo = start.AddMinutes(1),
-                PageSize = 1,
-            },
-            cancellationToken);
+        await AssertTaskHubConnectionAsync(cancellationToken);
 
         _logger.LogInformation("Successfully connected to the Durable TaskHub '{Name}.'", _client.TaskHubName);
         return HealthCheckResult.Healthy();
+    }
+
+    private Task AssertTaskHubConnectionAsync(CancellationToken cancellationToken)
+    {
+        // Attempt to query the state the orchestrations. The results of the query do not matter.
+        // We simply want to run a relatively "cheap" query against the table storage to ensure we can connect successfully.
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return _client.GetStatusAsync(
+            _guidFactory.Create().ToString(OperationId.FormatSpecifier),
+            showHistory: false,
+            showHistoryOutput: false,
+            showInput: false);
     }
 }

--- a/src/Microsoft.Health.Dicom.Functions.Client/HealthChecks/DurableTaskHealthCheck.cs
+++ b/src/Microsoft.Health.Dicom.Functions.Client/HealthChecks/DurableTaskHealthCheck.cs
@@ -1,0 +1,46 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Health.Core;
+
+namespace Microsoft.Health.Dicom.Functions.Client.HealthChecks;
+
+internal sealed class DurableTaskHealthCheck : IHealthCheck
+{
+    private readonly IDurableClient _client;
+    private readonly ILogger _logger;
+
+    public DurableTaskHealthCheck(IDurableClientFactory factory, ILogger<DurableTaskHealthCheck> logger)
+    {
+        _client = EnsureArg.IsNotNull(factory, nameof(factory)).CreateClient();
+        _logger = EnsureArg.IsNotNull(logger, nameof(logger));
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        EnsureArg.IsNotNull(context, nameof(context));
+
+        DateTime start = Clock.UtcNow.DateTime;
+        await _client.ListInstancesAsync(
+            new OrchestrationStatusQueryCondition
+            {
+                CreatedTimeFrom = start,
+                CreatedTimeTo = start.AddMinutes(1),
+                PageSize = 1,
+            },
+            cancellationToken);
+
+        _logger.LogInformation("Successfully connected to the Durable TaskHub '{Name}.'", _client.TaskHubName);
+        return HealthCheckResult.Healthy();
+    }
+}

--- a/src/Microsoft.Health.Dicom.Functions.Client/Microsoft.Health.Dicom.Functions.Client.csproj
+++ b/src/Microsoft.Health.Dicom.Functions.Client/Microsoft.Health.Dicom.Functions.Client.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Defines a client for interacting with the DICOM Azure Functions.</Description>
@@ -11,10 +11,13 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />
+    <PackageReference Include="Microsoft.Health.Core" />
     <PackageReference Include="Microsoft.Health.Operations" />
     <PackageReference Include="Microsoft.Health.Operations.Functions" />
     <PackageReference Include="Newtonsoft.Json" />

--- a/src/Microsoft.Health.Dicom.Functions.Client/Registration/DicomServerBuilderFunctionClientRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Functions.Client/Registration/DicomServerBuilderFunctionClientRegistrationExtensions.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -12,6 +12,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Core.Features.Operations;
 using Microsoft.Health.Dicom.Core.Registration;
+using Microsoft.Health.Dicom.Functions.Client.HealthChecks;
 using Microsoft.Health.Operations.Functions.DurableTask;
 using Newtonsoft.Json;
 
@@ -50,14 +51,17 @@ public static class DicomServerBuilderFunctionClientRegistrationExtensions
         services.AddOptions<DicomFunctionOptions>()
             .Bind(configuration.GetSection(DicomFunctionOptions.SectionName))
             .ValidateDataAnnotations();
-        services.AddDurableClientFactory(x => configuration
-            .GetSection(DicomFunctionOptions.SectionName)
-            .GetSection(nameof(DicomFunctionOptions.DurableTask))
-            .Bind(x));
+        services.AddDurableClientFactory(
+            x => configuration
+                .GetSection(DicomFunctionOptions.SectionName)
+                .GetSection(nameof(DicomFunctionOptions.DurableTask))
+                .Bind(x));
 
         services.Configure<JsonSerializerSettings>(o => o.ConfigureDefaultDicomSettings());
         services.Replace(ServiceDescriptor.Singleton<IMessageSerializerSettingsFactory, MessageSerializerSettingsFactory>());
         services.TryAddScoped<IDicomOperationsClient, DicomAzureFunctionsClient>();
+
+        services.AddHealthChecks().AddCheck<DurableTaskHealthCheck>("DurableTask");
 
         return dicomServerBuilder;
     }

--- a/src/Microsoft.Health.Dicom.Web/appsettings.Development.json
+++ b/src/Microsoft.Health.Dicom.Web/appsettings.Development.json
@@ -14,8 +14,6 @@
     }
   },
   "DicomServer": {
-    "Features": {
-    },
     "Services": {
       "FormatType": "Old",
       "StartCopy": false,

--- a/src/Microsoft.Health.Dicom.Web/appsettings.json
+++ b/src/Microsoft.Health.Dicom.Web/appsettings.json
@@ -70,6 +70,7 @@
       }
     },
     "Features": {
+      "EnableExport": true,
       "EnableDataPartitions": false,
       "EnableFullDicomItemValidation": false,
       "EnableOhifViewer": false


### PR DESCRIPTION
## Description
- Add new durable task health check to ensure calls aren't made to the service before the underlying task hub has been initialized
- Update export docs
- Enable export by default

## Related issues
[AB#94982](https://microsofthealth.visualstudio.com/Health/_workitems/edit/94982/)

## Testing
Added new tests
