### PR TITLE
Asynchronously Amortize WADO Latency When Reading Many Instances

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -83,7 +83,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="$(IdentityModelTokenPackageVersion)" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.1" />
     <PackageVersion Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageVersion Include="Microsoft.OpenApi" Version="1.4.3" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Microsoft.SqlServer.DACFx" Version="160.6161.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.4.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.13.1" />
     <PackageVersion Include="Azure.Storage.Common" Version="12.12.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.2" />
     <PackageVersion Include="Ensure.That" Version="10.1.0" />
     <PackageVersion Include="fo-dicom" Version="5.0.3" />
     <PackageVersion Include="fo-dicom.Codecs" Version="5.1.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -95,8 +95,9 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
-    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="$(IdentityModelTokenPackageVersion)" />
+    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
+    <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Text.Json" Version="6.0.6" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.assert" Version="2.4.2" />

--- a/Microsoft.Health.Dicom.sln
+++ b/Microsoft.Health.Dicom.sln
@@ -77,6 +77,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "forks", "forks", "{AEDC6C96
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.FellowOakDicom", "forks\Microsoft.Health.FellowOakDicom\Microsoft.Health.FellowOakDicom.csproj", "{ADD2B971-3C5C-429A-B954-A55FA0FA987D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Dicom.Benchmark", "src\Microsoft.Health.Dicom.Benchmark\Microsoft.Health.Dicom.Benchmark.csproj", "{756A3876-6DD1-49CF-A05D-F5C81218039A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -191,6 +193,10 @@ Global
 		{ADD2B971-3C5C-429A-B954-A55FA0FA987D}.Debug|x64.Build.0 = Debug|x64
 		{ADD2B971-3C5C-429A-B954-A55FA0FA987D}.Release|x64.ActiveCfg = Release|x64
 		{ADD2B971-3C5C-429A-B954-A55FA0FA987D}.Release|x64.Build.0 = Release|x64
+		{756A3876-6DD1-49CF-A05D-F5C81218039A}.Debug|x64.ActiveCfg = Debug|x64
+		{756A3876-6DD1-49CF-A05D-F5C81218039A}.Debug|x64.Build.0 = Debug|x64
+		{756A3876-6DD1-49CF-A05D-F5C81218039A}.Release|x64.ActiveCfg = Release|x64
+		{756A3876-6DD1-49CF-A05D-F5C81218039A}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -222,9 +228,10 @@ Global
 		{C8BB8AF3-DCD1-49A4-A082-9152686AD222} = {176641B3-297C-4E04-A83D-8F80F80485E8}
 		{7AE5FC7B-CE2D-4B5A-B8BB-9B673469EA88} = {176641B3-297C-4E04-A83D-8F80F80485E8}
 		{ADD2B971-3C5C-429A-B954-A55FA0FA987D} = {AEDC6C96-15FF-4AFB-BD49-3549211AACCF}
+		{756A3876-6DD1-49CF-A05D-F5C81218039A} = {176641B3-297C-4E04-A83D-8F80F80485E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		RESX_SortFileContentOnSave = True
 		SolutionGuid = {E370FB31-CF95-47D1-B1E1-863A77973FF8}
+		RESX_SortFileContentOnSave = True
 	EndGlobalSection
 EndGlobal

--- a/docker/benchmark/Dockerfile
+++ b/docker/benchmark/Dockerfile
@@ -1,0 +1,15 @@
+# Copy the DICOM Server project and build the benchmark
+FROM mcr.microsoft.com/dotnet/sdk:6.0.401-alpine3.16@sha256:ed94db9b569b9315978fd54a7cb5f95f23229746493d91dc5c5d122d0fcfe368 AS sdk
+RUN set -x && \
+    # See https://www.abhith.net/blog/docker-sql-error-on-aspnet-core-alpine/
+    apk add --no-cache icu-libs && \
+    addgroup nonroot && \
+    adduser -S -D -H -s /sbin/nologin -G nonroot -g nonroot nonroot
+ENV LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8
+WORKDIR /dicom-server
+COPY . .
+WORKDIR /dicom-server/src/Microsoft.Health.Dicom.Benchmark
+RUN dotnet publish "Microsoft.Health.Dicom.Benchmark.csproj" -c Release -p:ContinuousIntegrationBuild=false -warnaserror -o /dicom-server/src/Microsoft.Health.Dicom.Benchmark/publish
+WORKDIR /dicom-server/src/Microsoft.Health.Dicom.Benchmark/publish
+ENTRYPOINT ["dotnet", "Microsoft.Health.Dicom.Benchmark.dll"]

--- a/docs/development/benchmarking.md
+++ b/docs/development/benchmarking.md
@@ -1,0 +1,20 @@
+# Benchmarking
+
+Our benchmarks are written using [BenchmarkDotNet](https://benchmarkdotnet.org/articles/overview.html) and can be run via [Docker](https://www.docker.com/) or directly from the EXE. Remember that benchmarks must be run with the Release configurtion. All benchmarks are included in the project [`Microsoft.Health.Dicom.Benchmark`](../../src/Microsoft.Health.Dicom.Benchmark/).
+
+## Running Benchmarks
+
+The easiest way to run the benchmarks is to run them via docker, as you'll likely need to pass in connection information benchmarks via environment variables.
+
+### Docker
+First build the image:
+```bash
+docker build -f ./docker/benchmark/Dockerfile -t dicom-benchmark .
+```
+
+The run the image (in the below example, the container has access to 1 core):
+```bash
+docker run -e BlobStore__ConnectionString='<connection-string>' -e SqlServer__ConnectionString='<connection-string>' -e DicomClient__BaseAddress='<dicom base address>' -a stdin -a stdout -a stderr --rm --privileged --cpus=1 --cpuset-cpus='0' --name benchmark dicom-benchmark
+```
+
+Feel free to customize the resources used by docker based on your scenario.

--- a/forks/.globalconfig
+++ b/forks/.globalconfig
@@ -2,26 +2,17 @@
 # For details: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files
 # For rules: https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
 is_global = true
-global_level = 101
-
-# Language code styles
-# Most use "options_name = false|true : none|silent|suggestion|warning|error"
-
-# Analyzers
-
-# See https://github.com/dotnet/roslyn-analyzers/blob/master/docs/Analyzer%20Configuration.md
-
-# Note that the above severities do not affect builds by design. These values are only used
-# to configure the entries in Visual Studio's "Error List" and power its Intellisense.
-# Instead, the rules below are used to configure build-time analyzer behavior.
-# Unfortunately, some rules have been disabled due to performance reasons outside of
-# Visual Studio and can be found here:
-# https://github.com/dotnet/roslyn/blob/0a73f08951f408624639e1601bb828b396f154c8/src/Analyzers/Core/Analyzers/EnforceOnBuildValues.cs#L99
+global_level = 2
 
 # Code Quality Rules
+dotnet_diagnostic.CA1012.severity = none # Abstract types should not have public constructors
 dotnet_diagnostic.CA1054.severity = none # URI parameters should not be strings
-dotnet_diagnostic.CA1305.severity = none
-dotnet_diagnostic.CA1822.severity = none
+dotnet_diagnostic.CA1062.severity = none # Validate arguments of public methods
+dotnet_diagnostic.CA1200.severity = none # Avoid using cref tags with a prefix
+dotnet_diagnostic.CA1305.severity = none # Specify IFormatProvider
+dotnet_diagnostic.CA1707.severity = none # Identifiers should not contain underscores
+dotnet_diagnostic.CA1802.severity = none # Use Literals Where Appropriate
+dotnet_diagnostic.CA1822.severity = none # Mark members as static
 
 # C# Compiler Rules
 dotnet_diagnostic.CS1572.severity = none # XML comment on 'construct' has a param tag for 'parameter', but there is no parameter by that name
@@ -29,7 +20,7 @@ dotnet_diagnostic.CS1573.severity = none # Parameter 'parameter' has no matching
 
 # Code Style Rules
 dotnet_diagnostic.IDE0006.severity = none # Copyright File Header
-dotnet_diagnostic.IDE0055.severity = none
+dotnet_diagnostic.IDE0055.severity = none # Fix formatting
 dotnet_diagnostic.IDE1006.severity = none # Naming rule violation: Prefix '_' is not expected
 dotnet_diagnostic.IDE0161.severity = none # Convert to file-scoped namespace
 dotnet_diagnostic.IDE0073.severity = none # Copyright File Header

--- a/forks/Microsoft.Health.FellowOakDicom/Microsoft.Health.FellowOakDicom.csproj
+++ b/forks/Microsoft.Health.FellowOakDicom/Microsoft.Health.FellowOakDicom.csproj
@@ -1,11 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>library</OutputType>
+    <Description>A fork of Fellow Oak's Dicom library with changes included in the next release.</Description>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
-    <Nullable>disable</Nullable>
-    <AnalysisLevel></AnalysisLevel>
-    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/forks/Microsoft.Health.FellowOakDicom/Microsoft.Health.FellowOakDicom.csproj
+++ b/forks/Microsoft.Health.FellowOakDicom/Microsoft.Health.FellowOakDicom.csproj
@@ -9,4 +9,9 @@
     <PackageReference Include="fo-dicom" Version="$(FoDicomVersion)" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Memory" />
+    <PackageReference Include="System.Text.Json" />
+  </ItemGroup>
+
 </Project>

--- a/forks/Microsoft.Health.FellowOakDicom/Properties/AssemblyInfo.cs
+++ b/forks/Microsoft.Health.FellowOakDicom/Properties/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Resources;
+
+[assembly: NeutralResourcesLanguage("en-us")]
+[assembly: CLSCompliant(false)]

--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Exceptions/ExceptionHandlingMiddlewareTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Exceptions/ExceptionHandlingMiddlewareTests.cs
@@ -53,6 +53,7 @@ public class ExceptionHandlingMiddlewareTests
         yield return new object[] { new IOException("The request stream was aborted."), HttpStatusCode.BadRequest };
         yield return new object[] { new ConnectionResetException(string.Empty), HttpStatusCode.BadRequest };
         yield return new object[] { new OperationCanceledException(), HttpStatusCode.BadRequest };
+        yield return new object[] { new TaskCanceledException(), HttpStatusCode.BadRequest };
         yield return new object[] { new InvalidOperationException(), HttpStatusCode.BadRequest };
         yield return new object[] { new PayloadTooLargeException(1), HttpStatusCode.RequestEntityTooLarge };
     }

--- a/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
@@ -94,7 +94,7 @@ public static class DicomServerServiceCollectionExtensions
         services.AddSingleton(Options.Create(dicomServerConfiguration.Services.DataPartition));
         services.AddSingleton(Options.Create(dicomServerConfiguration.Audit));
         services.AddSingleton(Options.Create(dicomServerConfiguration.Swagger));
-        services.AddSingleton(Options.Create(dicomServerConfiguration.Services.RetrieveConfiguration));
+        services.AddSingleton(Options.Create(dicomServerConfiguration.Services.Retrieve));
         services.AddSingleton(Options.Create(dicomServerConfiguration.Services.BlobMigration));
         services.AddSingleton(Options.Create(dicomServerConfiguration.Services.InstanceMetadataCacheConfiguration));
         services.AddSingleton(Options.Create(dicomServerConfiguration.Services.FramesRangeCacheConfiguration));

--- a/src/Microsoft.Health.Dicom.Benchmark/DicomBenchmark.cs
+++ b/src/Microsoft.Health.Dicom.Benchmark/DicomBenchmark.cs
@@ -1,0 +1,44 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using FellowOakDicom.Imaging;
+using FellowOakDicom;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Health.Dicom.Benchmark;
+
+public class DicomBenchmark
+{
+    protected DicomBenchmark()
+    {
+        Configuration = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json")
+            .AddEnvironmentVariables()
+            .Build();
+    }
+
+    public IConfiguration Configuration { get; }
+
+    protected static DicomDataset CreateRandomInstanceDataset(
+        string studyInstanceUid = null,
+        string seriesInstanceUid = null,
+        string sopInstanceUid = null,
+        string sopClassUid = null,
+        DicomTransferSyntax dicomTransferSyntax = null)
+    {
+        var ds = new DicomDataset(dicomTransferSyntax ?? DicomTransferSyntax.ExplicitVRLittleEndian);
+        ds = ds.NotValidated();
+
+        ds.Add(DicomTag.StudyInstanceUID, studyInstanceUid ?? DicomUID.Generate().UID);
+        ds.Add(DicomTag.SeriesInstanceUID, seriesInstanceUid ?? DicomUID.Generate().UID);
+        ds.Add(DicomTag.SOPInstanceUID, sopInstanceUid ?? DicomUID.Generate().UID);
+        ds.Add(DicomTag.SOPClassUID, sopClassUid ?? DicomUID.Generate().UID);
+        ds.Add(DicomTag.BitsAllocated, (ushort)8);
+        ds.Add(DicomTag.PhotometricInterpretation, PhotometricInterpretation.Monochrome2.Value);
+        ds.Add(DicomTag.PatientID, DicomUID.Generate().UID);
+
+        return ds;
+    }
+}

--- a/src/Microsoft.Health.Dicom.Benchmark/DicomClientOptions.cs
+++ b/src/Microsoft.Health.Dicom.Benchmark/DicomClientOptions.cs
@@ -4,11 +4,12 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Resources;
-using System.Runtime.CompilerServices;
+using System.Diagnostics.CodeAnalysis;
 
-[assembly: InternalsVisibleTo("Microsoft.Health.Dicom.Benchmark")]
-[assembly: InternalsVisibleTo("Microsoft.Health.Dicom.Tests.Integration")]
-[assembly: InternalsVisibleTo("Microsoft.Health.Dicom.SqlServer.UnitTests")]
-[assembly: NeutralResourcesLanguage("en-us")]
-[assembly: CLSCompliant(false)]
+namespace Microsoft.Health.Dicom.Benchmark;
+
+[SuppressMessage("Microsoft.Performance", "CA1812:Avoid uninstantiated internal classes.", Justification = "This class is deserialized.")]
+internal class DicomClientOptions
+{
+    public Uri BaseAddress { get; set; }
+}

--- a/src/Microsoft.Health.Dicom.Benchmark/Microsoft.Health.Dicom.Benchmark.csproj
+++ b/src/Microsoft.Health.Dicom.Benchmark/Microsoft.Health.Dicom.Benchmark.csproj
@@ -1,0 +1,43 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Core" />
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Storage.Blobs" />
+    <PackageReference Include="Azure.Storage.Common" />
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="Ensure.That" />
+    <PackageReference Include="fo-dicom" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" />
+    <PackageReference Include="Microsoft.Health.Blob" />
+    <PackageReference Include="Microsoft.Health.SqlServer" />
+    <PackageReference Include="System.Linq.Async" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Health.Dicom.Blob\Microsoft.Health.Dicom.Blob.csproj" />
+    <ProjectReference Include="..\Microsoft.Health.Dicom.Client\Microsoft.Health.Dicom.Client.csproj" />
+    <ProjectReference Include="..\Microsoft.Health.Dicom.Core\Microsoft.Health.Dicom.Core.csproj" />
+    <ProjectReference Include="..\Microsoft.Health.Dicom.SqlServer\Microsoft.Health.Dicom.SqlServer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.Health.Dicom.Benchmark/Program.cs
+++ b/src/Microsoft.Health.Dicom.Benchmark/Program.cs
@@ -1,0 +1,17 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using BenchmarkDotNet.Running;
+using Microsoft.Health.Dicom.Benchmark.Retrieve;
+
+namespace Microsoft.Health.Dicom.Benchmark;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        var summary = BenchmarkRunner.Run<WadoBenchmark>();
+    }
+}

--- a/src/Microsoft.Health.Dicom.Benchmark/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Health.Dicom.Benchmark/Properties/AssemblyInfo.cs
@@ -5,10 +5,6 @@
 
 using System;
 using System.Resources;
-using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Microsoft.Health.Dicom.Benchmark")]
-[assembly: InternalsVisibleTo("Microsoft.Health.Dicom.Tests.Integration")]
-[assembly: InternalsVisibleTo("Microsoft.Health.Dicom.SqlServer.UnitTests")]
 [assembly: NeutralResourcesLanguage("en-us")]
 [assembly: CLSCompliant(false)]

--- a/src/Microsoft.Health.Dicom.Benchmark/Retrieve/LegacyRetrieveMetadataResponse.cs
+++ b/src/Microsoft.Health.Dicom.Benchmark/Retrieve/LegacyRetrieveMetadataResponse.cs
@@ -1,0 +1,27 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using EnsureThat;
+using FellowOakDicom;
+
+namespace Microsoft.Health.Dicom.Benchmark.Retrieve;
+
+public class LegacyRetrieveMetadataResponse
+{
+    public LegacyRetrieveMetadataResponse(IEnumerable<DicomDataset> responseMetadata, bool isCacheValid = false, string eTag = null)
+    {
+        EnsureArg.IsNotNull(responseMetadata, nameof(responseMetadata));
+        ResponseMetadata = responseMetadata;
+        IsCacheValid = isCacheValid;
+        ETag = eTag;
+    }
+
+    public IEnumerable<DicomDataset> ResponseMetadata { get; }
+
+    public bool IsCacheValid { get; }
+
+    public string ETag { get; }
+}

--- a/src/Microsoft.Health.Dicom.Benchmark/Retrieve/LegacyRetrieveMetadataService.cs
+++ b/src/Microsoft.Health.Dicom.Benchmark/Retrieve/LegacyRetrieveMetadataService.cs
@@ -1,0 +1,86 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using FellowOakDicom;
+using Microsoft.Health.Dicom.Core.Extensions;
+using Microsoft.Health.Dicom.Core.Features.Common;
+using Microsoft.Health.Dicom.Core.Features.Context;
+using Microsoft.Health.Dicom.Core.Features.Model;
+using Microsoft.Health.Dicom.Core.Features.Retrieve;
+using Microsoft.Health.Dicom.Core.Messages;
+
+namespace Microsoft.Health.Dicom.Benchmark.Retrieve;
+
+public class LegacyRetrieveMetadataService
+{
+    private readonly IInstanceStore _instanceStore;
+    private readonly IMetadataStore _metadataStore;
+    private readonly IETagGenerator _eTagGenerator;
+    private readonly IDicomRequestContextAccessor _contextAccessor;
+
+    public LegacyRetrieveMetadataService(
+        IInstanceStore instanceStore,
+        IMetadataStore metadataStore,
+        IETagGenerator eTagGenerator,
+        IDicomRequestContextAccessor contextAccessor)
+    {
+        _instanceStore = EnsureArg.IsNotNull(instanceStore, nameof(instanceStore));
+        _metadataStore = EnsureArg.IsNotNull(metadataStore, nameof(metadataStore));
+        _eTagGenerator = EnsureArg.IsNotNull(eTagGenerator, nameof(eTagGenerator));
+        _contextAccessor = EnsureArg.IsNotNull(contextAccessor, nameof(contextAccessor));
+    }
+
+    public async Task<LegacyRetrieveMetadataResponse> RetrieveStudyInstanceMetadataAsync(string studyInstanceUid, string ifNoneMatch = null, CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<VersionedInstanceIdentifier> retrieveInstances = await _instanceStore.GetInstancesToRetrieve(
+            ResourceType.Study,
+            GetPartitionKey(),
+            studyInstanceUid,
+            seriesInstanceUid: null,
+            sopInstanceUid: null,
+            cancellationToken);
+
+        string eTag = _eTagGenerator.GetETag(ResourceType.Study, retrieveInstances);
+        bool isCacheValid = IsCacheValid(eTag, ifNoneMatch);
+        return await RetrieveOldMetadata(retrieveInstances, isCacheValid, eTag, cancellationToken);
+    }
+
+    private async Task<LegacyRetrieveMetadataResponse> RetrieveOldMetadata(IEnumerable<VersionedInstanceIdentifier> instancesToRetrieve, bool isCacheValid, string eTag, CancellationToken cancellationToken)
+    {
+        IEnumerable<DicomDataset> instanceMetadata = Enumerable.Empty<DicomDataset>();
+        _contextAccessor.RequestContext.PartCount = instancesToRetrieve.Count();
+
+        // Retrieve metadata instances only if cache is not valid.
+        if (!isCacheValid)
+        {
+            instanceMetadata = await Task.WhenAll(
+                    instancesToRetrieve
+                    .Select(x => _metadataStore.GetInstanceMetadataAsync(x, cancellationToken)));
+        }
+
+        return new LegacyRetrieveMetadataResponse(instanceMetadata, isCacheValid, eTag);
+    }
+
+    /// <summary>
+    /// Check if cache is valid.
+    /// Cache is regarded as valid if the following criteria passes:
+    ///     1. User has passed If-None-Match in the header.
+    ///     2. Calculated ETag is equals to the If-None-Match header field.
+    /// </summary>
+    /// <param name="eTag">ETag.</param>
+    /// <param name="ifNoneMatch">If-None-Match</param>
+    /// <returns>True if cache is valid, i.e. content has not modified, else returns false.</returns>
+    private static bool IsCacheValid(string eTag, string ifNoneMatch)
+        => !string.IsNullOrEmpty(ifNoneMatch) && string.Equals(ifNoneMatch, eTag, StringComparison.OrdinalIgnoreCase);
+
+    private int GetPartitionKey()
+        => _contextAccessor.RequestContext.GetPartitionKey();
+}

--- a/src/Microsoft.Health.Dicom.Benchmark/Retrieve/WadoBenchmark.cs
+++ b/src/Microsoft.Health.Dicom.Benchmark/Retrieve/WadoBenchmark.cs
@@ -33,7 +33,7 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Health.Dicom.Benchmark.Retrieve;
 
-[SimpleJob(RunStrategy.Monitoring, targetCount: 10)]
+[SimpleJob(RunStrategy.Monitoring, targetCount: 25)]
 [MinColumn, Q1Column, Q3Column, MaxColumn]
 [MemoryDiagnoser]
 [ThreadingDiagnoser]
@@ -110,8 +110,16 @@ public class WadoBenchmark : DicomBenchmark
         => NewWado(100);
 
     [Benchmark]
-    public Task NewWado999()
-        => NewWado(999);
+    public Task NewWado200()
+        => NewWado(200);
+
+    [Benchmark]
+    public Task NewWado500()
+        => NewWado(500);
+
+    [Benchmark]
+    public Task NewWado1000()
+        => NewWado(1000);
 
     private async Task NewWado(int parallelism)
     {

--- a/src/Microsoft.Health.Dicom.Benchmark/Retrieve/WadoBenchmark.cs
+++ b/src/Microsoft.Health.Dicom.Benchmark/Retrieve/WadoBenchmark.cs
@@ -1,0 +1,133 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using FellowOakDicom;
+using Microsoft.Health.Dicom.Core.Features.Retrieve;
+using Microsoft.Health.Dicom.SqlServer.Features.Retrieve;
+using Microsoft.Health.SqlServer.Configs;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Health.Dicom.Core.Features.Common;
+using Microsoft.Health.Dicom.Blob.Features.Storage;
+using Microsoft.Health.SqlServer.Registration;
+using Microsoft.Health.Blob.Configs;
+using Microsoft.IO;
+using Microsoft.Health.Dicom.Core.Configs;
+using System.Text.Json;
+using Microsoft.Health.Dicom.Core.Extensions;
+using Microsoft.Health.Dicom.Blob;
+using Microsoft.Extensions.Logging;
+using Microsoft.Health.Dicom.Core.Features.Context;
+using Microsoft.Health.Dicom.Client;
+using System.Net.Http;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Dicom.Core.Messages.Retrieve;
+using BenchmarkDotNet.Engines;
+using System.Collections.Generic;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.Health.Dicom.Benchmark.Retrieve;
+
+[SimpleJob(RunStrategy.Monitoring, targetCount: 10)]
+[MinColumn, Q1Column, Q3Column, MaxColumn]
+[MemoryDiagnoser]
+[ThreadingDiagnoser]
+public class WadoBenchmark : DicomBenchmark
+{
+    private const int StudySize = 1000;
+    private const string StudyUid = "123456.789.10";
+
+    private readonly IServiceProvider _services;
+
+    public WadoBenchmark()
+    {
+        _services = new ServiceCollection()
+            .AddSingleton(Configuration)
+            .AddLogging(x => x.AddConsole())
+            .Configure<DicomClientOptions>(Configuration.GetSection("DicomClient"))
+            .Configure<SqlServerDataStoreConfiguration>(Configuration.GetSection(SqlServerDataStoreConfiguration.SectionName))
+            .Configure<BlobServiceClientOptions>(Configuration.GetSection(BlobServiceClientOptions.DefaultSectionName))
+            .Configure<BlobMigrationConfiguration>(Configuration.GetSection("DicomServer:Services:BlobMigration"))
+            .Configure<BlobContainerConfiguration>(Constants.MetadataContainerConfigurationName, Configuration.GetSection("DicomWeb:MetadataStore"))
+            .Configure<FeatureConfiguration>(Configuration.GetSection("DicomServer:Features"))
+            .Configure<JsonSerializerOptions>(o => o.ConfigureDefaultDicomSettings())
+            .Configure<RetrieveConfiguration>(Configuration.GetSection("DicomServer:Services:Retrieve"))
+            .Configure<LoggerFilterOptions>(Configuration.GetSection("Logging"))
+            .AddBlobServiceClient(Configuration.GetSection(BlobServiceClientOptions.DefaultSectionName))
+            .AddSqlServerConnection()
+            .AddScoped<IDicomRequestContext>(s => new DicomRequestContext(HttpMethod.Get.Method, new Uri("http://localhost/benchmark"), new Uri("http://localhost"), Guid.NewGuid().ToString(), new Dictionary<string, StringValues>(), new Dictionary<string, StringValues>()))
+            .AddScoped<IDicomRequestContextAccessor>(s => new DicomRequestContextAccessor { RequestContext = s.GetRequiredService<IDicomRequestContext>() })
+            .AddSingleton<RecyclableMemoryStreamManager>()
+            .AddSingleton<DicomFileNameWithUid>()
+            .AddSingleton<DicomFileNameWithPrefix>()
+            .AddScoped<IETagGenerator, ETagGenerator>()
+            .AddScoped<IInstanceStore, SqlInstanceStoreV23>()
+            .AddScoped<IMetadataStore, BlobMetadataStore>()
+            .AddScoped<LegacyRetrieveMetadataService>()
+            .BuildServiceProvider();
+    }
+
+    [GlobalSetup]
+    public async Task SetupAsync()
+    {
+        DicomClientOptions options = _services.GetRequiredService<IOptions<DicomClientOptions>>().Value;
+        using var httpClient = new HttpClient { BaseAddress = options.BaseAddress };
+        var client = new DicomWebClient(httpClient, "v1");
+
+        var result = await client.QueryStudyAsync($"StudyInstanceUID={StudyUid}");
+        if (await result.AnyAsync())
+            return; // Already uploaded
+
+        // Upload test data
+        await client.StoreAsync
+            (Enumerable.Range(1, StudySize).Select(x => new DicomFile(CreateRandomInstanceDataset(StudyUid))),
+            StudyUid);
+    }
+
+    [Benchmark(Baseline = true)]
+    public async Task OldWado()
+    {
+        using IServiceScope scope = _services.CreateScope();
+        LegacyRetrieveMetadataService service = scope.ServiceProvider.GetRequiredService<LegacyRetrieveMetadataService>();
+
+        LegacyRetrieveMetadataResponse response = await service.RetrieveStudyInstanceMetadataAsync(StudyUid);
+        int count = response.ResponseMetadata.Count();
+        if (count != StudySize)
+            throw new InvalidOperationException("Invalid study!");
+    }
+
+    [Benchmark]
+    public Task NewWado10()
+        => NewWado(10);
+
+    [Benchmark]
+    public Task NewWado100()
+        => NewWado(100);
+
+    [Benchmark]
+    public Task NewWado999()
+        => NewWado(999);
+
+    private async Task NewWado(int parallelism)
+    {
+        var options = new RetrieveConfiguration { MaxBufferedDataSets = StudySize, MaxDegreeOfParallelism = parallelism };
+
+        using IServiceScope scope = _services.CreateScope();
+        var service = new RetrieveMetadataService(
+            scope.ServiceProvider.GetRequiredService<IInstanceStore>(),
+            scope.ServiceProvider.GetRequiredService<IMetadataStore>(),
+            scope.ServiceProvider.GetRequiredService<IETagGenerator>(),
+            scope.ServiceProvider.GetRequiredService<IDicomRequestContextAccessor>(),
+            Options.Create(options));
+
+        RetrieveMetadataResponse response = await service.RetrieveStudyInstanceMetadataAsync(StudyUid);
+        int count = await response.ResponseMetadata.CountAsync();
+        if (count != StudySize)
+            throw new InvalidOperationException("Invalid study!");
+    }
+}

--- a/src/Microsoft.Health.Dicom.Benchmark/Retrieve/WadoBenchmark.cs
+++ b/src/Microsoft.Health.Dicom.Benchmark/Retrieve/WadoBenchmark.cs
@@ -123,7 +123,7 @@ public class WadoBenchmark : DicomBenchmark
 
     private async Task NewWado(int parallelism)
     {
-        var options = new RetrieveConfiguration { MaxBufferedDataSets = StudySize, MaxDegreeOfParallelism = parallelism };
+        var options = new RetrieveConfiguration { MaxDegreeOfParallelism = parallelism };
 
         using IServiceScope scope = _services.CreateScope();
         var service = new RetrieveMetadataService(

--- a/src/Microsoft.Health.Dicom.Benchmark/appsettings.json
+++ b/src/Microsoft.Health.Dicom.Benchmark/appsettings.json
@@ -34,8 +34,7 @@
         "FormatType": "New"
       },
       "Retrieve": {
-        "MaxDegreeOfParallelism": 10,
-        "MaxBufferedDataSets": 100
+        "MaxDegreeOfParallelism": 10
       }
     }
   },

--- a/src/Microsoft.Health.Dicom.Benchmark/appsettings.json
+++ b/src/Microsoft.Health.Dicom.Benchmark/appsettings.json
@@ -1,0 +1,66 @@
+{
+  "BlobStore": {
+    "Initialization": {
+      "RetryDelay": "00:00:15",
+      "Timeout": "00:06:00"
+    },
+    "Operations": {
+      "Download": {
+        "MaximumConcurrency": 5
+      },
+      "Upload": {
+        "MaximumConcurrency": 5
+      }
+    },
+    "Retry": {
+      "Delay": "00:00:04",
+      "MaxRetries": 6,
+      "Mode": "Exponential",
+      "NetworkTimeout": "00:02:00"
+    },
+    "TransportOverride": {
+      "ConnectTimeout": "00:00:02"
+    }
+  },
+  "DicomServer": {
+    "Features": {
+      "EnableExport": true,
+      "EnableDataPartitions": false,
+      "EnableFullDicomItemValidation": false,
+      "EnableOhifViewer": false
+    },
+    "Services": {
+      "BlobMigration": {
+        "FormatType": "New"
+      },
+      "Retrieve": {
+        "MaxDegreeOfParallelism": 10,
+        "MaxBufferedDataSets": 100
+      }
+    }
+  },
+  "DicomWeb": {
+    "MetadataStore": {
+      "ContainerName": "metadatacontainer"
+    }
+  },
+  "Logging": {
+    "CaptureScopes": false,
+    "MinLevel": "Error"
+  },
+  "SqlServer": {
+    "Initialize": "false",
+    "AllowDatabaseCreation": "false",
+    "Retry": {
+      "Mode": "Exponential",
+      "Settings ": {
+        "NumberOfTries": 5,
+        "DeltaTime": "00:00:01",
+        "MaxTimeInterval": "00:00:20"
+      }
+    },
+    "SchemaOptions": {
+      "AutomaticUpdatesEnabled": false
+    }
+  }
+}

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Common/ParallelEnumerableTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Common/ParallelEnumerableTests.cs
@@ -102,11 +102,8 @@ public class ParallelEnumerableTests
 
                         return ParseAsync(x, t);
                     },
