### PR TITLE
[AB#95663] fix for Unhandled System.ArgumentException when creating workitem

### DIFF
--- a/forks/Microsoft.Health.FellowOakDicom/Serialization/JsonDicomConverter.cs
+++ b/forks/Microsoft.Health.FellowOakDicom/Serialization/JsonDicomConverter.cs
@@ -920,7 +920,7 @@ namespace Microsoft.Health.FellowOakDicom.Serialization
                 return ByteConverter.ToByteBuffer(string.Join("\\", valArray));
             }
 
-            return childValues.Select(x => x).Cast<T>().ToArray();
+            return childValues.Cast<T>().ToArray();
         }
 
         private object ReadJsonMultiNumber<T>(ref Utf8JsonReader reader, GetValue<T> getValue)

--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Exceptions/ExceptionHandlingMiddlewareTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Exceptions/ExceptionHandlingMiddlewareTests.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -35,6 +35,7 @@ public class ExceptionHandlingMiddlewareTests
     public static IEnumerable<object[]> GetExceptionToStatusCodeMapping()
     {
         yield return new object[] { new CustomValidationException(), HttpStatusCode.BadRequest };
+        yield return new object[] { new ArgumentException(), HttpStatusCode.BadRequest };
         yield return new object[] { new System.ComponentModel.DataAnnotations.ValidationException(), HttpStatusCode.BadRequest };
         yield return new object[] { new NotSupportedException("Not supported."), HttpStatusCode.BadRequest };
         yield return new object[] { new AuditHeaderCountExceededException(AuditConstants.MaximumNumberOfCustomHeaders + 1), HttpStatusCode.BadRequest };

--- a/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -75,6 +75,7 @@ public class ExceptionHandlingMiddleware
                 message = DicomApiResource.InvalidSyntax;
                 statusCode = HttpStatusCode.BadRequest;
                 break;
+            case ArgumentException:
             case FormatException:
             case InvalidOperationException:
             case ValidationException:


### PR DESCRIPTION
## Description
Handle ArgumentException in the Exception handler middleware and return BadRequest (400) error.

## Related issues
Addresses [[AB#95663](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/95663)].

## Testing
Added ArgumentException in the list of Exception data to be tried in the test coverage
