### PR TITLE
Fix MI Durable Task Connections

### DIFF
--- a/src/Microsoft.Health.Dicom.Functions.Client.UnitTests/Extensions/AzureComponentFactoryExtensionsTests.cs
+++ b/src/Microsoft.Health.Dicom.Functions.Client.UnitTests/Extensions/AzureComponentFactoryExtensionsTests.cs
@@ -1,0 +1,119 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Azure.Data.Tables;
+using Azure.Storage.Blobs;
+using Azure.Storage.Queues;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Health.Dicom.Functions.Client.Extensions;
+using Xunit;
+
+namespace Microsoft.Health.Dicom.Functions.Client.UnitTests.Extensions;
+
+public class AzureComponentFactoryExtensionsTests
+{
+    private const string AccountName = "unittest";
+    private const string SectionName = "AzureWebJobsStorage";
+
+    private readonly AzureComponentFactory _factory;
+
+    public AzureComponentFactoryExtensionsTests()
+    {
+        ServiceCollection services = new ServiceCollection();
+
+        services
+            .AddLogging()
+            .AddAzureClientsCore();
+
+        _factory = services.BuildServiceProvider().GetRequiredService<AzureComponentFactory>();
+    }
+
+    [Fact]
+    public void GivenBasicConfiguration_WhenCreatingBlobServiceClient_ThenCreateClient()
+    {
+        IConfiguration config = CreateConnectionStringConfiguration(SectionName);
+        BlobServiceClient actual = _factory.CreateBlobServiceClient(config.GetSection(SectionName));
+        Assert.Equal(new Uri("http://127.0.0.1:10000/devstoreaccount1"), actual.Uri);
+    }
+
+    [Fact]
+    public void GivenBasicConfiguration_WhenCreatingQueueServiceClient_ThenCreateClient()
+    {
+        IConfiguration config = CreateConnectionStringConfiguration(SectionName);
+        QueueServiceClient actual = _factory.CreateQueueServiceClient(config.GetSection(SectionName));
+        Assert.Equal(new Uri("http://127.0.0.1:10001/devstoreaccount1"), actual.Uri);
+    }
+
+    [Fact]
+    public void GivenBasicConfiguration_WhenCreatingTableServiceClient_ThenCreateClient()
+    {
+        IConfiguration config = CreateConnectionStringConfiguration(SectionName);
+        TableServiceClient actual = _factory.CreateTableServiceClient(config.GetSection(SectionName));
+        Assert.Equal(new Uri("http://127.0.0.1:10002/devstoreaccount1"), actual.Uri);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GivenManagedIdentityConfiguration_WhenCreatingBlobServiceClient_ThenCreateClient(bool specifyServiceUri)
+    {
+        IConfiguration config = CreateManagedIdentityConfiguration(SectionName, AccountName, specifyServiceUri ? "blob" : null);
+        BlobServiceClient actual = _factory.CreateBlobServiceClient(config.GetSection(SectionName));
+        Assert.Equal(new Uri($"https://{AccountName}.blob.core.windows.net"), actual.Uri);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GivenManagedIdentityConfiguration_WhenCreatingQueueServiceClient_ThenCreateClient(bool specifyServiceUri)
+    {
+        IConfiguration config = CreateManagedIdentityConfiguration(SectionName, AccountName, specifyServiceUri ? "queue" : null);
+        QueueServiceClient actual = _factory.CreateQueueServiceClient(config.GetSection(SectionName));
+        Assert.Equal(new Uri($"https://{AccountName}.queue.core.windows.net"), actual.Uri);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GivenManagedIdentityConfiguration_WhenCreatingTableServiceClient_ThenCreateClient(bool specifyServiceUri)
+    {
+        IConfiguration config = CreateManagedIdentityConfiguration(SectionName, AccountName, specifyServiceUri ? "table" : null);
+        TableServiceClient actual = _factory.CreateTableServiceClient(config.GetSection(SectionName));
+        Assert.Equal(new Uri($"https://{AccountName}.table.core.windows.net"), actual.Uri);
+    }
+
+    private static IConfiguration CreateConnectionStringConfiguration(string section)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new KeyValuePair<string, string>[]
+                {
+                    KeyValuePair.Create(section, "UseDevelopmentStorage=true"),
+                })
+            .Build();
+    }
+
+    private static IConfiguration CreateManagedIdentityConfiguration(string section, string accountName, string service = null)
+    {
+        string prefix = section + ":";
+        KeyValuePair<string, string> connectionProperty = service is null
+            ? KeyValuePair.Create(prefix + "AccountName", accountName)
+            : KeyValuePair.Create(prefix + service + "ServiceUri", $"https://{accountName}.{service}.core.windows.net");
+
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new KeyValuePair<string, string>[]
+                {
+                    connectionProperty,
+                    KeyValuePair.Create(prefix + "ClientId", Guid.NewGuid().ToString()),
+                    KeyValuePair.Create(prefix + "Credential", "ManagedIdentity"),
+                })
+            .Build();
+    }
+}