-                    new ParallelEnumerationOptions
-                    {
-                        CancellationToken = tokenSource.Token,
-                        MaxDegreeOfParallelism = 2
-                    })
+                    new ParallelEnumerationOptions { MaxDegreeOfParallelism = 2 },
+                    tokenSource.Token)
                 .ToListAsync()
                 .AsTask());
     }
@@ -147,6 +144,7 @@ public class ParallelEnumerableTests
         // Beginning the enumerable should have triggered the producer, but only up to the buffered max of 3.
         // Therefore the values 2, 3, and 4 have been resolved, while 5 and 6 and still waiting.
         bufferFullEvent.Wait();
+        Assert.All(buffer.Keys, x => Assert.InRange(x, 1, 4));
 
         Assert.True(buffer.TryRemove(1, out _)); // We know 1 must have passed through the buffer
         Assert.Equal(MaxBuffered, buffer.Count);

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Common/ParallelEnumerableTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Common/ParallelEnumerableTests.cs
@@ -1,0 +1,188 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Health.Dicom.Core.Features.Common;
+using Xunit;
+
+namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Common;
+
+public class ParallelEnumerableTests
+{
+    [Fact]
+    public async Task GivenInvalidInput_WhenSelectingInParallel_ThenThrowArgumentException()
+    {
+        var input = new List<string> { "1", "2", "3" };
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => ((List<string>)null).SelectParallel(ParseAsync, new ParallelEnumerationOptions()).ToListAsync().AsTask());
+        await Assert.ThrowsAsync<ArgumentNullException>(() => input.SelectParallel((Func<string, CancellationToken, ValueTask<int>>)null, new ParallelEnumerationOptions()).ToListAsync().AsTask());
+        await Assert.ThrowsAsync<ArgumentNullException>(() => input.SelectParallel(ParseAsync, null).ToListAsync().AsTask());
+
+        var options = new ParallelEnumerationOptions { MaxBufferedItems = 1, MaxDegreeOfParallelism = -1 };
+        await Assert.ThrowsAsync<ArgumentException>(() => input.SelectParallel(ParseAsync, options).ToListAsync().AsTask());
+
+        options = new ParallelEnumerationOptions { MaxBufferedItems = 5, MaxDegreeOfParallelism = 6 };
+        await Assert.ThrowsAsync<ArgumentException>(() => input.SelectParallel(ParseAsync, options).ToListAsync().AsTask());
+    }
+
+    [Fact]
+    public async Task GivenNoElements_WhenSelectingInParallel_ThenReturnEmpty()
+    {
+        var input = Enumerable.Empty<string>();
+        Assert.Empty(await input.SelectParallel(ParseAsync, new ParallelEnumerationOptions()).ToListAsync());
+    }
+
+    [Fact]
+    public async Task GivenOneElement_WhenSelectingInParallel_ThenReturnOneElement()
+    {
+        var input = new List<string> { "42" };
+        Assert.Equal(42, await input.SelectParallel(ParseAsync, new ParallelEnumerationOptions()).SingleAsync());
+    }
+
+    [Fact]
+    public async Task GivenFewerThenParallelism_WhenSelectingInParallel_ThenReturnAllResults()
+    {
+        var input = new List<string> { "1", "2", "3" };
+        await AssertValuesAsync(
+            input.SelectParallel(ParseAsync, new ParallelEnumerationOptions { MaxDegreeOfParallelism = input.Count + 1 }),
+            1, 2, 3);
+    }
+
+    [Fact]
+    public async Task GivenMoreThenParallelism_WhenSelectingInParallel_ThenReturnAllResults()
+    {
+        var input = new List<string> { "1", "2", "3", "4", "5" };
+        await AssertValuesAsync(
+            input.SelectParallel(ParseAsync, new ParallelEnumerationOptions { MaxDegreeOfParallelism = input.Count - 2 }),
+            1, 2, 3, 4, 5);
+    }
+
+    [Fact]
+    public async Task GivenSource_WhenEnumeratingMultipleTimes_ThenReturnSameishResults()
+    {
+        var input = new List<string> { "1", "2", "3", "4", "5" };
+        for (int i = 0; i < 5; i++)
+        {
+            await AssertValuesAsync(
+                input.SelectParallel(ParseAsync, new ParallelEnumerationOptions { MaxDegreeOfParallelism = input.Count - 2 }),
+                1, 2, 3, 4, 5);
+        }
+    }
+
+    [Fact]
+    public async Task GivenError_WhenSelectingInParallel_ThenRethrowError()
+    {
+        var input = new List<string> { "1", "foo", "3" };
+        await Assert.ThrowsAsync<FormatException>(
+            () => input.SelectParallel(ParseAsync, new ParallelEnumerationOptions()).ToListAsync().AsTask());
+    }
+
+    [Fact]
+    public async Task GivenCancelledToken_WhenSelectingInParallel_ThenThrowException()
+    {
+        using var tokenSource = new CancellationTokenSource();
+
+        int count = 0;
+        var input = new List<string> { "1", "2", "3", "4", "5" };
+        await Assert.ThrowsAsync<TaskCanceledException>(
+            () => input
+                .SelectParallel(
+                    (x, t) =>
+                    {
+                        if (Interlocked.Increment(ref count) == 4)
+                            tokenSource.Cancel();
+
+                        return ParseAsync(x, t);
+                    },
+                    new ParallelEnumerationOptions
+                    {
+                        CancellationToken = tokenSource.Token,
+                        MaxDegreeOfParallelism = 2
+                    })
+                .ToListAsync()
+                .AsTask());
+    }
+
+    [Fact]
+    public async Task GivenMaxBuffer_WhenSelectingInParallel_ThenWaitForConsumption()
+    {
+        const int MaxBuffered = 3;
+
+        int bufferCount = 0;
+        var buffer = new ConcurrentDictionary<int, object>(); // Dictionary for key-based lookups
+        using var bufferFullEvent = new ManualResetEventSlim(false);
+
+        var input = new List<string> { "1", "2", "3", "4", "5", "6" };
+        IAsyncEnumerator<int> results = input
+            .SelectParallel(
+                async (x, t) =>
+                {
+                    int result = await ParseAsync(x, t);
+
+                    Assert.True(buffer.TryAdd(result, null));
+                    if (Interlocked.Increment(ref bufferCount) == MaxBuffered + 1)
+                        bufferFullEvent.Set();
+
+                    return result;
+                },
+                new ParallelEnumerationOptions
+                {
+                    MaxBufferedItems = MaxBuffered,
+                    MaxDegreeOfParallelism = MaxBuffered - 1,
+                })
+            .GetAsyncEnumerator();
+
+        var actual = new HashSet<int>();
+        Assert.True(await results.MoveNextAsync());
+        Assert.True(actual.Add(results.Current));
+
+        // Beginning the enumerable should have triggered the producer, but only up to the buffered max of 3.
+        // Therefore the values 2, 3, and 4 are have been resolved, while 5 and 6 and still waiting.
+        bufferFullEvent.Wait();
+
+        Assert.True(buffer.TryRemove(1, out _)); // We know 1 must have passed through the buffer
+        Assert.Equal(MaxBuffered, buffer.Count);
+
+        // Wait a bit longer -- nothing more is going to get added
+        await Task.Delay(1000);
+
+        Assert.Equal(MaxBuffered, buffer.Count);
+        Assert.All(buffer.Keys, x => Assert.InRange(x, 2, 4));
+
+        // Finish enumerating and validate
+        while (await results.MoveNextAsync())
+        {
+            Assert.True(actual.Add(results.Current));
+        }
+
+        Assert.Equal(6, actual.Count);
+        Assert.Contains(1, actual);
+        Assert.Contains(2, actual);
+        Assert.Contains(3, actual);
+        Assert.Contains(4, actual);
+        Assert.Contains(5, actual);
+        Assert.Contains(6, actual);
+    }
+
+    private static ValueTask<int> ParseAsync(string s, CancellationToken cancellationToken)
+        => new ValueTask<int>(Task.Run(() => int.Parse(s, CultureInfo.InvariantCulture), cancellationToken));
+
+    private static async ValueTask AssertValuesAsync<T>(IAsyncEnumerable<T> actual, params T[] expected)
+    {
+        HashSet<T> set = await actual.ToHashSetAsync();
+
+        Assert.Equal(expected.Length, set.Count);
+        foreach (T e in expected)
+        {
+            Assert.True(set.Remove(e));
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Common/ParallelEnumerableTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Common/ParallelEnumerableTests.cs
@@ -114,7 +114,7 @@ public class ParallelEnumerableTests
         const int MaxBuffered = 3;
 
         int bufferCount = 0;
-        var buffer = new ConcurrentDictionary<int, object>(); // Dictionary for key-based lookups
+        var resolved = new ConcurrentDictionary<int, object>(); // Dictionary for key-based lookups
         using var bufferFullEvent = new ManualResetEventSlim(false);
 
         var input = new List<string> { "1", "2", "3", "4", "5", "6" };
@@ -124,7 +124,7 @@ public class ParallelEnumerableTests
                 {
                     int result = await ParseAsync(x, t);
 
-                    Assert.True(buffer.TryAdd(result, null));
+                    Assert.True(resolved.TryAdd(result, null));
                     if (Interlocked.Increment(ref bufferCount) == MaxBuffered + 1)
                         bufferFullEvent.Set();
 
@@ -142,32 +142,31 @@ public class ParallelEnumerableTests
         Assert.True(actual.Add(results.Current));
 
         // Beginning the enumerable should have triggered the producer, but only up to the buffered max of 3.
-        // Therefore the values 2, 3, and 4 have been resolved, while 5 and 6 and still waiting.
+        // Let E = { 1, 2, 3 }. Let e be the element of E that was yielded first by the producer.
+        // After yielding the element e, the buffered elements shall be the set F = E U { e } U { 4 }.
+        // E.g. If e = 1 because 1 was yielded first, then F = { 2, 3, 4 } OR if 3 was yielded first,
+        // then { 1, 2, 4 } are buffered and waiting to be read by the consumer
         bufferFullEvent.Wait();
-        Assert.All(buffer.Keys, x => Assert.InRange(x, 1, 4));
 
-        Assert.True(buffer.TryRemove(1, out _)); // We know 1 must have passed through the buffer
-        Assert.Equal(MaxBuffered, buffer.Count);
+        // So far, 4 elements have been resolved. The 1 that was yielded and the 3 buffered values.
+        Assert.Equal(MaxBuffered + 1, resolved.Count);
+        Assert.All(resolved.Keys, x => Assert.InRange(x, 1, 4));
 
         // Wait a bit longer -- nothing more is going to be added
         await Task.Delay(1000);
 
-        Assert.Equal(MaxBuffered, buffer.Count);
-        Assert.All(buffer.Keys, x => Assert.InRange(x, 2, 4));
+        Assert.Equal(MaxBuffered + 1, resolved.Count);
+        Assert.All(resolved.Keys, x => Assert.InRange(x, 1, 4));
 
-        // Finish enumerating and validate
+        // Finish enumerating and validate the yielded elements
         while (await results.MoveNextAsync())
         {
             Assert.True(actual.Add(results.Current));
         }
 
         Assert.Equal(6, actual.Count);
-        Assert.Contains(1, actual);
-        Assert.Contains(2, actual);
-        Assert.Contains(3, actual);
-        Assert.Contains(4, actual);
-        Assert.Contains(5, actual);
-        Assert.Contains(6, actual);
+        Assert.All(resolved.Keys, x => Assert.InRange(x, 1, 6));
+        Assert.All(actual, x => Assert.InRange(x, 1, 6));
     }
 
     private static ValueTask<int> ParseAsync(string s, CancellationToken cancellationToken)

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Common/ParallelEnumerableTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Common/ParallelEnumerableTests.cs
@@ -24,12 +24,6 @@ public class ParallelEnumerableTests
         await Assert.ThrowsAsync<ArgumentNullException>(() => ((List<string>)null).SelectParallel(ParseAsync, new ParallelEnumerationOptions()).ToListAsync().AsTask());
         await Assert.ThrowsAsync<ArgumentNullException>(() => input.SelectParallel((Func<string, CancellationToken, ValueTask<int>>)null, new ParallelEnumerationOptions()).ToListAsync().AsTask());
         await Assert.ThrowsAsync<ArgumentNullException>(() => input.SelectParallel(ParseAsync, null).ToListAsync().AsTask());
-
-        var options = new ParallelEnumerationOptions { MaxBufferedItems = 1, MaxDegreeOfParallelism = -1 };
-        await Assert.ThrowsAsync<ArgumentException>(() => input.SelectParallel(ParseAsync, options).ToListAsync().AsTask());
-
-        options = new ParallelEnumerationOptions { MaxBufferedItems = 5, MaxDegreeOfParallelism = 6 };
-        await Assert.ThrowsAsync<ArgumentException>(() => input.SelectParallel(ParseAsync, options).ToListAsync().AsTask());
     }
 
     [Fact]

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveMetadataHandlerTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveMetadataHandlerTests.cs
@@ -1,9 +1,10 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -243,8 +244,7 @@ public class RetrieveMetadataHandlerTests
 
     private static RetrieveMetadataResponse SetupRetrieveMetadataResponse()
     {
-        return new RetrieveMetadataResponse(
-            new List<DicomDataset> { new DicomDataset() });
+        return new RetrieveMetadataResponse(new List<DicomDataset> { new DicomDataset() }.ToAsyncEnumerable());
     }
 
     private static RetrieveMetadataResponse SetupRetrieveMetadataResponseForValidatingCache(bool isCacheValid, string eTag)
@@ -257,7 +257,7 @@ public class RetrieveMetadataHandlerTests
         }
 
         return new RetrieveMetadataResponse(
-            responseMetadata,
+            responseMetadata.ToAsyncEnumerable(),
             isCacheValid: isCacheValid,
             eTag: eTag);
     }

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveMetadataServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveMetadataServiceTests.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -8,6 +8,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FellowOakDicom;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Dicom.Core.Configs;
 using Microsoft.Health.Dicom.Core.Exceptions;
 using Microsoft.Health.Dicom.Core.Features.Common;
 using Microsoft.Health.Dicom.Core.Features.Context;
