### PR TITLE
Updating System.drawing.common to latest version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,5 +1,4 @@
 <Project>
-
   <ItemGroup>
     <PackageVersion Include="Azure.Core" Version="1.28.0" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.7.1" />
@@ -99,7 +98,7 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
-    <PackageVersion Include="System.Drawing.Common" Version="$(SdkPackageVersion)" />
+    <PackageVersion Include="System.Drawing.Common" Version="7.0.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="$(IdentityModelTokenPackageVersion)" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
@@ -108,5 +107,4 @@
     <PackageVersion Include="xunit.assert" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
## Description
Upgrading nugets to latest version for functions.
Most of the libraries specified in the s360 vurenlability  has already been updated

## Related issues
Addresses [bug #100513](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Medical%20Imaging/Stories/?workitem=100513)
