### PR TITLE
Handling DataStoreExceptions when caused by a TaskCanceledException

### DIFF
--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Exceptions/ExceptionHandlingMiddlewareTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Exceptions/ExceptionHandlingMiddlewareTests.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -41,6 +41,7 @@ public class ExceptionHandlingMiddlewareTests
         yield return new object[] { new AuditHeaderTooLargeException("TestHeader", AuditConstants.MaximumLengthOfCustomHeader + 1), HttpStatusCode.BadRequest };
         yield return new object[] { new ResourceNotFoundException("Resource not found."), HttpStatusCode.NotFound };
         yield return new object[] { new TranscodingException(), HttpStatusCode.NotAcceptable };
+        yield return new object[] { new DataStoreException(new TaskCanceledException()), HttpStatusCode.BadRequest };
         yield return new object[] { new DataStoreException("Something went wrong."), HttpStatusCode.ServiceUnavailable };
         yield return new object[] { new InstanceAlreadyExistsException(), HttpStatusCode.Conflict };
         yield return new object[] { new UnsupportedMediaTypeException("Media type is not supported."), HttpStatusCode.UnsupportedMediaType };

--- a/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -84,6 +84,7 @@ public class ExceptionHandlingMiddleware
             case AuditHeaderTooLargeException:
             case ConnectionResetException:
             case OperationCanceledException:
+            case DataStoreException e when e.InnerException is TaskCanceledException:
             case BadHttpRequestException:
             case IOException io when io.Message.Equals("The request stream was aborted.", StringComparison.OrdinalIgnoreCase):
                 statusCode = HttpStatusCode.BadRequest;


### PR DESCRIPTION
## Description
Currently, a request that is cancelled by the client will throw a `TaskCanceledException` in the blob libraries that is wrapped in a `DataStoreException`. This change will return 400 Bad Request in this case rather than a 500.

## Related issues
Addresses AB#95767

## Testing
Added a unit test.