@@ -45,7 +47,12 @@ public class RetrieveMetadataServiceTests
 
         _dicomRequestContextAccessor.RequestContext.DataPartitionEntry = PartitionEntry.Default;
 
-        _retrieveMetadataService = new RetrieveMetadataService(_instanceStore, _metadataStore, _eTagGenerator, _dicomRequestContextAccessor);
+        _retrieveMetadataService = new RetrieveMetadataService(
+            _instanceStore,
+            _metadataStore,
+            _eTagGenerator,
+            _dicomRequestContextAccessor,
+            Options.Create(new RetrieveConfiguration()));
     }
 
     [Fact]
@@ -136,8 +143,8 @@ public class RetrieveMetadataServiceTests
         string ifNoneMatch = null;
         RetrieveMetadataResponse response = await _retrieveMetadataService.RetrieveStudyInstanceMetadataAsync(_studyInstanceUid, ifNoneMatch, DefaultCancellationToken);
 
-        Assert.Equal(response.ResponseMetadata.Count(), versionedInstanceIdentifiers.Count);
-        Assert.Equal(response.ResponseMetadata.Count(), _dicomRequestContextAccessor.RequestContext.PartCount);
+        Assert.Equal(await response.ResponseMetadata.CountAsync(), versionedInstanceIdentifiers.Count);
+        Assert.Equal(await response.ResponseMetadata.CountAsync(), _dicomRequestContextAccessor.RequestContext.PartCount);
     }
 
     [Fact]
