### PR TITLE
Add .NET Standard 2.0 Target to Dicom Client

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,6 +37,11 @@
     <Platforms>x64</Platforms>
   </PropertyGroup>
 
+  <!-- Include the following source files for .NET Standard 2.0 projects -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)\lang\*" Visible="false" />
+  </ItemGroup>
+
   <Choose>
     <When Condition="$(MSBuildProjectName.Contains('Test'))">
       <PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,6 +28,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(SdkPackageVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageVersion Include="Microsoft.Azure.ServiceBus" Version="5.2.0" />
     <PackageVersion Include="Microsoft.Azure.WebJobs" Version="3.0.33" />
@@ -96,6 +97,7 @@
     <PackageVersion Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="$(IdentityModelTokenPackageVersion)" />
+    <PackageVersion Include="System.Text.Json" Version="6.0.6" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.assert" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/forks/Microsoft.Health.FellowOakDicom/Microsoft.Health.FellowOakDicom.csproj
+++ b/forks/Microsoft.Health.FellowOakDicom/Microsoft.Health.FellowOakDicom.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <Nullable>disable</Nullable>
     <AnalysisLevel></AnalysisLevel>
     <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>

--- a/lang/IsExternalInit.cs
+++ b/lang/IsExternalInit.cs
@@ -1,0 +1,23 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+// This file defines the IsExternalInit static class used to implement init-only properties.
+//
+// Documentation: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/init
+// Source: https://github.com/dotnet/runtime/blob/v6.0.0/src/libraries/Common/src/System/Runtime/CompilerServices/IsExternalInit.cs
+
+#if NETSTANDARD2_0
+
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Runtime.CompilerServices;
+
+[ExcludeFromCodeCoverage]
+[EditorBrowsable(EditorBrowsableState.Never)]
+internal static class IsExternalInit
+{ }
+
+#endif

--- a/src/Microsoft.Health.Dicom.Client/DicomWebClient.ExtendedQueryTag.cs
+++ b/src/Microsoft.Health.Dicom.Client/DicomWebClient.ExtendedQueryTag.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -101,7 +101,13 @@ public partial class DicomWebClient : IDicomWebClient
         string jsonString = JsonSerializer.Serialize(newValue, JsonSerializerOptions);
         var uri = new Uri($"/{_apiVersion}{DicomWebConstants.BaseExtendedQueryTagUri}/{tagPath}", UriKind.Relative);
 
-        using var request = new HttpRequestMessage(HttpMethod.Patch, uri);
+        using var request = new HttpRequestMessage(
+#if NETSTANDARD2_0
+            new HttpMethod("PATCH"),
+#else
+            HttpMethod.Patch,
+#endif
+            uri);
         {
             request.Content = new StringContent(jsonString);
             request.Content.Headers.ContentType = new MediaTypeHeaderValue(DicomWebConstants.ApplicationJsonMediaType) { CharSet = Encoding.UTF8.WebName };

--- a/src/Microsoft.Health.Dicom.Client/DicomWebClient.Store.cs
+++ b/src/Microsoft.Health.Dicom.Client/DicomWebClient.Store.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -48,7 +48,11 @@ public partial class DicomWebClient : IDicomWebClient
         {
             foreach (Stream stream in postContent)
             {
+#if NETSTANDARD2_0
+                stream.Dispose();
+#else
                 await stream.DisposeAsync().ConfigureAwait(false);
+#endif
             }
         }
     }
@@ -93,7 +97,11 @@ public partial class DicomWebClient : IDicomWebClient
     {
         EnsureArg.IsNotNull(dicomFile, nameof(dicomFile));
 
+#if NETSTANDARD2_0
+        using MemoryStream stream = GetMemoryStream();
+#else
         await using MemoryStream stream = GetMemoryStream();
+#endif
         await dicomFile.SaveAsync(stream).ConfigureAwait(false);
         stream.Seek(0, SeekOrigin.Begin);
 

--- a/src/Microsoft.Health.Dicom.Client/Microsoft.Health.Dicom.Client.csproj
+++ b/src/Microsoft.Health.Dicom.Client/Microsoft.Health.Dicom.Client.csproj
@@ -2,12 +2,22 @@
 
   <PropertyGroup>
     <Description>Defines a RESTful client for interacting with DICOMweb APIs.</Description>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
+  <Choose>
+    <When Condition="'$(TargetFramework)' == 'netstandard2.0'">
+      <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.WebUtilities" />
+        <PackageReference Include="System.Text.Json" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
 
   <ItemGroup>
     <PackageReference Include="Ensure.That" />


### PR DESCRIPTION
## Description
- Add .NET Standard 2.0 target to client
- Add build properties necessary to support future C# language feature "polyfills"

## Related issues
N/A

## Testing
N/A
