### PR TITLE
Handle DBNull to fix log issues

### DIFF
--- a/src/Microsoft.Health.Dicom.SqlServer/Features/ChangeFeed/SqlChangeFeedStoreV24.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/ChangeFeed/SqlChangeFeedStoreV24.cs
@@ -76,8 +76,8 @@ internal class SqlChangeFeedStoreV24 : SqlChangeFeedStoreV6
         using SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand();
 
         VLatest.GetMaxDeletedChangeFeedWatermark.PopulateCommand(sqlCommandWrapper, timeStamp);
-        var maxSequence = (long?)(await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken));
+        var maxSequence = await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken);
 
-        return maxSequence.GetValueOrDefault();
+        return maxSequence != null && maxSequence != DBNull.Value ? (long)maxSequence : default;
     }
 }


### PR DESCRIPTION
## Description
Fix DbNull issue when there is no watermark in changefeed table. The operation won't be executed but just keeping the code clean

## Related issues
Addresses [issue [AB#98482](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/98482)].

## Testing
Describe how this change was tested.