@@ -164,8 +171,8 @@ public class RetrieveMetadataServiceTests
         string ifNoneMatch = null;
         RetrieveMetadataResponse response = await _retrieveMetadataService.RetrieveSeriesInstanceMetadataAsync(_studyInstanceUid, _seriesInstanceUid, ifNoneMatch, DefaultCancellationToken);
 
-        Assert.Equal(response.ResponseMetadata.Count(), versionedInstanceIdentifiers.Count);
-        Assert.Equal(response.ResponseMetadata.Count(), _dicomRequestContextAccessor.RequestContext.PartCount);
+        Assert.Equal(await response.ResponseMetadata.CountAsync(), versionedInstanceIdentifiers.Count);
+        Assert.Equal(await response.ResponseMetadata.CountAsync(), _dicomRequestContextAccessor.RequestContext.PartCount);
     }
 
     [Fact]
@@ -190,7 +197,7 @@ public class RetrieveMetadataServiceTests
         string ifNoneMatch = null;
         RetrieveMetadataResponse response = await _retrieveMetadataService.RetrieveSopInstanceMetadataAsync(_studyInstanceUid, _seriesInstanceUid, _sopInstanceUid, ifNoneMatch, DefaultCancellationToken);
 
-        Assert.Single(response.ResponseMetadata);
+        Assert.Equal(1, await response.ResponseMetadata.CountAsync());
         Assert.Equal(1, _dicomRequestContextAccessor.RequestContext.PartCount);
     }
 

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveMetadataServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveMetadataServiceTests.cs
@@ -124,11 +124,12 @@ public class RetrieveMetadataServiceTests
     {
         List<VersionedInstanceIdentifier> versionedInstanceIdentifiers = SetupInstanceIdentifiersList(ResourceType.Study);
 
-        _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifiers.Last(), DefaultCancellationToken).Throws(new InstanceNotFoundException());
-        _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifiers.First(), DefaultCancellationToken).Returns(new DicomDataset());
+        _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifiers.Last(), Arg.Any<CancellationToken>()).Throws(new InstanceNotFoundException());
+        _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifiers.First(), Arg.Any<CancellationToken>()).Returns(new DicomDataset());
 
         string ifNoneMatch = null;
