### PR TITLE
Handle dbNull for Cleanup operation

### DIFF
--- a/src/Microsoft.Health.Dicom.SqlServer/Features/ChangeFeed/SqlChangeFeedStoreV24.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/ChangeFeed/SqlChangeFeedStoreV24.cs
@@ -76,6 +76,8 @@ internal class SqlChangeFeedStoreV24 : SqlChangeFeedStoreV6
         using SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand();
 
         VLatest.GetMaxDeletedChangeFeedWatermark.PopulateCommand(sqlCommandWrapper, timeStamp);
-        return (long)(await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken));
+        var maxSequence = (long?)(await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken));
+
+        return maxSequence.GetValueOrDefault();
     }
 }


### PR DESCRIPTION
## Description
Handle dbNull for cleanup operation. 

This PR changes doesn't affect the existing but checking in to have bug free code.

## Related issues
Addresses [issue [AB#98482](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/98482)].

## Testing
Describe how this change was tested.
