### PR TITLE
Fix Durable Task Health Check to Validate all Services

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -101,6 +101,7 @@
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Text.Json" Version="6.0.6" />
+    <PackageVersion Include="WindowsAzure.Storage" Version="9.3.3" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.assert" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/src/Microsoft.Health.Dicom.Functions.Client.UnitTests/HealthChecks/DurableTaskHealthCheckTests.cs
+++ b/src/Microsoft.Health.Dicom.Functions.Client.UnitTests/HealthChecks/DurableTaskHealthCheckTests.cs
@@ -13,7 +13,7 @@ using Microsoft.Health.Dicom.Functions.Client.HealthChecks;
 using Microsoft.WindowsAzure.Storage.Auth;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Microsoft.WindowsAzure.Storage.Queue;
-using Microsoft.WindowsAzure.Storage.Shared.Protocol;
+using Microsoft.WindowsAzure.Storage.Queue.Protocol;
 using Microsoft.WindowsAzure.Storage.Table;
 using NSubstitute;
 using Xunit;
@@ -37,15 +37,15 @@ public class DurableTaskHealthCheckTests
     {
         using var tokenSource = new CancellationTokenSource();
 
-        _blobClient.GetServicePropertiesAsync(null, null, tokenSource.Token).Returns(Task.FromException<ServiceProperties>(new IOException()));
-        _queueClient.GetServicePropertiesAsync(null, null, tokenSource.Token).Returns(Task.FromResult(new ServiceProperties()));
-        _tableClient.GetServicePropertiesAsync(null, null, tokenSource.Token).Returns(Task.FromResult(new ServiceProperties()));
+        _blobClient.ListContainersSegmentedAsync(null, ContainerListingDetails.None, 1, null, null, null, tokenSource.Token).Returns(Task.FromException<ContainerResultSegment>(new IOException()));
+        _queueClient.ListQueuesSegmentedAsync(null, QueueListingDetails.None, 1, null, null, null, tokenSource.Token).Returns(Task.FromResult<QueueResultSegment>(null));
+        _tableClient.ListTablesSegmentedAsync(null, 1, null, null, null, tokenSource.Token).Returns(Task.FromResult<TableResultSegment>(null));
 
         await Assert.ThrowsAsync<IOException>(() => _healthCheck.CheckHealthAsync(new HealthCheckContext(), tokenSource.Token));
 
-        await _blobClient.Received(1).GetServicePropertiesAsync(null, null, tokenSource.Token);
-        await _queueClient.Received(0).GetServicePropertiesAsync(null, null, tokenSource.Token);
-        await _tableClient.Received(0).GetServicePropertiesAsync(null, null, tokenSource.Token);
+        await _blobClient.Received(1).ListContainersSegmentedAsync(null, ContainerListingDetails.None, 1, null, null, null, tokenSource.Token);
+        await _queueClient.Received(0).ListQueuesSegmentedAsync(null, QueueListingDetails.None, 1, null, null, null, tokenSource.Token);
+        await _tableClient.Received(0).ListTablesSegmentedAsync(null, 1, null, null, null, tokenSource.Token);
     }
 
     [Fact]
@@ -53,16 +53,15 @@ public class DurableTaskHealthCheckTests
     {
         using var tokenSource = new CancellationTokenSource();
 
-
-        _blobClient.GetServicePropertiesAsync(null, null, tokenSource.Token).Returns(Task.FromResult(new ServiceProperties()));
-        _queueClient.GetServicePropertiesAsync(null, null, tokenSource.Token).Returns(Task.FromException<ServiceProperties>(new IOException()));
-        _tableClient.GetServicePropertiesAsync(null, null, tokenSource.Token).Returns(Task.FromResult(new ServiceProperties()));
+        _blobClient.ListContainersSegmentedAsync(null, ContainerListingDetails.None, 1, null, null, null, tokenSource.Token).Returns(Task.FromResult<ContainerResultSegment>(null));
+        _queueClient.ListQueuesSegmentedAsync(null, QueueListingDetails.None, 1, null, null, null, tokenSource.Token).Returns(Task.FromException<QueueResultSegment>(new IOException()));
+        _tableClient.ListTablesSegmentedAsync(null, 1, null, null, null, tokenSource.Token).Returns(Task.FromResult<TableResultSegment>(null));
 
         await Assert.ThrowsAsync<IOException>(() => _healthCheck.CheckHealthAsync(new HealthCheckContext(), tokenSource.Token));
 
-        await _blobClient.Received(1).GetServicePropertiesAsync(null, null, tokenSource.Token);
-        await _queueClient.Received(1).GetServicePropertiesAsync(null, null, tokenSource.Token);
-        await _tableClient.Received(0).GetServicePropertiesAsync(null, null, tokenSource.Token);
+        await _blobClient.Received(1).ListContainersSegmentedAsync(null, ContainerListingDetails.None, 1, null, null, null, tokenSource.Token);
+        await _queueClient.Received(1).ListQueuesSegmentedAsync(null, QueueListingDetails.None, 1, null, null, null, tokenSource.Token);
+        await _tableClient.Received(0).ListTablesSegmentedAsync(null, 1, null, null, null, tokenSource.Token);
     }
 
     [Fact]