-        InstanceNotFoundException exception = await Assert.ThrowsAsync<InstanceNotFoundException>(() => _retrieveMetadataService.RetrieveStudyInstanceMetadataAsync(_studyInstanceUid, ifNoneMatch, DefaultCancellationToken));
+        RetrieveMetadataResponse response = await _retrieveMetadataService.RetrieveStudyInstanceMetadataAsync(_studyInstanceUid, ifNoneMatch, DefaultCancellationToken);
+        InstanceNotFoundException exception = await Assert.ThrowsAsync<InstanceNotFoundException>(() => response.ResponseMetadata.ToListAsync().AsTask());
         Assert.Equal("The specified instance cannot be found.", exception.Message);
     }
 
@@ -152,11 +153,12 @@ public class RetrieveMetadataServiceTests
     {
         List<VersionedInstanceIdentifier> versionedInstanceIdentifiers = SetupInstanceIdentifiersList(ResourceType.Series);
 
-        _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifiers.Last(), DefaultCancellationToken).Throws(new InstanceNotFoundException());
-        _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifiers.First(), DefaultCancellationToken).Returns(new DicomDataset());
+        _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifiers.Last(), Arg.Any<CancellationToken>()).Throws(new InstanceNotFoundException());
+        _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifiers.First(), Arg.Any<CancellationToken>()).Returns(new DicomDataset());
 
         string ifNoneMatch = null;
-        InstanceNotFoundException exception = await Assert.ThrowsAsync<InstanceNotFoundException>(() => _retrieveMetadataService.RetrieveSeriesInstanceMetadataAsync(_studyInstanceUid, _seriesInstanceUid, ifNoneMatch, DefaultCancellationToken));
+        RetrieveMetadataResponse response = await _retrieveMetadataService.RetrieveSeriesInstanceMetadataAsync(_studyInstanceUid, _seriesInstanceUid, ifNoneMatch, DefaultCancellationToken);
+        InstanceNotFoundException exception = await Assert.ThrowsAsync<InstanceNotFoundException>(() => response.ResponseMetadata.ToListAsync().AsTask());
         Assert.Equal("The specified instance cannot be found.", exception.Message);
     }
 
@@ -180,10 +182,11 @@ public class RetrieveMetadataServiceTests
     {
         VersionedInstanceIdentifier sopInstanceIdentifier = SetupInstanceIdentifiersList(ResourceType.Instance).First();
 
-        _metadataStore.GetInstanceMetadataAsync(sopInstanceIdentifier, DefaultCancellationToken).Throws(new InstanceNotFoundException());
+        _metadataStore.GetInstanceMetadataAsync(sopInstanceIdentifier, Arg.Any<CancellationToken>()).Throws(new InstanceNotFoundException());
 
         string ifNoneMatch = null;
-        InstanceNotFoundException exception = await Assert.ThrowsAsync<InstanceNotFoundException>(() => _retrieveMetadataService.RetrieveSopInstanceMetadataAsync(_studyInstanceUid, _seriesInstanceUid, _sopInstanceUid, ifNoneMatch, DefaultCancellationToken));
+        RetrieveMetadataResponse response = await _retrieveMetadataService.RetrieveSopInstanceMetadataAsync(_studyInstanceUid, _seriesInstanceUid, _sopInstanceUid, ifNoneMatch, DefaultCancellationToken);
+        InstanceNotFoundException exception = await Assert.ThrowsAsync<InstanceNotFoundException>(() => response.ResponseMetadata.ToListAsync().AsTask());
         Assert.Equal("The specified instance cannot be found.", exception.Message);
     }
 