--- a/src/Microsoft.Health.Dicom.Functions.Client.UnitTests/Extensions/AzureComponentFactoryExtensionsTests.cs
+++ b/src/Microsoft.Health.Dicom.Functions.Client.UnitTests/Extensions/AzureComponentFactoryExtensionsTests.cs
@@ -34,26 +34,32 @@ public class AzureComponentFactoryExtensionsTests
         _factory = services.BuildServiceProvider().GetRequiredService<AzureComponentFactory>();
     }
 
-    [Fact]
-    public void GivenBasicConfiguration_WhenCreatingBlobServiceClient_ThenCreateClient()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GivenBasicConfiguration_WhenCreatingBlobServiceClient_ThenCreateClient(bool direct)
     {
-        IConfiguration config = CreateConnectionStringConfiguration(SectionName);
+        IConfiguration config = CreateConnectionStringConfiguration(SectionName, direct);
         BlobServiceClient actual = _factory.CreateBlobServiceClient(config.GetSection(SectionName));
         Assert.Equal(new Uri("http://127.0.0.1:10000/devstoreaccount1"), actual.Uri);
     }
 
-    [Fact]
-    public void GivenBasicConfiguration_WhenCreatingQueueServiceClient_ThenCreateClient()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GivenBasicConfiguration_WhenCreatingQueueServiceClient_ThenCreateClient(bool direct)
     {
-        IConfiguration config = CreateConnectionStringConfiguration(SectionName);
+        IConfiguration config = CreateConnectionStringConfiguration(SectionName, direct);
         QueueServiceClient actual = _factory.CreateQueueServiceClient(config.GetSection(SectionName));
         Assert.Equal(new Uri("http://127.0.0.1:10001/devstoreaccount1"), actual.Uri);
     }
 
-    [Fact]
-    public void GivenBasicConfiguration_WhenCreatingTableServiceClient_ThenCreateClient()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GivenBasicConfiguration_WhenCreatingTableServiceClient_ThenCreateClient(bool direct)
     {
-        IConfiguration config = CreateConnectionStringConfiguration(SectionName);
+        IConfiguration config = CreateConnectionStringConfiguration(SectionName, direct);
         TableServiceClient actual = _factory.CreateTableServiceClient(config.GetSection(SectionName));
         Assert.Equal(new Uri("http://127.0.0.1:10002/devstoreaccount1"), actual.Uri);
     }
@@ -88,13 +94,14 @@ public class AzureComponentFactoryExtensionsTests
         Assert.Equal(new Uri($"https://{AccountName}.table.core.windows.net"), actual.Uri);
     }
 
-    private static IConfiguration CreateConnectionStringConfiguration(string section)
+    private static IConfiguration CreateConnectionStringConfiguration(string section, bool direct)
     {
+        string key = direct ? section : section + ":ConnectionString";
         return new ConfigurationBuilder()
             .AddInMemoryCollection(
                 new KeyValuePair<string, string>[]
                 {
-                    KeyValuePair.Create(section, "UseDevelopmentStorage=true"),
+                    KeyValuePair.Create(key, "UseDevelopmentStorage=true"),
                 })
             .Build();
     }

--- a/src/Microsoft.Health.Dicom.Functions.Client/Extensions/AzureComponentFactoryExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Functions.Client/Extensions/AzureComponentFactoryExtensions.cs
@@ -55,7 +55,7 @@ internal static class AzureComponentFactoryExtensions
                 return clientFactory(serviceUri, credential, options);
         }
 
-        return (TClient)factory.CreateClient(typeof(TClient), configuration, null, null);
+        return (TClient)factory.CreateClient(typeof(TClient), configuration, credential, options);
     }
 
     private sealed class StorageServiceUriOptions

--- a/src/Microsoft.Health.Dicom.Functions.Client/Extensions/AzureComponentFactoryExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Functions.Client/Extensions/AzureComponentFactoryExtensions.cs
@@ -3,7 +3,12 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
+using System.Globalization;
 using Azure.Core;
+using Azure.Data.Tables;
+using Azure.Storage.Blobs;
+using Azure.Storage.Queues;
 using EnsureThat;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
