### PR TITLE
Disabling warning for System.CommandLine

### DIFF
--- a/tools/file-generator-tool/Microsoft.Health.Dicom.FileGenerator/Microsoft.Health.Dicom.FileGenerator.csproj
+++ b/tools/file-generator-tool/Microsoft.Health.Dicom.FileGenerator/Microsoft.Health.Dicom.FileGenerator.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <TargetFramework>$(LatestVersion)</TargetFramework>


### PR DESCRIPTION
## Description
Following the existing pattern, we are ignoring `NU5104` in order to use System.CommandLine in tools that aren't part of the main service.