### PR TITLE
Catching task cancelled exceptions from WindowsAzure.Storage

### DIFF
--- a/src/Microsoft.Health.Dicom.Functions.Client/HealthChecks/DurableTaskHealthCheck.cs
+++ b/src/Microsoft.Health.Dicom.Functions.Client/HealthChecks/DurableTaskHealthCheck.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using DurableTask.AzureStorage;
@@ -58,7 +59,21 @@ internal sealed class DurableTaskHealthCheck : IHealthCheck
     {
         EnsureArg.IsNotNull(context, nameof(context));
 
-        await AssertTaskHubConnectionAsync(cancellationToken);
+        try
+        {
+            await AssertTaskHubConnectionAsync(cancellationToken);
+        }
+        catch (WindowsAzure.Storage.StorageException ex) when (cancellationToken.IsCancellationRequested && ex.InnerException is OperationCanceledException)
+        {
+            // Cancelled storage operations sometimes throw a StorageException wrapping an OperationCanceledException (or the child TaskCanceledException):
+            // https://github.com/Azure/azure-storage-net/issues/512
+            // The Azure Webjobs framework catches these exceptions (https://github.com/Azure/azure-webjobs-sdk/pull/1273) but we encounter this
+            // case because we use the DurableTask clients directly via reflection. Here we throw the inner exception, which is expected by ASP.NET Core's DefaultHealthCheckService:
+            // https://github.com/dotnet/aspnetcore/blob/9cbf44b7c192cf064a82934bbf479a93a1953c26/src/HealthChecks/HealthChecks/src/DefaultHealthCheckService.cs#L121,
+            // while maintaining the stack trace of the inner exception:
+            // https://learn.microsoft.com/en-us/archive/msdn-magazine/2015/november/essential-net-csharp-exception-handling#throwing-existing-exceptions-without-replacing-stack-information.
+            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+        }
 
         _logger.LogInformation("Successfully connected to the Durable TaskHub '{Name}.'", _taskHubName);
         return HealthCheckResult.Healthy("Successfully connected.");


### PR DESCRIPTION
## Description
Cancelled storage operations [sometimes throw](https://github.com/Azure/azure-storage-net/issues/512) a StorageException wrapping an OperationCanceledException (or the child TaskCanceledException).
The Azure Webjobs framework [catches these exceptions](https://github.com/Azure/azure-webjobs-sdk/pull/1273) but we encounter this case because we use the DurableTask clients directly via reflection. 

Here we throw the inner exception, which is [expected by ASP.NET Core's DefaultHealthCheckService](https://github.com/dotnet/aspnetcore/blob/9cbf44b7c192cf064a82934bbf479a93a1953c26/src/HealthChecks/HealthChecks/src/DefaultHealthCheckService.cs#L121), while [maintaining the stack trace of the inner exception](https://learn.microsoft.com/en-us/archive/msdn-magazine/2015/november/essential-net-csharp-exception-handling#throwing-existing-exceptions-without-replacing-stack-information).

## Related issues
Addresses [[AB#98973](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/98973)].

## Testing
Existing unit tests pass.