### PR TITLE
Fix prerelease warning for Azure monitor exporter package

### DIFF
--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Hosting/Microsoft.Health.DicomCast.Hosting.csproj
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Hosting/Microsoft.Health.DicomCast.Hosting.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
     <TargetFramework>$(LatestVersion)</TargetFramework>
   </PropertyGroup>
 

--- a/src/Microsoft.Health.Dicom.Web/Microsoft.Health.Dicom.Web.csproj
+++ b/src/Microsoft.Health.Dicom.Web/Microsoft.Health.Dicom.Web.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <Description>An example web app for Microsoft's Medical Imaging Server for DICOM.</Description>
     <IsPackable>true</IsPackable>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
     <TargetFramework>$(LatestVersion)</TargetFramework>
     <UserSecretsId>5af726e8-ef4d-4c66-9d3a-25b8d546261e</UserSecretsId>
   </PropertyGroup>


### PR DESCRIPTION
## Description
Fix prerelease warning for Azure.Monitor.OpenTelemetry.Exporter package

## Related issues
N/A

## Testing
Pack all the required nuget packages locally.