### PR TITLE
Support accept type with no quotes

### DIFF
--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Extensions/MediaTypeHeaderValueExtensionsTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Extensions/MediaTypeHeaderValueExtensionsTests.cs
@@ -1,8 +1,10 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Dicom.Api.Extensions;
 using Microsoft.Health.Dicom.Core;
@@ -92,6 +94,21 @@ public class MediaTypeHeaderValueExtensionsTests
         Assert.Equal(type, acceptHeader.MediaType);
         Assert.Equal(transferSyntax, acceptHeader.TransferSyntax);
         Assert.Equal(quality, acceptHeader.Quality);
+    }
+
+    /// <summary>
+    ///  used by OHIF viewer, we will continue to recommend quotes in our conformance doc
+    /// </summary>
+    [Fact]
+    public void GivenMultiPartRelatedHeaderWithNoQuotesOnType_WhenGetAcceptHeader_ShouldSucceed()
+    {
+        var newMediaTypes = MediaTypeHeaderValue.ParseList(new List<string> { "multipart/related; type=application/octet-stream; transfer-syntax=*" });
+        MediaTypeHeaderValue headerValue = newMediaTypes.First();
+
+        AcceptHeader acceptHeader = headerValue.ToAcceptHeader();
+        Assert.Equal(PayloadTypes.MultipartRelated, acceptHeader.PayloadType);
+        Assert.Equal("application/octet-stream", acceptHeader.MediaType);
+        Assert.Equal("*", acceptHeader.TransferSyntax);
     }
 
     [Fact]

--- a/src/Microsoft.Health.Dicom.Api/Extensions/MediaTypeHeaderValueExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Api/Extensions/MediaTypeHeaderValueExtensions.cs
@@ -37,7 +37,9 @@ public static class MediaTypeHeaderValueExtensions
 
         bool isMultipartRelated = StringSegment.Equals(KnownContentTypes.MultipartRelated, mediaType, StringComparison.OrdinalIgnoreCase);
         // handle accept type with no quotes like "multipart/related; type=application/octet-stream; transfer-syntax=*"
-        // RFC 2045 is clear that any content type parameter value must be quoted if it contains at least one special character. However, the DICOMweb standard incorrectly omits quotes, so we need to compensate for it in our server
+        // RFC 2045 is clear that any content type parameter value must be quoted if it contains at least one special character. 
+        // However, RFC 2387 which defines `multipart/related` specifies in its ABNF definition of the `type` parameter that quotes are not allowed, although all examples include quotes (Errata 5048). 
+        // The DICOMweb standard currently requires quotes, but will soon (CP 1776) allow both forms, so we will allow both.
         bool? startsWithMultiPart = mediaType.Buffer?.StartsWith(KnownContentTypes.MultipartRelated, StringComparison.OrdinalIgnoreCase);
         if (isMultipartRelated)
         {

--- a/src/Microsoft.Health.Dicom.Api/Extensions/MediaTypeHeaderValueExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Api/Extensions/MediaTypeHeaderValueExtensions.cs
@@ -37,6 +37,7 @@ public static class MediaTypeHeaderValueExtensions
 
         bool isMultipartRelated = StringSegment.Equals(KnownContentTypes.MultipartRelated, mediaType, StringComparison.OrdinalIgnoreCase);
         // handle accept type with no quotes like "multipart/related; type=application/octet-stream; transfer-syntax=*"
+        // RFC 2045 is clear that any content type parameter value must be quoted if it contains at least one special character. However, the DICOMweb standard incorrectly omits quotes, so we need to compensate for it in our server
         bool? startsWithMultiPart = mediaType.Buffer?.StartsWith(KnownContentTypes.MultipartRelated, StringComparison.OrdinalIgnoreCase);
         if (isMultipartRelated)
         {

--- a/src/Microsoft.Health.Dicom.Api/Extensions/MediaTypeHeaderValueExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Api/Extensions/MediaTypeHeaderValueExtensions.cs
@@ -36,12 +36,13 @@ public static class MediaTypeHeaderValueExtensions
         StringSegment mediaType = headerValue.MediaType;
 
         bool isMultipartRelated = StringSegment.Equals(KnownContentTypes.MultipartRelated, mediaType, StringComparison.OrdinalIgnoreCase);
+        // handle accept type with no quotes like "multipart/related; type=application/octet-stream; transfer-syntax=*"
+        bool? startsWithMultiPart = mediaType.Buffer?.StartsWith(KnownContentTypes.MultipartRelated, StringComparison.OrdinalIgnoreCase);
         if (isMultipartRelated)
         {
             mediaType = headerValue.GetParameter(AcceptHeaderParameterNames.Type);
         }
-        // handle accept type with no quotes like "multipart/related; type=application/octet-stream; transfer-syntax=*"
-        else if ((bool)(mediaType.Buffer?.StartsWith(KnownContentTypes.MultipartRelated, StringComparison.OrdinalIgnoreCase)))
+        else if (startsWithMultiPart.HasValue && startsWithMultiPart == true)
         {
             isMultipartRelated = true;
         }

--- a/src/Microsoft.Health.Dicom.Api/Extensions/MediaTypeHeaderValueExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Api/Extensions/MediaTypeHeaderValueExtensions.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -34,10 +34,16 @@ public static class MediaTypeHeaderValueExtensions
     {
         EnsureArg.IsNotNull(headerValue, nameof(headerValue));
         StringSegment mediaType = headerValue.MediaType;
+
         bool isMultipartRelated = StringSegment.Equals(KnownContentTypes.MultipartRelated, mediaType, StringComparison.OrdinalIgnoreCase);
         if (isMultipartRelated)
         {
             mediaType = headerValue.GetParameter(AcceptHeaderParameterNames.Type);
+        }
+        // handle accept type with no quotes like "multipart/related; type=application/octet-stream; transfer-syntax=*"
+        else if ((bool)(mediaType.Buffer?.StartsWith(KnownContentTypes.MultipartRelated, StringComparison.OrdinalIgnoreCase)))
+        {
+            isMultipartRelated = true;
         }
 
         StringSegment transferSyntax = headerValue.GetParameter(AcceptHeaderParameterNames.TransferSyntax);

--- a/src/Microsoft.Health.Dicom.Web/wwwroot/index.html
+++ b/src/Microsoft.Health.Dicom.Web/wwwroot/index.html
@@ -20,7 +20,7 @@
 
     <div id="root"></div>
 
-    <script src="https://unpkg.com/@ohif/viewer@1.0.3/dist/index.umd.js" crossorigin></script>
+    <script src="https://unpkg.com/@ohif/viewer@4.10.0/dist/index.umd.js" crossorigin></script>
     <script>
         var rootUrl = `${window.location.protocol}//${window.location.hostname}:${window.location.port}/v1`;
         var containerId = "root";


### PR DESCRIPTION
## Description
Asp.net core/RFC expects request header accept to have quotes in the type like
multipart/related; type="application/octet-stream"; transfer-syntax=*

The new OHIF viewer version and the DICOM standard supports below
multipart/related; type=application/octet-stream; transfer-syntax=*

Put in a hack to handle this in the conversion code.

## Related issues
Addresses [issue #].

## Testing
Added a unit test
