### PR TITLE
Updated deployment template to include patient system id changes

### DIFF
--- a/converter/dicom-cast/samples/templates/default-azuredeploy.json
+++ b/converter/dicom-cast/samples/templates/default-azuredeploy.json
@@ -102,7 +102,7 @@
           }
         },
         "isIssuerIdUsed": {
-          "defaultValue":  false,
+          "defaultValue": false,
           "type": "Bool",
           "metadata": {
             "description": "Issuer id or patient system id used based on this boolean value"

--- a/converter/dicom-cast/samples/templates/deploy-with-healthcareapis.json
+++ b/converter/dicom-cast/samples/templates/deploy-with-healthcareapis.json
@@ -264,10 +264,10 @@
             "value": "[variables('authenticationArray')]"
           },
           "patientSystemId": {
-            "value": "[parameters('storageAccountSku')]"
+            "value": "[parameters('patientSystemId')]"
           },
           "isIssuerIdUsed": {
-            "value": "[parameters('storageAccountSku')]"
+            "value": "[parameters('isIssuerIdUsed')]"
           }
         }
       }

--- a/converter/dicom-cast/samples/templates/deploy-with-healthcareapis.json
+++ b/converter/dicom-cast/samples/templates/deploy-with-healthcareapis.json
@@ -125,14 +125,15 @@
       }
     },
     "patientSystemId": {
+      "defaultValue": "",
       "type": "string",
       "metadata": {
         "description": "Patient SystemId configured by the user"
       }
     },
     "isIssuerIdUsed": {
-      "defaultValue":  false,
-      "type": "Bool",
+      "defaultValue": false,
+      "type": "bool",
       "metadata": {
         "description": "Issuer id or patient system id used based on this boolean value"
       }

--- a/converter/dicom-cast/samples/templates/deploy-with-healthcareapis.json
+++ b/converter/dicom-cast/samples/templates/deploy-with-healthcareapis.json
@@ -124,6 +124,19 @@
         "description": "The behavior of Azure runtime if container has stopped."
       }
     },
+    "patientSystemId": {
+      "type": "string",
+      "metadata": {
+        "description": "Patient SystemId configured by the user"
+      }
+    },
+    "isIssuerIdUsed": {
+      "defaultValue":  false,
+      "type": "Bool",
+      "metadata": {
+        "description": "Issuer id or patient system id used based on this boolean value"
+      }
+    },
     "enforceValidationOfTagValues": {
       "defaultValue": false,
       "type": "bool",
@@ -248,6 +261,12 @@
           },
           "additionalEnvironmentVariables": {
             "value": "[variables('authenticationArray')]"
+          },
+          "patientSystemId": {
+            "value": "[parameters('storageAccountSku')]"
+          },
+          "isIssuerIdUsed": {
+            "value": "[parameters('storageAccountSku')]"
           }
         }
       }


### PR DESCRIPTION
## Description
Adding the mandatory parameters (patientSystemId and isIssuerIdUsed) that are required in default-azuredeploy.json

## Related issues
Addresses bug [95894](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/95894).

## Testing
Provisioned a personal environment using the new sample ARM template and verified whether the validation is successful.