@@ -70,15 +69,15 @@ public class DurableTaskHealthCheckTests
     {
         using var tokenSource = new CancellationTokenSource();
 
-        _blobClient.GetServicePropertiesAsync(null, null, tokenSource.Token).Returns(Task.FromResult(new ServiceProperties()));
-        _queueClient.GetServicePropertiesAsync(null, null, tokenSource.Token).Returns(Task.FromResult(new ServiceProperties()));
-        _tableClient.GetServicePropertiesAsync(null, null, tokenSource.Token).Returns(Task.FromException<ServiceProperties>(new IOException()));
+        _blobClient.ListContainersSegmentedAsync(null, ContainerListingDetails.None, 1, null, null, null, tokenSource.Token).Returns(Task.FromResult<ContainerResultSegment>(null));
+        _queueClient.ListQueuesSegmentedAsync(null, QueueListingDetails.None, 1, null, null, null, tokenSource.Token).Returns(Task.FromResult<QueueResultSegment>(null));
+        _tableClient.ListTablesSegmentedAsync(null, 1, null, null, null, tokenSource.Token).Returns(Task.FromException<TableResultSegment>(new IOException()));
 
         await Assert.ThrowsAsync<IOException>(() => _healthCheck.CheckHealthAsync(new HealthCheckContext(), tokenSource.Token));
 
-        await _blobClient.Received(1).GetServicePropertiesAsync(null, null, tokenSource.Token);
-        await _queueClient.Received(1).GetServicePropertiesAsync(null, null, tokenSource.Token);
-        await _tableClient.Received(1).GetServicePropertiesAsync(null, null, tokenSource.Token);
+        await _blobClient.Received(1).ListContainersSegmentedAsync(null, ContainerListingDetails.None, 1, null, null, null, tokenSource.Token);
+        await _queueClient.Received(1).ListQueuesSegmentedAsync(null, QueueListingDetails.None, 1, null, null, null, tokenSource.Token);
+        await _tableClient.Received(1).ListTablesSegmentedAsync(null, 1, null, null, null, tokenSource.Token);
     }
 
     [Fact]
@@ -86,15 +85,15 @@ public class DurableTaskHealthCheckTests
     {
         using var tokenSource = new CancellationTokenSource();
 
-        _blobClient.GetServicePropertiesAsync(null, null, tokenSource.Token).Returns(Task.FromResult(new ServiceProperties()));
-        _queueClient.GetServicePropertiesAsync(null, null, tokenSource.Token).Returns(Task.FromResult(new ServiceProperties()));
-        _tableClient.GetServicePropertiesAsync(null, null, tokenSource.Token).Returns(Task.FromResult(new ServiceProperties()));
+        _blobClient.ListContainersSegmentedAsync(null, ContainerListingDetails.None, 1, null, null, null, tokenSource.Token).Returns(Task.FromResult<ContainerResultSegment>(null));
+        _queueClient.ListQueuesSegmentedAsync(null, QueueListingDetails.None, 1, null, null, null, tokenSource.Token).Returns(Task.FromResult<QueueResultSegment>(null));
+        _tableClient.ListTablesSegmentedAsync(null, 1, null, null, null, tokenSource.Token).Returns(Task.FromResult<TableResultSegment>(null));
 
         HealthCheckResult actual = await _healthCheck.CheckHealthAsync(new HealthCheckContext(), tokenSource.Token);
 
-        await _blobClient.Received(1).GetServicePropertiesAsync(null, null, tokenSource.Token);
-        await _queueClient.Received(1).GetServicePropertiesAsync(null, null, tokenSource.Token);
-        await _tableClient.Received(1).GetServicePropertiesAsync(null, null, tokenSource.Token);
+        await _blobClient.Received(1).ListContainersSegmentedAsync(null, ContainerListingDetails.None, 1, null, null, null, tokenSource.Token);
+        await _queueClient.Received(1).ListQueuesSegmentedAsync(null, QueueListingDetails.None, 1, null, null, null, tokenSource.Token);
+        await _tableClient.Received(1).ListTablesSegmentedAsync(null, 1, null, null, null, tokenSource.Token);
 
         Assert.Equal(HealthStatus.Healthy, actual.Status);
     }