@@ -12,13 +17,76 @@ namespace Microsoft.Health.Dicom.Functions.Client.Extensions;
 
 internal static class AzureComponentFactoryExtensions
 {
-    public static TClient CreateClient<TOptions, TClient>(this AzureComponentFactory factory, IConfigurationSection configuration)
+    public static BlobServiceClient CreateBlobServiceClient(this AzureComponentFactory factory, IConfigurationSection configuration)
+        => factory.CreateClient<BlobClientOptions, BlobServiceClient>(
+            configuration,
+            uriOptions => uriOptions.BlobServiceUri,
+            (uri, credential, clientOptions) => new BlobServiceClient(uri, credential, clientOptions));
+
+    public static QueueServiceClient CreateQueueServiceClient(this AzureComponentFactory factory, IConfigurationSection configuration)
+        => factory.CreateClient<QueueClientOptions, QueueServiceClient>(
+            configuration,
+            uriOptions => uriOptions.QueueServiceUri,
+            (uri, credential, clientOptions) => new QueueServiceClient(uri, credential, clientOptions));
+
+    public static TableServiceClient CreateTableServiceClient(this AzureComponentFactory factory, IConfigurationSection configuration)
+        => factory.CreateClient<TableClientOptions, TableServiceClient>(
+            configuration,
+            uriOptions => uriOptions.TableServiceUri,
+            (uri, credential, clientOptions) => new TableServiceClient(uri, credential, clientOptions));
+
+    private static TClient CreateClient<TOptions, TClient>(
+        this AzureComponentFactory factory,
+        IConfigurationSection configuration,
+        Func<StorageServiceUriOptions, Uri> uriSelector,
+        Func<Uri, TokenCredential, TOptions, TClient> clientFactory)
     {
         EnsureArg.IsNotNull(factory, nameof(factory));
         EnsureArg.IsNotNull(configuration, nameof(configuration));
 
-        TokenCredential credential = configuration.Value is null ? factory.CreateTokenCredential(configuration) : null;
-        var options = (TOptions)factory.CreateClientOptions(typeof(TOptions), null, configuration);
-        return (TClient)factory.CreateClient(typeof(TClient), configuration, credential, options);
+        TokenCredential credential = factory.CreateTokenCredential(configuration);
+        TOptions options = (TOptions)factory.CreateClientOptions(typeof(TOptions), null, configuration);
+
+        if (configuration.Value is null)
+        {
+            StorageServiceUriOptions serviceUriOptions = configuration.Get<StorageServiceUriOptions>();
+            Uri serviceUri = serviceUriOptions is null ? null : uriSelector(serviceUriOptions);
+            if (serviceUri != null)
+                return clientFactory(serviceUri, credential, options);
+        }
+
+        return (TClient)factory.CreateClient(typeof(TClient), configuration, null, null);
+    }
+
+    private sealed class StorageServiceUriOptions
+    {
+        private Uri _blobServiceUri;
+        private Uri _queueServiceUri;
+        private Uri _tableServiceUri;
+
+        public Uri BlobServiceUri
+        {
+            get => _blobServiceUri ?? CreateStorageServiceUri("blob");
+            set => _blobServiceUri = value;
+        }
+
+        public Uri QueueServiceUri
+        {
+            get => _queueServiceUri ?? CreateStorageServiceUri("queue");
+            set => _queueServiceUri = value;
+        }
+
+        public Uri TableServiceUri
+        {
+            get => _tableServiceUri ?? CreateStorageServiceUri("table");
+            set => _tableServiceUri = value;
+        }
+
+        public string AccountName { get; set; }
+
+        private Uri CreateStorageServiceUri(string service)
+            => string.IsNullOrEmpty(AccountName)
+                ? null
+                : new Uri(string.Format(CultureInfo.InvariantCulture, "https://{0}.{1}.core.windows.net", AccountName, service));
     }
 }

--- a/src/Microsoft.Health.Dicom.Functions.Client/TaskHub/AzureStorageTaskHubClient.cs
+++ b/src/Microsoft.Health.Dicom.Functions.Client/TaskHub/AzureStorageTaskHubClient.cs
@@ -6,7 +6,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Data.Tables;
-using Azure.Storage.Blobs;
 using Azure.Storage.Queues;
 using EnsureThat;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
@@ -37,9 +36,9 @@ internal class AzureStorageTaskHubClient : ITaskHubClient
         DurableClientOptions clientOptions = EnsureArg.IsNotNull(options?.Value, nameof(options));
         IConfigurationSection connectionSection = EnsureArg.IsNotNull(connectionInfoProvider, nameof(connectionInfoProvider)).Resolve(clientOptions.ConnectionName);
 
-        _leasesContainer = new LeasesContainer(factory.CreateClient<BlobClientOptions, BlobServiceClient>(connectionSection), clientOptions.TaskHub);
-        _queueServiceClient = factory.CreateClient<QueueClientOptions, QueueServiceClient>(connectionSection);
-        _tableServiceClient = factory.CreateClient<TableClientOptions, TableServiceClient>(connectionSection);
+        _leasesContainer = new LeasesContainer(factory.CreateBlobServiceClient(connectionSection), clientOptions.TaskHub);
+        _queueServiceClient = factory.CreateQueueServiceClient(connectionSection);
+        _tableServiceClient = factory.CreateTableServiceClient(connectionSection);
         _loggerFactory = EnsureArg.IsNotNull(loggerFactory, nameof(loggerFactory));
         _logger = _loggerFactory.CreateLogger<AzureStorageTaskHubClient>();
     }


### PR DESCRIPTION
## Description
Azure Functions allows for the use of `accountName` to specify the storage account as well as the specification of each storage service using `blobServiceUri`, `queueServiceUri`, and `tableServiceUri`. However, the `AzureComponentFactory` only expects either a connection string (via the section value or `connectionString`) or `serviceUri`. In this change, we add support for directly supplying the per-service URIs or the account name.

## Related issues
N/A

## Testing
Added new unit tests for parsing the configurations
