### PR TITLE
Fix OpenTelemetry NuGet Dependencies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,6 +18,7 @@
     <LangVersion>Latest</LangVersion>
     <LtsVersion>net6.0</LtsVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <OpenTelemetryVersion>1.4.0-rc.3</OpenTelemetryVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Product>Microsoft Health</Product>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -92,9 +92,9 @@
     <PackageVersion Include="Microsoft.SqlServer.DACFx" Version="161.6374.0" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.4.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageVersion Include="OpenTelemetry" Version="1.4.0-rc.3" />
-    <PackageVersion Include="OpenTelemetry.Metrics" Version="1.4.0-rc.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.3.2" />
+    <PackageVersion Include="OpenTelemetry" Version="$(OpenTelemetryVersion)" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="$(OpenTelemetryVersion)" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="NSubstitute" Version="5.0.0" />
     <PackageVersion Include="Polly" Version="7.2.3" />
     <PackageVersion Include="Polly.Extensions.Http" Version="3.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -92,7 +92,7 @@
     <PackageVersion Include="Microsoft.SqlServer.DACFx" Version="161.6374.0" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.4.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageVersion Include="OpenTelemetry" Version="1.4.0-rc.4" />
+    <PackageVersion Include="OpenTelemetry" Version="1.4.0-rc.3" />
     <PackageVersion Include="OpenTelemetry.Metrics" Version="1.4.0-rc.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.3.2" />
     <PackageVersion Include="NSubstitute" Version="5.0.0" />

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Microsoft.Health.DicomCast.Core.UnitTests.csproj
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Microsoft.Health.DicomCast.Core.UnitTests.csproj
@@ -17,6 +17,8 @@
     <PackageReference Include="Microsoft.Health.Test.Utilities" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
+    <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Api" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
     <PackageReference Include="Polly" />
     <PackageReference Include="xunit" />

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Hosting/Microsoft.Health.DicomCast.Hosting.csproj
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Hosting/Microsoft.Health.DicomCast.Hosting.csproj
@@ -16,6 +16,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" />
     <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" />
+    <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Api" />
     <PackageReference Include="System.Drawing.Common" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Microsoft.Health.Dicom.Web/Microsoft.Health.Dicom.Web.csproj
+++ b/src/Microsoft.Health.Dicom.Web/Microsoft.Health.Dicom.Web.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <Description>An example web app for Microsoft's Medical Imaging Server for DICOM.</Description>
@@ -20,6 +20,8 @@
     <PackageReference Include="Microsoft.Health.Development.IdentityProvider" />
     <PackageReference Include="Microsoft.Health.SqlServer" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" />
+    <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Api" />
     <PackageReference Include="System.Drawing.Common" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
## Description
The NuGet dependencies for OpenTelemetry do not accurately convey the necessary packages required to run the assembly. Three projects rely on both the `OpenTelemetry` and `OpenTelemetry.Api` NuGet packages, but no project has them properly declared. Furthermore, both the `OpenTelemetry` and ultimately unused `OpenTelemetry.Metrics` NuGet packages are declared in the *Directory.Packages.props* file and yet are not used as `PackageReference` elements in any project.

## Related issues
N/A

## Testing
PR pipeline and manual validation
