### PR TITLE
Fix Table Service Query

### DIFF
--- a/src/Microsoft.Health.Dicom.Functions.Client.UnitTests/TaskHub/TrackingTableTests.cs
+++ b/src/Microsoft.Health.Dicom.Functions.Client.UnitTests/TaskHub/TrackingTableTests.cs
@@ -22,7 +22,7 @@ public abstract class TrackingTableTests
     private readonly AsyncPageable<TableEntity> _asyncPageable = Substitute.For<AsyncPageable<TableEntity>>();
     private readonly IAsyncEnumerator<TableEntity> _asyncEnumerator = Substitute.For<IAsyncEnumerator<TableEntity>>();
 
-    private const string EmptyQuery = "PartitionKey eq null";
+    private const string EmptyQuery = "PartitionKey eq ''";
     private const string TaskHubName = "TestTaskHub";
 
     protected TrackingTableTests()

--- a/src/Microsoft.Health.Dicom.Functions.Client/TaskHub/TrackingTable.cs
+++ b/src/Microsoft.Health.Dicom.Functions.Client/TaskHub/TrackingTable.cs
@@ -24,9 +24,9 @@ internal abstract class TrackingTable
     public virtual async ValueTask<bool> ExistsAsync(CancellationToken cancellationToken = default)
     {
         // Note: There is no ExistsAsync method for TableClient, so instead
-        //       we'll run a query that returns no elements as PartitionKey can never be null
+        //       we'll run a query that will (probably) not return any results
         AsyncPageable<TableEntity> pageable = _tableClient.QueryAsync<TableEntity>(
-            filter: "PartitionKey eq null",
+            filter: "PartitionKey eq ''",
             maxPerPage: 1,
             cancellationToken: cancellationToken);
 

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/HealthCheckTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/HealthCheckTests.cs
@@ -1,0 +1,28 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using EnsureThat;
+using Xunit;
+
+namespace Microsoft.Health.Dicom.Web.Tests.E2E.Rest;
+
+public class HealthCheckTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
+{
+    private readonly HttpClient _client;
+
+    public HealthCheckTests(HttpIntegrationTestFixture<Startup> fixture)
+        => _client = EnsureArg.IsNotNull(fixture, nameof(fixture)).GetDicomWebClient().HttpClient;
+
+    [Fact]
+    [Trait("Category", "bvt")]
+    public async Task GivenDicomService_WhenCheckingHealth_ThenReturnHealthy()
+    {
+        HttpResponseMessage response = await _client.GetAsync("/health/check");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}


### PR DESCRIPTION
## Description
Strangely, there have been some regressions and differences between Azurite and the real Azure Table Service's OData behavior. Specifically, previous versions of Azurite accepted the query `PartitionKey eq null` while the Azure Table Service currently rejects it. This has since been fixed in the latest version. Furthermore, Azurite currently rejects the query `false` while the Azure Table Service currently accepts this query. This bug in Azurite appears to be fixed now but has yet to be unreleased.

Therefore, we'll change the query to one that is unlikely to return results, before eventually changing the query to `false` in the future once acceptable in Azurite. Furthermore, with the addition of health check tests, we'll assert the behavior in both Azurite during PRs and the real Azure Table Service in CI builds.

## Related issues
[AB#100096](https://microsofthealth.visualstudio.com/Health/_workitems/edit/100096)

## Testing
New E2E test for health checks
