### PR TITLE
Handle multipart requests that don't include a final boundary

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Web/AspNetCoreMultipartReader.cs
+++ b/src/Microsoft.Health.Dicom.Api/Web/AspNetCoreMultipartReader.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -106,13 +106,17 @@ internal class AspNetCoreMultipartReader : IMultipartReader
         {
             section = await _multipartReader.ReadNextSectionAsync(cancellationToken);
         }
+        catch (BadHttpRequestException ex) when (ex.Message.StartsWith(BodyTooLargeExceptionMessage, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new PayloadTooLargeException(_storeConfiguration.Value.MaxAllowedDicomFileSize);
+        }
         catch (InvalidDataException ex)
         {
             throw new InvalidMultipartRequestException(ex.Message);
         }
-        catch (BadHttpRequestException ex) when (ex.Message.StartsWith(BodyTooLargeExceptionMessage, StringComparison.OrdinalIgnoreCase))
+        catch (IOException ex)
         {
-            throw new PayloadTooLargeException(_storeConfiguration.Value.MaxAllowedDicomFileSize);
+            throw new InvalidMultipartRequestException(ex.Message);
         }
 
         if (section == null)


### PR DESCRIPTION
## Description
Previously, multipart requests that didn't include a final boundary would be an unhandled exception. The underlying reader [throws an exception](https://github.com/dotnet/aspnetcore/blob/6850cc8187751cdec3e4071e8786aeffe29d11ee/src/Http/WebUtilities/src/MultipartReaderStream.cs#L173) when this happens. 

## Related issues
Addresses AB#94227

## Testing
Added a unit test for this case.