### PR TITLE
Move wado resource get without transcoding to new blob network api to reduce buffer copy and possible reduce cpu cycle

### DIFF
--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveResourceServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveResourceServiceTests.cs
@@ -104,6 +104,7 @@ public class RetrieveResourceServiceTests
     public async Task GivenStoredInstancesWhereOneIsMissingFile_WhenRetrieveRequestForStudy_ThenNotFoundIsThrown()
     {
         List<InstanceMetadata> instances = SetupInstanceIdentifiersList(ResourceType.Study);
+        _fileStore.GetFilePropertiesAsync(Arg.Any<VersionedInstanceIdentifier>(), DefaultCancellationToken).Returns(new FileProperties() { ContentLength = 1000 });
 
         // For each instance identifier but the last, set up the fileStore to return a stream containing a file associated with the identifier.
         // For each instance identifier but the last, set up the fileStore to return a stream containing a file associated with the identifier.
@@ -134,6 +135,7 @@ public class RetrieveResourceServiceTests
         var streamsAndStoredFiles = versionedInstanceIdentifiers.Select(
             x => StreamAndStoredFileFromDataset(GenerateDatasetsFromIdentifiers(x.VersionedInstanceIdentifier)).Result).ToList();
 
+        _fileStore.GetFilePropertiesAsync(Arg.Any<VersionedInstanceIdentifier>(), DefaultCancellationToken).Returns(new FileProperties() { ContentLength = 1000 });
         streamsAndStoredFiles.ForEach(x => _fileStore.GetStreamingFileAsync(x.Key.Dataset.ToVersionedInstanceIdentifier(0), DefaultCancellationToken).Returns(x.Value));
 
         RetrieveResourceResponse response = await _retrieveResourceService.GetInstanceResourceAsync(
@@ -197,6 +199,7 @@ public class RetrieveResourceServiceTests
     public async Task GivenStoredInstancesWhereOneIsMissingFile_WhenRetrieveRequestForSeries_ThenNotFoundIsThrown()
     {
         List<InstanceMetadata> versionedInstanceIdentifiers = SetupInstanceIdentifiersList(ResourceType.Series);
+        _fileStore.GetFilePropertiesAsync(Arg.Any<VersionedInstanceIdentifier>(), DefaultCancellationToken).Returns(new FileProperties() { ContentLength = 1000 });
 
         // For each instance identifier but the last, set up the fileStore to return a stream containing a file associated with the identifier.
         for (int i = 0; i < versionedInstanceIdentifiers.Count - 1; i++)
@@ -227,6 +230,7 @@ public class RetrieveResourceServiceTests
             .Select(x => StreamAndStoredFileFromDataset(GenerateDatasetsFromIdentifiers(x.VersionedInstanceIdentifier)).Result)
             .ToList();
 
+        _fileStore.GetFilePropertiesAsync(Arg.Any<VersionedInstanceIdentifier>(), DefaultCancellationToken).Returns(new FileProperties() { ContentLength = 1000 });
         streamsAndStoredFiles.ForEach(x => _fileStore.GetStreamingFileAsync(x.Key.Dataset.ToVersionedInstanceIdentifier(0), DefaultCancellationToken).Returns(x.Value));
 
         RetrieveResourceResponse response = await _retrieveResourceService.GetInstanceResourceAsync(
@@ -282,6 +286,7 @@ public class RetrieveResourceServiceTests
         // Add multiple instances to validate that we return the requested instance and ignore the other(s).
         List<InstanceMetadata> versionedInstanceIdentifiers = SetupInstanceIdentifiersList(ResourceType.Instance);
 
+        _fileStore.GetFilePropertiesAsync(Arg.Any<VersionedInstanceIdentifier>(), DefaultCancellationToken).Returns(new FileProperties() { ContentLength = 1000 });
         // For the first instance identifier, set up the fileStore to return a stream containing a file associated with the identifier.
         KeyValuePair<DicomFile, Stream> streamAndStoredFile = StreamAndStoredFileFromDataset(GenerateDatasetsFromIdentifiers(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier)).Result;
         _fileStore.GetStreamingFileAsync(streamAndStoredFile.Key.Dataset.ToVersionedInstanceIdentifier(0), DefaultCancellationToken).Returns(streamAndStoredFile.Value);

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveResourceServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveResourceServiceTests.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -111,12 +111,12 @@ public class RetrieveResourceServiceTests
         {
             InstanceMetadata instance = instances[i];
             KeyValuePair<DicomFile, Stream> stream = await StreamAndStoredFileFromDataset(GenerateDatasetsFromIdentifiers(instance.VersionedInstanceIdentifier), frames: 0, disposeStreams: false);
-            _fileStore.GetFileAsync(instance.VersionedInstanceIdentifier, DefaultCancellationToken).Returns(stream.Value);
+            _fileStore.GetStreamingFileAsync(instance.VersionedInstanceIdentifier, DefaultCancellationToken).Returns(stream.Value);
             _retrieveTranscoder.TranscodeFileAsync(stream.Value, "*").Returns(stream.Value);
         }
 
         // For the last identifier, set up the fileStore to throw a store exception with the status code 404 (NotFound).
-        _fileStore.GetFileAsync(instances.Last().VersionedInstanceIdentifier, DefaultCancellationToken).Throws(new InstanceNotFoundException());
+        _fileStore.GetStreamingFileAsync(instances.Last().VersionedInstanceIdentifier, DefaultCancellationToken).Throws(new InstanceNotFoundException());
 
         var response = await _retrieveResourceService.GetInstanceResourceAsync(
                                 new RetrieveResourceRequest(_studyInstanceUid, new[] { AcceptHeaderHelpers.CreateAcceptHeaderForGetStudy() }),
@@ -134,7 +134,7 @@ public class RetrieveResourceServiceTests
         var streamsAndStoredFiles = versionedInstanceIdentifiers.Select(
             x => StreamAndStoredFileFromDataset(GenerateDatasetsFromIdentifiers(x.VersionedInstanceIdentifier)).Result).ToList();
 
-        streamsAndStoredFiles.ForEach(x => _fileStore.GetFileAsync(x.Key.Dataset.ToVersionedInstanceIdentifier(0), DefaultCancellationToken).Returns(x.Value));
+        streamsAndStoredFiles.ForEach(x => _fileStore.GetStreamingFileAsync(x.Key.Dataset.ToVersionedInstanceIdentifier(0), DefaultCancellationToken).Returns(x.Value));
 
         RetrieveResourceResponse response = await _retrieveResourceService.GetInstanceResourceAsync(
                new RetrieveResourceRequest(_studyInstanceUid, new[] { AcceptHeaderHelpers.CreateAcceptHeaderForGetStudy() }),
@@ -203,12 +203,12 @@ public class RetrieveResourceServiceTests
         {
             InstanceMetadata instance = versionedInstanceIdentifiers[i];
             KeyValuePair<DicomFile, Stream> stream = await StreamAndStoredFileFromDataset(GenerateDatasetsFromIdentifiers(instance.VersionedInstanceIdentifier), frames: 0, disposeStreams: false);
-            _fileStore.GetFileAsync(instance.VersionedInstanceIdentifier, DefaultCancellationToken).Returns(stream.Value);
+            _fileStore.GetStreamingFileAsync(instance.VersionedInstanceIdentifier, DefaultCancellationToken).Returns(stream.Value);
             _retrieveTranscoder.TranscodeFileAsync(stream.Value, "*").Returns(stream.Value);
         }
 
         // For the last identifier, set up the fileStore to throw a store exception with the status code 404 (NotFound).
-        _fileStore.GetFileAsync(versionedInstanceIdentifiers.Last().VersionedInstanceIdentifier, DefaultCancellationToken).Throws(new InstanceNotFoundException());
+        _fileStore.GetStreamingFileAsync(versionedInstanceIdentifiers.Last().VersionedInstanceIdentifier, DefaultCancellationToken).Throws(new InstanceNotFoundException());
 
         var response = await _retrieveResourceService.GetInstanceResourceAsync(
                                 new RetrieveResourceRequest(_studyInstanceUid, _firstSeriesInstanceUid, new[] { AcceptHeaderHelpers.CreateAcceptHeaderForGetSeries() }),
@@ -227,7 +227,7 @@ public class RetrieveResourceServiceTests
             .Select(x => StreamAndStoredFileFromDataset(GenerateDatasetsFromIdentifiers(x.VersionedInstanceIdentifier)).Result)
             .ToList();
 
-        streamsAndStoredFiles.ForEach(x => _fileStore.GetFileAsync(x.Key.Dataset.ToVersionedInstanceIdentifier(0), DefaultCancellationToken).Returns(x.Value));
+        streamsAndStoredFiles.ForEach(x => _fileStore.GetStreamingFileAsync(x.Key.Dataset.ToVersionedInstanceIdentifier(0), DefaultCancellationToken).Returns(x.Value));
 
         RetrieveResourceResponse response = await _retrieveResourceService.GetInstanceResourceAsync(
                new RetrieveResourceRequest(
@@ -266,7 +266,7 @@ public class RetrieveResourceServiceTests
         List<InstanceMetadata> versionedInstanceIdentifiers = SetupInstanceIdentifiersList(ResourceType.Instance);
 
         // For the first instance identifier, set up the fileStore to throw a store exception with the status code 404 (NotFound).
-        _fileStore.GetFileAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier, DefaultCancellationToken).Throws(new InstanceNotFoundException());
+        _fileStore.GetStreamingFileAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier, DefaultCancellationToken).Throws(new InstanceNotFoundException());
 
         var response = await _retrieveResourceService.GetInstanceResourceAsync(
                     new RetrieveResourceRequest(_studyInstanceUid, _firstSeriesInstanceUid, _sopInstanceUid, new[] { AcceptHeaderHelpers.CreateAcceptHeaderForGetInstance() }),
@@ -284,7 +284,7 @@ public class RetrieveResourceServiceTests
 
         // For the first instance identifier, set up the fileStore to return a stream containing a file associated with the identifier.
         KeyValuePair<DicomFile, Stream> streamAndStoredFile = StreamAndStoredFileFromDataset(GenerateDatasetsFromIdentifiers(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier)).Result;
-        _fileStore.GetFileAsync(streamAndStoredFile.Key.Dataset.ToVersionedInstanceIdentifier(0), DefaultCancellationToken).Returns(streamAndStoredFile.Value);
+        _fileStore.GetStreamingFileAsync(streamAndStoredFile.Key.Dataset.ToVersionedInstanceIdentifier(0), DefaultCancellationToken).Returns(streamAndStoredFile.Value);
 
         RetrieveResourceResponse response = await _retrieveResourceService.GetInstanceResourceAsync(
                new RetrieveResourceRequest(
@@ -406,6 +406,7 @@ public class RetrieveResourceServiceTests
         var streamsAndStoredFiles = versionedInstanceIdentifiers.Select(
             x => StreamAndStoredFileFromDataset(GenerateDatasetsFromIdentifiers(x.VersionedInstanceIdentifier, originalTransferSyntax)).Result).ToList();
         streamsAndStoredFiles.ForEach(x => _fileStore.GetFileAsync(x.Key.Dataset.ToVersionedInstanceIdentifier(0), DefaultCancellationToken).Returns(x.Value));
+        streamsAndStoredFiles.ForEach(x => _fileStore.GetStreamingFileAsync(x.Key.Dataset.ToVersionedInstanceIdentifier(0), DefaultCancellationToken).Returns(x.Value));
         _fileStore.GetFilePropertiesAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier, DefaultCancellationToken).Returns(new FileProperties() { ContentLength = streamsAndStoredFiles.First().Value.Length });
         streamsAndStoredFiles.ForEach(x => _retrieveTranscoder.TranscodeFileAsync(x.Value, requestedTransferSyntax).Returns(x.Value));
 
@@ -484,6 +485,7 @@ public class RetrieveResourceServiceTests
         var streamsAndStoredFiles = versionedInstanceIdentifiers.Select(
             x => StreamAndStoredFileFromDataset(GenerateDatasetsFromIdentifiers(x.VersionedInstanceIdentifier, originalTransferSyntax)).Result).ToList();
         streamsAndStoredFiles.ForEach(x => _fileStore.GetFileAsync(x.Key.Dataset.ToVersionedInstanceIdentifier(0), DefaultCancellationToken).Returns(x.Value));
+        streamsAndStoredFiles.ForEach(x => _fileStore.GetStreamingFileAsync(x.Key.Dataset.ToVersionedInstanceIdentifier(0), DefaultCancellationToken).Returns(x.Value));
         _fileStore.GetFilePropertiesAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier, DefaultCancellationToken).Returns(new FileProperties() { ContentLength = streamsAndStoredFiles.First().Value.Length });
         _fileStore.GetFilePropertiesAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier, DefaultCancellationToken).Returns(new FileProperties() { ContentLength = streamsAndStoredFiles.First().Value.Length });
         streamsAndStoredFiles.ForEach(x => _retrieveTranscoder.TranscodeFileAsync(x.Value, requestedTransferSyntax).Returns(x.Value));

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveResourceService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveResourceService.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -283,7 +283,7 @@ public class RetrieveResourceService : IRetrieveResourceService
     {
         foreach (var instanceMetadata in instanceMetadatas)
         {
-            Stream stream = await _blobDataStore.GetFileAsync(instanceMetadata.VersionedInstanceIdentifier, cancellationToken);
+            Stream stream = await _blobDataStore.GetStreamingFileAsync(instanceMetadata.VersionedInstanceIdentifier, cancellationToken);
             yield return
                 new RetrieveResourceInstance(
                     stream,

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveResourceService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveResourceService.cs
@@ -283,12 +283,13 @@ public class RetrieveResourceService : IRetrieveResourceService
     {
         foreach (var instanceMetadata in instanceMetadatas)
         {
+            FileProperties fileProperties = await _blobDataStore.GetFilePropertiesAsync(instanceMetadata.VersionedInstanceIdentifier, cancellationToken);
             Stream stream = await _blobDataStore.GetStreamingFileAsync(instanceMetadata.VersionedInstanceIdentifier, cancellationToken);
             yield return
                 new RetrieveResourceInstance(
                     stream,
                     GetResponseTransferSyntax(isOriginalTransferSyntaxRequested, requestedTransferSyntax, instanceMetadata),
-                    stream.Length);
+                    fileProperties.ContentLength);
         }
     }
 

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Features/RetrieveResourceServiceTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Features/RetrieveResourceServiceTests.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -109,7 +109,7 @@ public class RetrieveResourceServiceTests : IClassFixture<DataStoreTestsFixture>
         await Assert.ThrowsAsync<ItemNotFoundException>(() => response.GetStreamsAsync());
     }
 
-    [Fact]
+    [Fact(Skip = "Fix getting stream")]
     public async Task GivenStoredInstances_WhenRetrieveRequestForStudy_ThenInstancesInStudyAreRetrievedSuccesfully()
     {
         var datasets = new List<DicomDataset>();
@@ -144,7 +144,7 @@ public class RetrieveResourceServiceTests : IClassFixture<DataStoreTestsFixture>
         await Assert.ThrowsAsync<ItemNotFoundException>(() => response.GetStreamsAsync());
     }
 
-    [Fact]
+    [Fact(Skip = "Fix getting stream")]
     public async Task GivenStoredInstances_WhenRetrieveRequestForSeries_ThenInstancesInSeriesAreRetrievedSuccesfully()
     {
         var datasets = new List<DicomDataset>();
@@ -210,7 +210,15 @@ public class RetrieveResourceServiceTests : IClassFixture<DataStoreTestsFixture>
         IEnumerable<Stream> responseStreams,
         IEnumerable<DicomDataset> expectedDatasets)
     {
-        var responseDicomFiles = responseStreams.Select(x => DicomFile.Open(x)).ToList();
+        var realizedStreams = new List<Stream>();
+        foreach (var responseStream in responseStreams)
+        {
+            MemoryStream memoryStream = _recyclableMemoryStreamManager.GetStream();
+            responseStream.CopyTo(memoryStream);
+            realizedStreams.Add(memoryStream);
+        }
+
+        var responseDicomFiles = realizedStreams.Select(x => DicomFile.Open(x)).ToList();
 
         Assert.Equal(expectedDatasets.Count(), responseDicomFiles.Count);
 

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Features/RetrieveResourceServiceTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Features/RetrieveResourceServiceTests.cs
@@ -109,7 +109,7 @@ public class RetrieveResourceServiceTests : IClassFixture<DataStoreTestsFixture>
         await Assert.ThrowsAsync<ItemNotFoundException>(() => response.GetStreamsAsync());
     }
 
-    [Fact(Skip = "Fix getting stream")]
+    [Fact]
     public async Task GivenStoredInstances_WhenRetrieveRequestForStudy_ThenInstancesInStudyAreRetrievedSuccesfully()
     {
         var datasets = new List<DicomDataset>();
@@ -144,7 +144,7 @@ public class RetrieveResourceServiceTests : IClassFixture<DataStoreTestsFixture>
         await Assert.ThrowsAsync<ItemNotFoundException>(() => response.GetStreamsAsync());
     }
 
-    [Fact(Skip = "Fix getting stream")]
+    [Fact]
     public async Task GivenStoredInstances_WhenRetrieveRequestForSeries_ThenInstancesInSeriesAreRetrievedSuccesfully()
     {
         var datasets = new List<DicomDataset>();
@@ -215,6 +215,7 @@ public class RetrieveResourceServiceTests : IClassFixture<DataStoreTestsFixture>
         {
             MemoryStream memoryStream = _recyclableMemoryStreamManager.GetStream();
             responseStream.CopyTo(memoryStream);
+            memoryStream.Position = 0;
             realizedStreams.Add(memoryStream);
         }
 


### PR DESCRIPTION
## Description
Based on the doc https://github.com/microsoft/dicom-server/blob/main/src/Microsoft.Health.Dicom.Blob/AzureBlobAPIs.md

## Related issues
[AB#96577](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/96577)

## Testing
Existing tests pass.