--- a/src/Microsoft.Health.Dicom.Functions.Client.UnitTests/Microsoft.Health.Dicom.Functions.Client.UnitTests.csproj
+++ b/src/Microsoft.Health.Dicom.Functions.Client.UnitTests/Microsoft.Health.Dicom.Functions.Client.UnitTests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NSubstitute" />
+    <PackageReference Include="WindowsAzure.Storage" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Microsoft.Health.Dicom.Functions.Client/HealthChecks/DurableTaskHealthCheck.cs
+++ b/src/Microsoft.Health.Dicom.Functions.Client/HealthChecks/DurableTaskHealthCheck.cs
@@ -3,28 +3,53 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using DurableTask.AzureStorage;
+using DurableTask.Core;
 using EnsureThat;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask.ContextImplementations;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
-using Microsoft.Health.Dicom.Core.Features.Common;
-using Microsoft.Health.Operations;
+using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.WindowsAzure.Storage.Queue;
+using Microsoft.WindowsAzure.Storage.Table;
 
 namespace Microsoft.Health.Dicom.Functions.Client.HealthChecks;
 
 internal sealed class DurableTaskHealthCheck : IHealthCheck
 {
-    private readonly IDurableClient _client;
-    private readonly IGuidFactory _guidFactory;
+    private readonly string _taskHubName;
+    private readonly CloudBlobClient _blobClient;
+    private readonly CloudQueueClient _queueClient;
+    private readonly CloudTableClient _tableClient;
     private readonly ILogger _logger;
 
-    public DurableTaskHealthCheck(IDurableClientFactory factory, IGuidFactory guidFactory, ILogger<DurableTaskHealthCheck> logger)
+    // TODO: Replace this reflection-based approached with a first-class API from the DurableTask library
+    private readonly static Func<IDurableClient, CloudBlobClient> GetBlobClient = GetBodyClientAccessor();
+    private readonly static Func<IDurableClient, CloudQueueClient> GetQueueClient = GetQueueClientAccessor();
+    private readonly static Func<IDurableClient, CloudTableClient> GetTableClient = GetTableClientAccessor();
+
+    public DurableTaskHealthCheck(IDurableClientFactory factory, ILogger<DurableTaskHealthCheck> logger)
+        : this(EnsureArg.IsNotNull(factory, nameof(factory)).CreateClient(), logger)
     {
-        _client = EnsureArg.IsNotNull(factory, nameof(factory)).CreateClient();
-        _guidFactory = EnsureArg.IsNotNull(guidFactory, nameof(guidFactory));
+    }
+
+    internal DurableTaskHealthCheck(IDurableClient client, ILogger<DurableTaskHealthCheck> logger)
+        : this(client.TaskHubName, GetBlobClient(client), GetQueueClient(client), GetTableClient(client), logger)
+    {
+    }
+
+    internal DurableTaskHealthCheck(string name, CloudBlobClient blobClient, CloudQueueClient queueClient, CloudTableClient tableClient, ILogger<DurableTaskHealthCheck> logger)
+    {
+        _taskHubName = name;
+        _blobClient = EnsureArg.IsNotNull(blobClient, nameof(blobClient));
+        _queueClient = EnsureArg.IsNotNull(queueClient, nameof(queueClient));
+        _tableClient = EnsureArg.IsNotNull(tableClient, nameof(tableClient));
         _logger = EnsureArg.IsNotNull(logger, nameof(logger));
     }
 
@@ -34,20 +59,63 @@ internal sealed class DurableTaskHealthCheck : IHealthCheck
 
         await AssertTaskHubConnectionAsync(cancellationToken);
 
-        _logger.LogInformation("Successfully connected to the Durable TaskHub '{Name}.'", _client.TaskHubName);
+        _logger.LogInformation("Successfully connected to the Durable TaskHub '{Name}.'", _taskHubName);
         return HealthCheckResult.Healthy();
     }
 
