### PR TITLE
Revert "Bump OpenTelemetry from 1.4.0-rc.3 to 1.4.0-rc.4"

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -92,7 +92,7 @@
     <PackageVersion Include="Microsoft.SqlServer.DACFx" Version="161.6374.0" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.4.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageVersion Include="OpenTelemetry" Version="1.4.0-rc.4" />
+    <PackageVersion Include="OpenTelemetry" Version="1.4.0-rc.3" />
     <PackageVersion Include="OpenTelemetry.Metrics" Version="1.4.0-rc.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.3.2" />
     <PackageVersion Include="NSubstitute" Version="5.0.0" />


### PR DESCRIPTION
Reverts microsoft/dicom-server#2331

We'll increment again once the AzureMonitor exporter has been updated