--- a/src/Microsoft.Health.Dicom.Core/Configs/RetrieveConfiguration.cs
+++ b/src/Microsoft.Health.Dicom.Core/Configs/RetrieveConfiguration.cs
@@ -25,8 +25,8 @@ public class RetrieveConfiguration
     /// Gets or sets the maximum number of tasks that should be concurrently scheduled to read for a single metadata request.
     /// </summary>
     /// <value>A positive number or <c>-1</c> for unbounded parallelism.</value>
-    [Range(1, int.MaxValue)]
-    public int MaxDegreeOfParallelism { get; set; } = Environment.ProcessorCount * 4;
+    [Range(-1, int.MaxValue)]
+    public int MaxDegreeOfParallelism { get; set; } = -1;
 
     /// <summary>
     /// Gets or sets the maximum number of Dicom Data Sets to buffer in memory before pausing.

--- a/src/Microsoft.Health.Dicom.Core/Configs/RetrieveConfiguration.cs
+++ b/src/Microsoft.Health.Dicom.Core/Configs/RetrieveConfiguration.cs
@@ -3,6 +3,9 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
+using System.ComponentModel.DataAnnotations;
+
 namespace Microsoft.Health.Dicom.Core.Configs;
 
 public class RetrieveConfiguration
@@ -22,7 +25,8 @@ public class RetrieveConfiguration
     /// Gets or sets the maximum number of tasks that should be concurrently scheduled to read for a single metadata request.
     /// </summary>
     /// <value>A positive number or <c>-1</c> for unbounded parallelism.</value>
-    public int MaxDegreeOfParallelism { get; set; } = 10;
+    [Range(1, int.MaxValue)]
+    public int MaxDegreeOfParallelism { get; set; } = Environment.ProcessorCount * 4;
 
     /// <summary>
     /// Gets or sets the maximum number of Dicom Data Sets to buffer in memory before pausing.
@@ -30,6 +34,7 @@ public class RetrieveConfiguration
     /// <remarks>
     /// Once Dicom Data Sets are read by the caller, new Data Sets will begin buffering again.
     /// </remarks>
-    /// <value>A positive number or <c>-1</c> for unbounded buffering.</value>
+    /// <value>A positive number.</value>
+    [Range(1, int.MaxValue)]
     public int MaxBufferedDataSets { get; set; } = 100;
 }

--- a/src/Microsoft.Health.Dicom.Core/Configs/RetrieveConfiguration.cs
+++ b/src/Microsoft.Health.Dicom.Core/Configs/RetrieveConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -17,4 +17,19 @@ public class RetrieveConfiguration
     /// This is the size of the buffer
     /// </summary>
     public int LazyResponseStreamBufferSize { get; } = 1024 * 1024 * 4; //4 MB
+
+    /// <summary>
+    /// Gets or sets the maximum number of tasks that should be concurrently scheduled to read for a single metadata request.
+    /// </summary>
+    /// <value>A positive number or <c>-1</c> for unbounded parallelism.</value>
+    public int MaxDegreeOfParallelism { get; set; } = 10;
+
+    /// <summary>
+    /// Gets or sets the maximum number of Dicom Data Sets to buffer in memory before pausing.
+    /// </summary>
+    /// <remarks>
+    /// Once Dicom Data Sets are read by the caller, new Data Sets will begin buffering again.
+    /// </remarks>
+    /// <value>A positive number or <c>-1</c> for unbounded buffering.</value>
+    public int MaxBufferedDataSets { get; set; } = 100;
 }

--- a/src/Microsoft.Health.Dicom.Core/Configs/RetrieveConfiguration.cs
+++ b/src/Microsoft.Health.Dicom.Core/Configs/RetrieveConfiguration.cs
@@ -27,14 +27,4 @@ public class RetrieveConfiguration
     /// <value>A positive number or <c>-1</c> for unbounded parallelism.</value>
     [Range(-1, int.MaxValue)]
     public int MaxDegreeOfParallelism { get; set; } = -1;
-
-    /// <summary>
-    /// Gets or sets the maximum number of Dicom Data Sets to buffer in memory before pausing.
-    /// </summary>
-    /// <remarks>
-    /// Once Dicom Data Sets are read by the caller, new Data Sets will begin buffering again.
-    /// </remarks>
-    /// <value>A positive number.</value>
-    [Range(1, int.MaxValue)]
-    public int MaxBufferedDataSets { get; set; } = 100;
 }

--- a/src/Microsoft.Health.Dicom.Core/Configs/ServicesConfiguration.cs
+++ b/src/Microsoft.Health.Dicom.Core/Configs/ServicesConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -15,7 +15,7 @@ public class ServicesConfiguration
 
     public DataPartitionConfiguration DataPartition { get; } = new DataPartitionConfiguration();
 
