### PR TITLE
Throw 400 on quotes character in query filter condition with fuzzymatch

### DIFF
--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Query/QueryParserTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Query/QueryParserTests.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -91,6 +91,15 @@ public class QueryParserTests
         Assert.Throws<QueryParseException>(() => _queryParser
             .Parse(CreateParameters(GetSingleton(key, value), QueryResource.AllStudies), QueryTagService.CoreQueryTags));
     }
+
+    [Theory]
+    [InlineData("PatientName", "joe\"s")]
+    public void GivenFilterCondition_InvalidFuzzyMatchTagValue_Throws(string key, string value)
+    {
+        Assert.Throws<QueryParseException>(() => _queryParser
+            .Parse(CreateParameters(GetSingleton(key, value), QueryResource.AllStudies, null, null, true), QueryTagService.CoreQueryTags));
+    }
+
 
     [Theory]
     [InlineData("00100010", "joe")]

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.Designer.cs
@@ -714,6 +714,15 @@ namespace Microsoft.Health.Dicom.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid query: specified tag &apos;{0}&apos; value &apos;{1}&apos; contains unsupported character &apos;{2}&apos;. Character is not supported with Fuzzy match, try exact match or removing the invalid character. .
+        /// </summary>
+        internal static string InvalidTagValueWithFuzzyMatch {
+            get {
+                return ResourceManager.GetString("InvalidTagValueWithFuzzyMatch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid query: specified date range &apos;{0}&apos; is invalid.
         ///The first part time {1} should be lesser than or equal to the second part time {2}..
         /// </summary>

--- a/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
+++ b/src/Microsoft.Health.Dicom.Core/DicomCoreResource.resx
@@ -627,4 +627,8 @@ For details on valid range queries, please refer to Search Matching section in C
   <data name="UnsupportedBuffering" xml:space="preserve">
     <value>Cannot buffer items if parallelism is unbounded.</value>
   </data>
+  <data name="InvalidTagValueWithFuzzyMatch" xml:space="preserve">
+    <value>Invalid query: specified tag '{0}' value '{1}' contains unsupported character '{2}'. Character is not supported with Fuzzy match, try exact match or removing the invalid character. </value>
+    <comment>{0} Dicom Tag name, {1} Tag value to search. {2} Unsupported character.</comment>
+  </data>
 </root>

--- a/src/Microsoft.Health.Dicom.Core/Features/Query/QueryParser.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Query/QueryParser.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -129,18 +129,12 @@ public class QueryParser : BaseQueryParser<QueryExpression, QueryParameters>
             throw new QueryParseException(string.Format(CultureInfo.CurrentCulture, DicomCoreResource.QueryEmptyAttributeValue, queryParameter.Key));
         }
 
-        if (!ValueParsers.TryGetValue(queryTag.VR, out Func<QueryTag, string, QueryFilterCondition> valueParser))
+        if (!TryGetValueParser(queryTag, fuzzyMatching, out Func<QueryTag, string, QueryFilterCondition> valueParser))
         {
             return false;
         }
 
         condition = valueParser(queryTag, queryParameter.Value);
-        if (fuzzyMatching && QueryLimit.IsValidFuzzyMatchingQueryTag(queryTag))
-        {
-            var s = condition as StringSingleValueMatchCondition;
-            condition = new PersonNameFuzzyMatchCondition(s.QueryTag, s.Value);
-        }
-
         return true;
     }
 

--- a/src/Microsoft.Health.Dicom.Core/Features/Workitem/WorkitemQueryParser.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Workitem/WorkitemQueryParser.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -76,18 +76,12 @@ public class WorkitemQueryParser : BaseQueryParser<BaseQueryExpression, BaseQuer
             throw new QueryParseException(string.Format(CultureInfo.CurrentCulture, DicomCoreResource.QueryEmptyAttributeValue, queryParameter.Key));
         }
 
-        if (!ValueParsers.TryGetValue(queryTag.VR, out Func<QueryTag, string, QueryFilterCondition> valueParser))
+        if (!TryGetValueParser(queryTag, fuzzyMatching, out Func<QueryTag, string, QueryFilterCondition> valueParser))
         {
             return false;
         }
 
         condition = valueParser(queryTag, queryParameter.Value);
-        if (fuzzyMatching && QueryLimit.IsValidFuzzyMatchingQueryTag(queryTag))
-        {
-            var s = condition as StringSingleValueMatchCondition;
-            condition = new PersonNameFuzzyMatchCondition(s.QueryTag, s.Value);
-        }
-
         return true;
     }
 


### PR DESCRIPTION
## Description
Qido query with PatienName=Thoma"s&FuzzyMatching=True throws 500 error

This because double quote is a invalid char in any fuzzy matching(word or phrase) in SQL.
Since this a fuzzy matching it needs to be a word or phrase and we should not replace the quote with any character.
 
Error will recommend customer to do exact match or try a simple word with fuzzy match. Which will help the customer to have better success.

## Related issues
[AB#96513](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/96513)

## Testing
Unit test added