-    private Task AssertTaskHubConnectionAsync(CancellationToken cancellationToken)
+    private async Task AssertTaskHubConnectionAsync(CancellationToken cancellationToken)
     {
-        cancellationToken.ThrowIfCancellationRequested();
+        await _blobClient.GetServicePropertiesAsync(null, null, cancellationToken: cancellationToken);
+        await _queueClient.GetServicePropertiesAsync(null, null, cancellationToken: cancellationToken);
+        await _tableClient.GetServicePropertiesAsync(null, null, cancellationToken: cancellationToken);
+    }
 
-        // It does not matter whether GetStatusAsync finds an orchestration. We simply want to run
-        // a relatively "cheap" query against the table storage to ensure that we can connect successfully.
-        return _client.GetStatusAsync(
-            _guidFactory.Create().ToString(OperationId.FormatSpecifier),
-            showHistory: false,
-            showHistoryOutput: false,
-            showInput: false);
+    private static Func<IDurableClient, CloudBlobClient> GetBodyClientAccessor()
+    {
+        FieldInfo blobClientField = typeof(AzureStorageOrchestrationService).Assembly
+            .GetType("DurableTask.AzureStorage.Storage.AzureStorageClient")
+            .GetField("blobClient", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        ParameterExpression param = Expression.Parameter(typeof(IDurableClient), "client");
+        Expression body = Expression.MakeMemberAccess(GetAzureStorageClientExpression(param), blobClientField);
+        return Expression.Lambda<Func<IDurableClient, CloudBlobClient>>(body, param).Compile();
+    }
+
+    private static Func<IDurableClient, CloudQueueClient> GetQueueClientAccessor()
+    {
+        FieldInfo queueClientField = typeof(AzureStorageOrchestrationService).Assembly
+            .GetType("DurableTask.AzureStorage.Storage.AzureStorageClient")
+            .GetField("queueClient", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        ParameterExpression param = Expression.Parameter(typeof(IDurableClient), "client");
+        Expression body = Expression.MakeMemberAccess(GetAzureStorageClientExpression(param), queueClientField);
+        return Expression.Lambda<Func<IDurableClient, CloudQueueClient>>(body, param).Compile();
+    }
+
+    private static Func<IDurableClient, CloudTableClient> GetTableClientAccessor()
+    {
+        FieldInfo tableClientField = typeof(AzureStorageOrchestrationService).Assembly
+            .GetType("DurableTask.AzureStorage.Storage.AzureStorageClient")
+            .GetField("tableClient", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        ParameterExpression param = Expression.Parameter(typeof(IDurableClient), "client");
+        Expression body = Expression.MakeMemberAccess(GetAzureStorageClientExpression(param), tableClientField);
+        return Expression.Lambda<Func<IDurableClient, CloudTableClient>>(body, param).Compile();
+    }
+
+    private static Expression GetAzureStorageClientExpression(ParameterExpression param)
+    {
+        Type clientType = typeof(IDurableClient).Assembly.GetType("Microsoft.Azure.WebJobs.Extensions.DurableTask.DurableClient");
+        FieldInfo clientField = clientType.GetField("client", BindingFlags.NonPublic | BindingFlags.Instance);
+        PropertyInfo propertyInfo = typeof(TaskHubClient).GetProperty(nameof(TaskHubClient.ServiceClient));
+        FieldInfo storageClientField = typeof(AzureStorageOrchestrationService).GetField("azureStorageClient", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        return Expression.MakeMemberAccess(
+            Expression.Convert(
+                Expression.MakeMemberAccess(
+                Expression.MakeMemberAccess(Expression.Convert(param, clientType), clientField),
+                propertyInfo),
+                typeof(AzureStorageOrchestrationService)),
+            storageClientField);
     }
 }

--- a/src/Microsoft.Health.Dicom.Functions.Client/Microsoft.Health.Dicom.Functions.Client.csproj
+++ b/src/Microsoft.Health.Dicom.Functions.Client/Microsoft.Health.Dicom.Functions.Client.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.Health.Operations.Functions" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.Linq.Async" />
+    <PackageReference Include="WindowsAzure.Storage" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
Refactor the Durable Task health check to validate Azure Blob, Queue, and Table service connections

## Related issues
[AB#94982](https://microsofthealth.visualstudio.com/Health/_workitems/edit/94982)

## Testing
Refactored tests
