### PR TITLE
Handle version missing in Telemetry gracefully

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Logging/TelemetryInitializer.cs
+++ b/src/Microsoft.Health.Dicom.Api/Logging/TelemetryInitializer.cs
@@ -3,13 +3,12 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using EnsureThat;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Versioning;
 
 namespace Microsoft.Health.Dicom.Api.Logging;
 
@@ -38,18 +37,15 @@ internal class TelemetryInitializer : ITelemetryInitializer
         {
             return;
         }
+
         string version = null;
-        try
+        var feature = _httpContextAccessor.HttpContext?.Features.Get<IApiVersioningFeature>();
+
+        if (feature.RouteParameter != null)
         {
-            version = _httpContextAccessor.HttpContext?.GetRequestedApiVersion()?.ToString();
+            version = feature.RawRequestedApiVersion;
         }
-        catch (ArgumentNullException)
-        {
-            /*
-             * GetRequestedApiVersion() is throwing argument null on urls like health/check which as no version.
-             * logged a bug  https://github.com/dotnet/aspnet-api-versioning/issues/976
-             */
-        }
+
         if (version == null)
         {
             return;


### PR DESCRIPTION
## Description
HttpContext is winding down when TelemetryInit is called. when health/check is called, since the version is not there,
it tries to reparse the url, but the services are already winding down.

Handle it gracefully by checking the existing of the routeParam before logging the version.
https://github.com/dotnet/aspnet-api-versioning/blob/435a17ec5001690e531a1715bc736233a2a938db/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/ApiVersioningFeature.cs#L34


## Related issues
[AB#101437](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/101437)

## Testing
health/check does not throw anymore
