### PR TITLE
fix value for poly check for app insights dummy instrumentation key

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       AzureWebJobsStorage: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;QueueEndpoint=http://azurite:10001/devstoreaccount1;TableEndpoint=http://azurite:10002/devstoreaccount1;"
       AZURE_FUNCTIONS_ENVIRONMENT: "Development"
       WEBSITE_HOSTNAME: "localhost:8080"
-      APPINSIGHTS_INSTRUMENTATIONKEY: "00000000-0000-0000-0000-000000000000" # necessary value placeholder to get host to configure telemetry client even when just running locally
+      APPINSIGHTS_INSTRUMENTATIONKEY: "00000000-0000-0000-0000-000000000000" # required to configure telemetry client even when running locally
     ports:
       - "7072:8080"
     restart: on-failure


### PR DESCRIPTION
## Description
To understand how often we have issues with validation that occurs as part of fo-dicom json de/serialization, we want to track a metric each time an error occurs.
We want to track these as metrics instead of logs to avoid having any leaking PI data as well as to be able to have long term analysis of issues that crop up.

## Related issues
Addresses [[AB#98914](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/98914)].

example of adding the key: https://techcommunity.microsoft.com/t5/fasttrack-for-azure/application-insights-telemetry-in-azure-functions/ba-p/3280138

"APPINSIGHTS_INSTRUMENTATIONKEY" is necessary for the functions host to initialize and inject the TelemetryClient: https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring?tabs=v2#enable-application-insights-integration

unfortunately, the value cannot be an empty string. The job host checks if it's null or empty and then doesn't create the client