-    public RetrieveConfiguration RetrieveConfiguration { get; } = new RetrieveConfiguration();
+    public RetrieveConfiguration Retrieve { get; } = new RetrieveConfiguration();
 
     public BlobMigrationConfiguration BlobMigration { get; } = new BlobMigrationConfiguration();
 

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
@@ -622,6 +622,15 @@ namespace Microsoft.Health.Dicom.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to MaxBufferedItems must be greater than MaxDegreeOfParallelism if not unbounded..
+        /// </summary>
+        internal static string InvalidItemBuffering {
+            get {
+                return ResourceManager.GetString("InvalidItemBuffering", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Read invalid JSON token type &apos;{0}&apos;..
         /// </summary>
         internal static string InvalidJsonToken {
@@ -1152,6 +1161,15 @@ namespace Microsoft.Health.Dicom.Core {
         internal static string UnknownQueryParameter {
             get {
                 return ResourceManager.GetString("UnknownQueryParameter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot buffer items if parallelism is unbounded..
+        /// </summary>
+        internal static string UnsupportedBuffering {
+            get {
+                return ResourceManager.GetString("UnsupportedBuffering", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
@@ -621,4 +621,10 @@ For details on valid range queries, please refer to Search Matching section in C
   <data name="SinglePartSupportedForSingleFrame" xml:space="preserve">
     <value>The accept header is supported for single frame retrieval, use multi-part accept header instead.</value>
   </data>
+  <data name="InvalidItemBuffering" xml:space="preserve">
+    <value>MaxBufferedItems must be greater than MaxDegreeOfParallelism if not unbounded.</value>
+  </data>
+  <data name="UnsupportedBuffering" xml:space="preserve">
+    <value>Cannot buffer items if parallelism is unbounded.</value>
+  </data>
 </root>

--- a/src/Microsoft.Health.Dicom.Core/Features/Common/ParallelEnumerable.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Common/ParallelEnumerable.cs
@@ -1,0 +1,100 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using EnsureThat;
+
+namespace Microsoft.Health.Dicom.Core.Features.Common;
+
+internal sealed class ParallelEnumerationOptions
+{
+    public int MaxBufferedItems { get; init; } = -1;
+
+    public int MaxDegreeOfParallelism { get; init; } = -1;
+}
+
+internal static class ParallelEnumerable
+{
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Any failure should be surfaced to the reader.")]
+    public static async IAsyncEnumerable<TResult> SelectParallel<TSource, TResult>(
+        this IEnumerable<TSource> source,
+        Func<TSource, CancellationToken, ValueTask<TResult>> selector,
+        ParallelEnumerationOptions options,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var state = new State<TSource, TResult>(source, selector, options, cancellationToken);
+        ValueTask producer = ProduceAsync(state);
+
+        await foreach (TResult item in state.Items.Reader.ReadAllAsync(cancellationToken))
+        {
+            yield return item;
+        }
+
+        await producer;
+
+        static async ValueTask ProduceAsync(State<TSource, TResult> state)
+        {
+            ChannelWriter<TResult> writer = state.Items.Writer;
+
+            // Note that the order is not guaranteed to be deterministic. Items will be queued in the order they are found!
+            await Parallel.ForEachAsync(state.Source, state.Options, (item, token) => ProduceItemAsync(item, state.Selector, writer, token));
+            writer.Complete();
+        }
+
+        static async ValueTask ProduceItemAsync(
+            TSource item,
+            Func<TSource, CancellationToken, ValueTask<TResult>> selector,
+            ChannelWriter<TResult> writer,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                TResult result = await selector(item, cancellationToken);
+                await writer.WriteAsync(result, cancellationToken);
+            }
+            catch (Exception e)
+            {
+                writer.Complete(e);
+            }
+        }
+    }
+
+    private sealed class State<TSource, TResult>
+    {
+        public State(
+            IEnumerable<TSource> source,
+            Func<TSource, CancellationToken, ValueTask<TResult>> selector,
+            ParallelEnumerationOptions options,
+            CancellationToken cancellationToken)
+        {
+            EnsureArg.IsNotNull(options, nameof(options));
+
+            Items = options.MaxBufferedItems == -1
+                ? Channel.CreateUnbounded<TResult>(new UnboundedChannelOptions { SingleReader = true })
+                : Channel.CreateBounded<TResult>(new BoundedChannelOptions(options.MaxBufferedItems) { FullMode = BoundedChannelFullMode.Wait, SingleReader = true });
+            Options = new ParallelOptions
+            {
+                CancellationToken = cancellationToken,
+                MaxDegreeOfParallelism = options.MaxDegreeOfParallelism,
+            };
+            Selector = EnsureArg.IsNotNull(selector, nameof(selector));
+            Source = EnsureArg.IsNotNull(source, nameof(source));
+        }
+
+        public Channel<TResult> Items { get; }
+
+        public ParallelOptions Options { get; }
+
+        public Func<TSource, CancellationToken, ValueTask<TResult>> Selector { get; }
+
+        public IEnumerable<TSource> Source { get; }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Core/Features/Common/ParallelEnumerable.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Common/ParallelEnumerable.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Channels;
@@ -14,18 +13,8 @@ using EnsureThat;
 
 namespace Microsoft.Health.Dicom.Core.Features.Common;
 
-internal sealed class ParallelEnumerationOptions
-{
-    public int MaxBufferedItems { get; init; } = 100;
-
-    public int MaxDegreeOfParallelism { get; init; } = Environment.ProcessorCount * 4;
-
-    public TaskScheduler TaskScheduler { get; init; }
-}
-
 internal static class ParallelEnumerable
 {
-    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Any failure should be surfaced to the reader.")]
     public static async IAsyncEnumerable<TResult> SelectParallel<TSource, TResult>(
         this IEnumerable<TSource> source,
         Func<TSource, CancellationToken, ValueTask<TResult>> selector,
@@ -35,7 +24,7 @@ internal static class ParallelEnumerable
         var state = new State<TSource, TResult>(source, selector, options, cancellationToken);
         ValueTask producer = ProduceAsync(state);
 
-        await foreach (TResult item in state.Items.Reader.ReadAllAsync(cancellationToken))
+        await foreach (TResult item in state.Results.Reader.ReadAllAsync(cancellationToken))
         {
             yield return item;
         }
@@ -44,7 +33,7 @@ internal static class ParallelEnumerable
 
         static async ValueTask ProduceAsync(State<TSource, TResult> state)
         {
-            ChannelWriter<TResult> writer = state.Items.Writer;
+            ChannelWriter<TResult> writer = state.Results.Writer;
 
             try
             {
@@ -53,25 +42,17 @@ internal static class ParallelEnumerable
                 await Parallel.ForEachAsync(
                     state.Source,
                     state.Options,
-                    (item, token) => ProduceItemAsync(item, state.Selector, writer, token));
+                    async (item, token) =>
+                    {
+                        await writer.WaitToWriteAsync(token);
+                        TResult result = await state.Selector(item, token);
+                        await writer.WriteAsync(result, token);
+                    });
             }
-            catch (Exception e)
+            finally
             {
-                writer.Complete(e);
-                return;
+                writer.Complete();
             }
-
-            writer.Complete();
-        }
-
-        static async ValueTask ProduceItemAsync(
-            TSource item,
-            Func<TSource, CancellationToken, ValueTask<TResult>> selector,
-            ChannelWriter<TResult> writer,
-            CancellationToken cancellationToken)
-        {
-            TResult result = await selector(item, cancellationToken);
-            await writer.WriteAsync(result, cancellationToken);
         }
     }
 
@@ -85,6 +66,8 @@ internal static class ParallelEnumerable
         {
             EnsureArg.IsNotNull(options, nameof(options));
 
+            Selector = EnsureArg.IsNotNull(selector, nameof(selector));
+            Source = EnsureArg.IsNotNull(source, nameof(source));
             Options = new ParallelOptions
             {
                 CancellationToken = cancellationToken,
@@ -92,31 +75,17 @@ internal static class ParallelEnumerable
                 TaskScheduler = options.TaskScheduler,
             };
 
-            Selector = EnsureArg.IsNotNull(selector, nameof(selector));
-            Source = EnsureArg.IsNotNull(source, nameof(source));
-
-            // TODO: Enable buffering with unbounded parallelism if ChannelWriter supports a factory argument.
-            // We have to modify the channel capacity as we will still resolve the selector before blocking
-            // on the channel write. So if the maximum parallelism is 'p', there will be at most 'p' additional
-            // threads blocked after the channel has reached capacity.
-            if (options.MaxBufferedItems <= 0)
-                throw new ArgumentOutOfRangeException(nameof(options));
-
-            if (options.MaxDegreeOfParallelism == -1)
-                throw new ArgumentException(DicomCoreResource.UnsupportedBuffering, nameof(options));
-
-            if (options.MaxBufferedItems <= options.MaxDegreeOfParallelism)
-                throw new ArgumentException(DicomCoreResource.InvalidItemBuffering, nameof(options));
-
-            Items = Channel.CreateBounded<TResult>(
-                new BoundedChannelOptions(options.MaxBufferedItems - options.MaxDegreeOfParallelism)
+            // Note: The WaitToWriteAsync/WaitAsync pattern is a best-effort, and some results
+            // may be resolved that cannot be immediately written to the channel
+            Results = Channel.CreateBounded<TResult>(
+                new BoundedChannelOptions(options.MaxBufferedItems)
                 {
                     FullMode = BoundedChannelFullMode.Wait,
                     SingleReader = true,
                 });
         }
 
-        public Channel<TResult> Items { get; }
+        public Channel<TResult> Results { get; }
 
         public ParallelOptions Options { get; }
 

--- a/src/Microsoft.Health.Dicom.Core/Features/Common/ParallelEnumerationOptions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Common/ParallelEnumerationOptions.cs
@@ -1,0 +1,17 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Threading.Tasks;
+
+namespace Microsoft.Health.Dicom.Core.Features.Common;
+
+internal sealed class ParallelEnumerationOptions
+{
+    public int MaxBufferedItems { get; init; } = 100;
+
+    public int MaxDegreeOfParallelism { get; init; } = -1;
+
+    public TaskScheduler TaskScheduler { get; init; }
+}

--- a/src/Microsoft.Health.Dicom.Core/Features/Common/ParallelEnumerationOptions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Common/ParallelEnumerationOptions.cs
@@ -9,8 +9,6 @@ namespace Microsoft.Health.Dicom.Core.Features.Common;
 
 internal sealed class ParallelEnumerationOptions
 {
-    public int MaxBufferedItems { get; init; } = 100;
-
     public int MaxDegreeOfParallelism { get; init; } = -1;
 
     public TaskScheduler TaskScheduler { get; init; }

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/InstanceStoreExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/InstanceStoreExtensions.cs
@@ -1,8 +1,9 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -17,7 +18,7 @@ namespace Microsoft.Health.Dicom.Core.Features.Retrieve;
 
 public static class InstanceStoreExtensions
 {
-    public static async Task<IEnumerable<VersionedInstanceIdentifier>> GetInstancesToRetrieve(
+    public static async Task<IReadOnlyList<VersionedInstanceIdentifier>> GetInstancesToRetrieve(
             this IInstanceStore instanceStore,
             ResourceType resourceType,
             int partitionKey,
@@ -28,7 +29,7 @@ public static class InstanceStoreExtensions
     {
         EnsureArg.IsNotNull(instanceStore, nameof(instanceStore));
 
-        IEnumerable<VersionedInstanceIdentifier> instancesToRetrieve = Enumerable.Empty<VersionedInstanceIdentifier>();
+        IReadOnlyList<VersionedInstanceIdentifier> instancesToRetrieve = Array.Empty<VersionedInstanceIdentifier>();
 
         switch (resourceType)
         {
@@ -59,7 +60,7 @@ public static class InstanceStoreExtensions
                 break;
         }
 
-        if (!instancesToRetrieve.Any())
+        if (instancesToRetrieve.Count == 0)
         {
             ThrowNotFoundException(resourceType);
         }

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveMetadataService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveMetadataService.cs
@@ -97,11 +97,7 @@ public class RetrieveMetadataService : IRetrieveMetadataService
             ? AsyncEnumerable.Empty<DicomDataset>()
             : instancesToRetrieve.SelectParallel(
                 (x, t) => new ValueTask<DicomDataset>(_metadataStore.GetInstanceMetadataAsync(x, t)),
-                new ParallelEnumerationOptions
-                {
-                    MaxBufferedItems = _options.MaxBufferedDataSets,
-                    MaxDegreeOfParallelism = _options.MaxDegreeOfParallelism,
-                },
+                new ParallelEnumerationOptions { MaxDegreeOfParallelism = _options.MaxDegreeOfParallelism },
                 cancellationToken);
 
         return new RetrieveMetadataResponse(instanceMetadata, isCacheValid, eTag);

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveMetadataService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveMetadataService.cs
@@ -99,10 +99,10 @@ public class RetrieveMetadataService : IRetrieveMetadataService
                 (x, t) => new ValueTask<DicomDataset>(_metadataStore.GetInstanceMetadataAsync(x, t)),
                 new ParallelEnumerationOptions
                 {
-                    CancellationToken = cancellationToken,
                     MaxBufferedItems = _options.MaxBufferedDataSets,
                     MaxDegreeOfParallelism = _options.MaxDegreeOfParallelism,
-                });
+                },
+                cancellationToken);
 
         return new RetrieveMetadataResponse(instanceMetadata, isCacheValid, eTag);
     }

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveMetadataService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveMetadataService.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -10,6 +10,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using FellowOakDicom;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Dicom.Core.Configs;
 using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Core.Features.Common;
 using Microsoft.Health.Dicom.Core.Features.Context;
@@ -25,27 +27,25 @@ public class RetrieveMetadataService : IRetrieveMetadataService
     private readonly IMetadataStore _metadataStore;
     private readonly IETagGenerator _eTagGenerator;
     private readonly IDicomRequestContextAccessor _contextAccessor;
+    private readonly RetrieveConfiguration _options;
 
     public RetrieveMetadataService(
         IInstanceStore instanceStore,
         IMetadataStore metadataStore,
         IETagGenerator eTagGenerator,
-        IDicomRequestContextAccessor contextAccessor)
+        IDicomRequestContextAccessor contextAccessor,
+        IOptions<RetrieveConfiguration> options)
     {
-        EnsureArg.IsNotNull(instanceStore, nameof(instanceStore));
-        EnsureArg.IsNotNull(metadataStore, nameof(metadataStore));
-        EnsureArg.IsNotNull(eTagGenerator, nameof(eTagGenerator));
-        EnsureArg.IsNotNull(contextAccessor, nameof(contextAccessor));
-
-        _instanceStore = instanceStore;
-        _metadataStore = metadataStore;
-        _eTagGenerator = eTagGenerator;
-        _contextAccessor = contextAccessor;
+        _instanceStore = EnsureArg.IsNotNull(instanceStore, nameof(instanceStore));
+        _metadataStore = EnsureArg.IsNotNull(metadataStore, nameof(metadataStore));
+        _eTagGenerator = EnsureArg.IsNotNull(eTagGenerator, nameof(eTagGenerator));
+        _contextAccessor = EnsureArg.IsNotNull(contextAccessor, nameof(contextAccessor));
+        _options = EnsureArg.IsNotNull(options?.Value, nameof(options));
     }
 
     public async Task<RetrieveMetadataResponse> RetrieveStudyInstanceMetadataAsync(string studyInstanceUid, string ifNoneMatch = null, CancellationToken cancellationToken = default)
     {
-        IEnumerable<VersionedInstanceIdentifier> retrieveInstances = await _instanceStore.GetInstancesToRetrieve(
+        IReadOnlyList<VersionedInstanceIdentifier> retrieveInstances = await _instanceStore.GetInstancesToRetrieve(
             ResourceType.Study,
             GetPartitionKey(),
             studyInstanceUid,
@@ -55,12 +55,12 @@ public class RetrieveMetadataService : IRetrieveMetadataService
 
         string eTag = _eTagGenerator.GetETag(ResourceType.Study, retrieveInstances);
         bool isCacheValid = IsCacheValid(eTag, ifNoneMatch);
-        return await RetrieveMetadata(retrieveInstances, isCacheValid, eTag, cancellationToken);
+        return RetrieveMetadata(retrieveInstances, isCacheValid, eTag, cancellationToken);
     }
 
     public async Task<RetrieveMetadataResponse> RetrieveSeriesInstanceMetadataAsync(string studyInstanceUid, string seriesInstanceUid, string ifNoneMatch = null, CancellationToken cancellationToken = default)
     {
-        IEnumerable<VersionedInstanceIdentifier> retrieveInstances = await _instanceStore.GetInstancesToRetrieve(
+        IReadOnlyList<VersionedInstanceIdentifier> retrieveInstances = await _instanceStore.GetInstancesToRetrieve(
                 ResourceType.Series,
                 GetPartitionKey(),
                 studyInstanceUid,
@@ -70,12 +70,12 @@ public class RetrieveMetadataService : IRetrieveMetadataService
 
         string eTag = _eTagGenerator.GetETag(ResourceType.Series, retrieveInstances);
         bool isCacheValid = IsCacheValid(eTag, ifNoneMatch);
-        return await RetrieveMetadata(retrieveInstances, isCacheValid, eTag, cancellationToken);
+        return RetrieveMetadata(retrieveInstances, isCacheValid, eTag, cancellationToken);
     }
 
     public async Task<RetrieveMetadataResponse> RetrieveSopInstanceMetadataAsync(string studyInstanceUid, string seriesInstanceUid, string sopInstanceUid, string ifNoneMatch = null, CancellationToken cancellationToken = default)
     {
-        IEnumerable<VersionedInstanceIdentifier> retrieveInstances = await _instanceStore.GetInstancesToRetrieve(
+        IReadOnlyList<VersionedInstanceIdentifier> retrieveInstances = await _instanceStore.GetInstancesToRetrieve(
             ResourceType.Instance,
             GetPartitionKey(),
             studyInstanceUid,
@@ -85,21 +85,24 @@ public class RetrieveMetadataService : IRetrieveMetadataService
 
         string eTag = _eTagGenerator.GetETag(ResourceType.Instance, retrieveInstances);
         bool isCacheValid = IsCacheValid(eTag, ifNoneMatch);
-        return await RetrieveMetadata(retrieveInstances, isCacheValid, eTag, cancellationToken);
+        return RetrieveMetadata(retrieveInstances, isCacheValid, eTag, cancellationToken);
     }
 
-    private async Task<RetrieveMetadataResponse> RetrieveMetadata(IEnumerable<VersionedInstanceIdentifier> instancesToRetrieve, bool isCacheValid, string eTag, CancellationToken cancellationToken)
+    private RetrieveMetadataResponse RetrieveMetadata(IReadOnlyList<VersionedInstanceIdentifier> instancesToRetrieve, bool isCacheValid, string eTag, CancellationToken cancellationToken)
     {
-        IEnumerable<DicomDataset> instanceMetadata = Enumerable.Empty<DicomDataset>();
-        _contextAccessor.RequestContext.PartCount = instancesToRetrieve.Count();
+        _contextAccessor.RequestContext.PartCount = instancesToRetrieve.Count;
 
         // Retrieve metadata instances only if cache is not valid.
-        if (!isCacheValid)
-        {
-            instanceMetadata = await Task.WhenAll(
-                    instancesToRetrieve
-                    .Select(x => _metadataStore.GetInstanceMetadataAsync(x, cancellationToken)));
-        }
+        IAsyncEnumerable<DicomDataset> instanceMetadata = isCacheValid
+            ? AsyncEnumerable.Empty<DicomDataset>()
+            : instancesToRetrieve.SelectParallel(
+                (x, t) => new ValueTask<DicomDataset>(_metadataStore.GetInstanceMetadataAsync(x, t)),
+                new ParallelEnumerationOptions
+                {
+                    MaxBufferedItems = _options.MaxBufferedDataSets,
+                    MaxDegreeOfParallelism = _options.MaxDegreeOfParallelism,
+                },
+                cancellationToken);
 
         return new RetrieveMetadataResponse(instanceMetadata, isCacheValid, eTag);
     }
@@ -114,19 +117,8 @@ public class RetrieveMetadataService : IRetrieveMetadataService
     /// <param name="ifNoneMatch">If-None-Match</param>
     /// <returns>True if cache is valid, i.e. content has not modified, else returns false.</returns>
     private static bool IsCacheValid(string eTag, string ifNoneMatch)
-    {
-        bool isCacheValid = false;
-
-        if (!string.IsNullOrEmpty(ifNoneMatch) && string.Equals(ifNoneMatch, eTag, StringComparison.OrdinalIgnoreCase))
-        {
-            isCacheValid = true;
-        }
-
-        return isCacheValid;
-    }
+        => !string.IsNullOrEmpty(ifNoneMatch) && string.Equals(ifNoneMatch, eTag, StringComparison.OrdinalIgnoreCase);
 
     private int GetPartitionKey()
-    {
-        return _contextAccessor.RequestContext.GetPartitionKey();
-    }
+        => _contextAccessor.RequestContext.GetPartitionKey();
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveMetadataService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveMetadataService.cs
@@ -99,10 +99,10 @@ public class RetrieveMetadataService : IRetrieveMetadataService
                 (x, t) => new ValueTask<DicomDataset>(_metadataStore.GetInstanceMetadataAsync(x, t)),
                 new ParallelEnumerationOptions
                 {
+                    CancellationToken = cancellationToken,
                     MaxBufferedItems = _options.MaxBufferedDataSets,
                     MaxDegreeOfParallelism = _options.MaxDegreeOfParallelism,
-                },
-                cancellationToken);
+                });
 
         return new RetrieveMetadataResponse(instanceMetadata, isCacheValid, eTag);
     }

--- a/src/Microsoft.Health.Dicom.Core/Messages/Retrieve/RetrieveMetadataResponse.cs
+++ b/src/Microsoft.Health.Dicom.Core/Messages/Retrieve/RetrieveMetadataResponse.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -11,7 +11,7 @@ namespace Microsoft.Health.Dicom.Core.Messages.Retrieve;
 
 public class RetrieveMetadataResponse
 {
-    public RetrieveMetadataResponse(IEnumerable<DicomDataset> responseMetadata, bool isCacheValid = false, string eTag = null)
+    public RetrieveMetadataResponse(IAsyncEnumerable<DicomDataset> responseMetadata, bool isCacheValid = false, string eTag = null)
     {
         EnsureArg.IsNotNull(responseMetadata, nameof(responseMetadata));
         ResponseMetadata = responseMetadata;
@@ -19,7 +19,7 @@ public class RetrieveMetadataResponse
         ETag = eTag;
     }
 
-    public IEnumerable<DicomDataset> ResponseMetadata { get; }
+    public IAsyncEnumerable<DicomDataset> ResponseMetadata { get; }
 
     public bool IsCacheValid { get; }
 

--- a/src/Microsoft.Health.Dicom.Web/appsettings.json
+++ b/src/Microsoft.Health.Dicom.Web/appsettings.json
@@ -76,6 +76,13 @@
       "EnableOhifViewer": false
     },
     "Services": {
+      "BlobMigration": {
+        "FormatType": "Old",
+        "StartCopy": false,
+        "StartDelete": false,
+        "CopyFileOperationId": "1d4689da-ca3b-4659-b0c7-7bf6c9ff25e1",
+        "DeleteFileOperationId": "ce38a27e-b194-4645-b47a-fe91c38c330f"
+      },
       "DeletedInstanceCleanup": {
         "DeleteDelay": "3.00:00:00",
         "MaxRetries": 5,
@@ -83,18 +90,14 @@
         "PollingInterval": "00:03:00",
         "BatchSize": 10
       },
-      "StoreServiceSettings": {
-        "MaxAllowedDicomFileSize": 2147483647
-      },
       "ExtendedQueryTag": {
         "MaxAllowedCount": 128
       },
-      "BlobMigration": {
-        "FormatType": "Old",
-        "StartCopy": false,
-        "StartDelete": false,
-        "CopyFileOperationId": "1d4689da-ca3b-4659-b0c7-7bf6c9ff25e1",
-        "DeleteFileOperationId": "ce38a27e-b194-4645-b47a-fe91c38c330f"
+      "Retrieve": {
+        "MaxDegreeOfParallelism": 200
+      },
+      "StoreServiceSettings": {
+        "MaxAllowedDicomFileSize": 2147483647
       }
     },
     "Audit": {

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Features/RetrieveMetadataServiceTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Features/RetrieveMetadataServiceTests.cs
@@ -11,6 +11,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using FellowOakDicom;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Dicom.Core.Configs;
 using Microsoft.Health.Dicom.Core.Exceptions;
 using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Core.Features.Common;
@@ -51,7 +53,12 @@ public class RetrieveMetadataServiceTests : IClassFixture<DataStoreTestsFixture>
 
         _dicomRequestContextAccessor.RequestContext.DataPartitionEntry = PartitionEntry.Default;
 
-        _retrieveMetadataService = new RetrieveMetadataService(_instanceStore, _metadataStore, _eTagGenerator, _dicomRequestContextAccessor);
+        _retrieveMetadataService = new RetrieveMetadataService(
+            _instanceStore,
+            _metadataStore,
+            _eTagGenerator,
+            _dicomRequestContextAccessor,
+            Options.Create(new RetrieveConfiguration()));
     }
 
     [Fact]
@@ -93,7 +100,7 @@ public class RetrieveMetadataServiceTests : IClassFixture<DataStoreTestsFixture>
 
         RetrieveMetadataResponse response = await _retrieveMetadataService.RetrieveStudyInstanceMetadataAsync(_studyInstanceUid, ifNoneMatch, tokenSource.Token);
 
-        var actual = response.ResponseMetadata.ToList();
+        var actual = await response.ResponseMetadata.ToListAsync();
         Assert.Equal(2, actual.Count);
         ValidateResponseMetadataDataset(first.Dataset, actual[0]);
         ValidateResponseMetadataDataset(second.Dataset, actual[1]);
@@ -138,7 +145,7 @@ public class RetrieveMetadataServiceTests : IClassFixture<DataStoreTestsFixture>
         string ifNoneMatch = null;
         RetrieveMetadataResponse response = await _retrieveMetadataService.RetrieveSeriesInstanceMetadataAsync(_studyInstanceUid, _seriesInstanceUid, ifNoneMatch, tokenSource.Token);
 
-        var actual = response.ResponseMetadata.ToList();
+        var actual = await response.ResponseMetadata.ToListAsync();
         Assert.Equal(2, actual.Count);
         ValidateResponseMetadataDataset(first.Dataset, actual[0]);
         ValidateResponseMetadataDataset(second.Dataset, actual[1]);


### PR DESCRIPTION
## Description
Asynchronously stream the datasets for metadata retrievals instead of buffering every instance's Dicom Data Set.
- Change return type of the `RetrieveController` to use `IAsyncEnumerable<T>` over `IEnumerable<T>`
- No longer use `Task.WhenAll` in the `RetrieveMetadataService`
    - Replace with new `SelectParallel` method that leverages an underlying producer/consumer pattern to eagerly buffer results asynchronously
- Refactor some of the fork project build
- Add new benchmarking project for future testing

## Related issues
[AB#95811](https://microsofthealth.visualstudio.com/Health/_workitems/edit/95811)

## Testing
New tests and re-running existing WADO tests
