### PR TITLE
Remove VersionedInstanceIdentifier on blob stores

### DIFF
--- a/src/Microsoft.Health.Dicom.Blob.UnitTests/DicomFileNameWithPrefixTests.cs
+++ b/src/Microsoft.Health.Dicom.Blob.UnitTests/DicomFileNameWithPrefixTests.cs
@@ -1,12 +1,10 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
 using Microsoft.Health.Dicom.Blob.Features.Storage;
 using Microsoft.Health.Dicom.Blob.Utilities;
-using Microsoft.Health.Dicom.Core.Features.Model;
-using Microsoft.Health.Dicom.Tests.Common;
 using Xunit;
 
 namespace Microsoft.Health.Dicom.Blob.UnitTests.Features.Common;
@@ -23,8 +21,8 @@ public class DicomFileNameWithPrefixTests
     [Fact]
     public void GivenIdentifier_GetFileNames_ShouldReturnExpectedValues()
     {
-        VersionedInstanceIdentifier instanceIdentifier = new VersionedInstanceIdentifier(TestUidGenerator.Generate(), TestUidGenerator.Generate(), TestUidGenerator.Generate(), 1);
-        Assert.Equal($"{HashingHelper.ComputeXXHash(instanceIdentifier.Version, 3)}_{instanceIdentifier.Version}.dcm", _nameWithPrefix.GetInstanceFileName(instanceIdentifier));
-        Assert.Equal($"{HashingHelper.ComputeXXHash(instanceIdentifier.Version, 3)}_{instanceIdentifier.Version}_metadata.json", _nameWithPrefix.GetMetadataFileName(instanceIdentifier));
+        var version = 1;
+        Assert.Equal($"{HashingHelper.ComputeXXHash(version, 3)}_{version}.dcm", _nameWithPrefix.GetInstanceFileName(version));
+        Assert.Equal($"{HashingHelper.ComputeXXHash(version, 3)}_{version}_metadata.json", _nameWithPrefix.GetMetadataFileName(version));
     }
 }

--- a/src/Microsoft.Health.Dicom.Blob.UnitTests/Features/Export/AzureBlobExportSinkTests.cs
+++ b/src/Microsoft.Health.Dicom.Blob.UnitTests/Features/Export/AzureBlobExportSinkTests.cs
@@ -89,7 +89,7 @@ public class AzureBlobExportSinkTests : IAsyncDisposable
         using var fileStream = new MemoryStream();
         using var tokenSource = new CancellationTokenSource();
 
-        _fileStore.GetStreamingFileAsync(identifier, tokenSource.Token).Returns(fileStream);
+        _fileStore.GetStreamingFileAsync(identifier.Version, tokenSource.Token).Returns(fileStream);
         _destClient.GetBlobClient($"{_output.OperationId:N}/results/1.2/3.4.5/6.7.8.9.10.dcm").Returns(_destBlob);
         _destBlob
             .UploadAsync(fileStream, Arg.Is<BlobUploadOptions>(x => x.TransferOptions == _blobOptions.Upload), tokenSource.Token)
@@ -97,7 +97,7 @@ public class AzureBlobExportSinkTests : IAsyncDisposable
 
         Assert.True(await _sink.CopyAsync(ReadResult.ForIdentifier(identifier), tokenSource.Token));
 
-        await _fileStore.Received(1).GetStreamingFileAsync(identifier, tokenSource.Token);
+        await _fileStore.Received(1).GetStreamingFileAsync(identifier.Version, tokenSource.Token);
         _destClient.Received(1).GetBlobClient($"{_output.OperationId:N}/results/1.2/3.4.5/6.7.8.9.10.dcm");
         await _destBlob
             .Received(1)
@@ -135,7 +135,7 @@ public class AzureBlobExportSinkTests : IAsyncDisposable
         using var fileStream = new MemoryStream();
         using var tokenSource = new CancellationTokenSource();
 
-        _fileStore.GetStreamingFileAsync(identifier, tokenSource.Token).Returns(fileStream);
+        _fileStore.GetStreamingFileAsync(identifier.Version, tokenSource.Token).Returns(fileStream);
         _destClient.GetBlobClient($"{_output.OperationId:N}/results/1.2/3.4.5/6.7.8.9.10.dcm").Returns(_destBlob);
         _destBlob
             .UploadAsync(fileStream, Arg.Is<BlobUploadOptions>(x => x.TransferOptions == _blobOptions.Upload), tokenSource.Token)
@@ -143,7 +143,7 @@ public class AzureBlobExportSinkTests : IAsyncDisposable
 
         Assert.False(await _sink.CopyAsync(ReadResult.ForIdentifier(identifier), tokenSource.Token));
 
-        await _fileStore.Received(1).GetStreamingFileAsync(identifier, tokenSource.Token);
+        await _fileStore.Received(1).GetStreamingFileAsync(identifier.Version, tokenSource.Token);
         _destClient.Received(1).GetBlobClient($"{_output.OperationId:N}/results/1.2/3.4.5/6.7.8.9.10.dcm");
         await _destBlob
             .Received(1)

--- a/src/Microsoft.Health.Dicom.Blob/Features/Export/AzureBlobExportSink.cs
+++ b/src/Microsoft.Health.Dicom.Blob/Features/Export/AzureBlobExportSink.cs
@@ -63,7 +63,7 @@ internal sealed class AzureBlobExportSink : IExportSink
             return false;
         }
 
-        using Stream sourceStream = await _source.GetStreamingFileAsync(value.Identifier, cancellationToken);
+        using Stream sourceStream = await _source.GetStreamingFileAsync(value.Identifier.Version, cancellationToken);
         BlobClient destBlob = _dest.GetBlobClient(_output.GetFilePath(value.Identifier));
 
         try

--- a/src/Microsoft.Health.Dicom.Blob/Features/Storage/BlobFileStore.cs
+++ b/src/Microsoft.Health.Dicom.Blob/Features/Storage/BlobFileStore.cs
@@ -113,7 +113,7 @@ public class BlobFileStore : IFileStore
         }
         catch (ItemNotFoundException ex)
         {
-            _logger.LogWarning(ex, "The DICOM instance file with '{Version}' does not exist.", version);
+            _logger.LogWarning(ex, "The DICOM instance file with watermark '{Version}' does not exist.", version);
 
             throw;
         }
@@ -152,7 +152,7 @@ public class BlobFileStore : IFileStore
         }
         catch (ItemNotFoundException ex)
         {
-            _logger.LogWarning(ex, "The DICOM instance file with '{Version}' does not exist.", version);
+            _logger.LogWarning(ex, "The DICOM instance file with watermark '{Version}' does not exist.", version);
 
             throw;
         }

--- a/src/Microsoft.Health.Dicom.Blob/Features/Storage/BlobMetadataStore.cs
+++ b/src/Microsoft.Health.Dicom.Blob/Features/Storage/BlobMetadataStore.cs
@@ -139,7 +139,7 @@ public class BlobMetadataStore : IMetadataStore
                 case ItemNotFoundException:
                     _logger.LogWarning(
                         ex,
-                        "The DICOM instance metadata file with '{Version}' does not exist.",
+                        "The DICOM instance metadata file with watermark '{Version}' does not exist.",
                         version);
                     break;
                 case JsonException or NotSupportedException:

--- a/src/Microsoft.Health.Dicom.Blob/Features/Storage/DicomFileNameWithPrefix.cs
+++ b/src/Microsoft.Health.Dicom.Blob/Features/Storage/DicomFileNameWithPrefix.cs
@@ -3,9 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using EnsureThat;
 using Microsoft.Health.Dicom.Blob.Utilities;
-using Microsoft.Health.Dicom.Core.Features.Model;
 
 namespace Microsoft.Health.Dicom.Blob.Features.Storage;
 
@@ -13,22 +11,18 @@ public class DicomFileNameWithPrefix : IDicomFileNameBuilder
 {
     public const int MaxPrefixLength = 3;
 
-    public string GetInstanceFileName(VersionedInstanceIdentifier instanceIdentifier)
+    public string GetInstanceFileName(long version)
     {
-        EnsureArg.IsNotNull(instanceIdentifier, nameof(instanceIdentifier));
-
-        return $"{HashingHelper.ComputeXXHash(instanceIdentifier.Version, MaxPrefixLength)}_{instanceIdentifier.Version}.dcm";
+        return $"{HashingHelper.ComputeXXHash(version, MaxPrefixLength)}_{version}.dcm";
     }
 
-    public string GetMetadataFileName(VersionedInstanceIdentifier instanceIdentifier)
+    public string GetMetadataFileName(long version)
     {
-        EnsureArg.IsNotNull(instanceIdentifier, nameof(instanceIdentifier));
-        return $"{HashingHelper.ComputeXXHash(instanceIdentifier.Version, MaxPrefixLength)}_{instanceIdentifier.Version}_metadata.json";
+        return $"{HashingHelper.ComputeXXHash(version, MaxPrefixLength)}_{version}_metadata.json";
     }
 
-    public static string GetInstanceFramesRangeFileName(VersionedInstanceIdentifier instanceIdentifier)
+    public static string GetInstanceFramesRangeFileName(long version)
     {
-        EnsureArg.IsNotNull(instanceIdentifier, nameof(instanceIdentifier));
-        return $"{HashingHelper.ComputeXXHash(instanceIdentifier.Version, MaxPrefixLength)}_{instanceIdentifier.Version}_frames_range.json";
+        return $"{HashingHelper.ComputeXXHash(version, MaxPrefixLength)}_ {version}_frames_range.json";
     }
 }

--- a/src/Microsoft.Health.Dicom.Blob/Features/Storage/IDicomFileNameBuilder.cs
+++ b/src/Microsoft.Health.Dicom.Blob/Features/Storage/IDicomFileNameBuilder.cs
@@ -1,14 +1,12 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using Microsoft.Health.Dicom.Core.Features.Model;
-
 namespace Microsoft.Health.Dicom.Blob.Features.Storage;
 public interface IDicomFileNameBuilder
 {
-    string GetInstanceFileName(VersionedInstanceIdentifier instanceIdentifier);
+    string GetInstanceFileName(long version);
 
-    string GetMetadataFileName(VersionedInstanceIdentifier instanceIdentifier);
+    string GetMetadataFileName(long version);
 }

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ChangeFeed/ChangeFeedServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/ChangeFeed/ChangeFeedServiceTests.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -10,7 +10,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Health.Dicom.Core.Features.ChangeFeed;
 using Microsoft.Health.Dicom.Core.Features.Common;
-using Microsoft.Health.Dicom.Core.Features.Model;
 using Microsoft.Health.Dicom.Tests.Common;
 using NSubstitute;
 using Xunit;
@@ -66,11 +65,11 @@ public class ChangeFeedServiceTests
 
         if (includeMetadata)
         {
-            await _metadataStore.Received(limit - offset).GetInstanceMetadataAsync(Arg.Any<VersionedInstanceIdentifier>(), default);
+            await _metadataStore.Received(limit - offset).GetInstanceMetadataAsync(Arg.Any<long>(), default);
         }
         else
         {
-            await _metadataStore.DidNotReceiveWithAnyArgs().GetInstanceMetadataAsync(Arg.Any<VersionedInstanceIdentifier>(), default);
+            await _metadataStore.DidNotReceiveWithAnyArgs().GetInstanceMetadataAsync(Arg.Any<long>(), default);
         }
 
         Assert.Equal(_changeFeedEntries.Skip(offset).Take(limit), results);
@@ -87,11 +86,11 @@ public class ChangeFeedServiceTests
 
         if (includeMetadata)
         {
-            await _metadataStore.Received(1).GetInstanceMetadataAsync(Arg.Any<VersionedInstanceIdentifier>(), default);
+            await _metadataStore.Received(1).GetInstanceMetadataAsync(Arg.Any<long>(), default);
         }
         else
         {
-            await _metadataStore.DidNotReceiveWithAnyArgs().GetInstanceMetadataAsync(Arg.Any<VersionedInstanceIdentifier>(), default);
+            await _metadataStore.DidNotReceiveWithAnyArgs().GetInstanceMetadataAsync(Arg.Any<long>(), default);
         }
 
         Assert.Equal(_changeFeedEntries.Last(), result);
@@ -105,7 +104,7 @@ public class ChangeFeedServiceTests
         IReadOnlyCollection<ChangeFeedEntry> results = await _changeFeedService.GetChangeFeedAsync(0, 10, true, CancellationToken.None);
 
         await _changeFeedStore.Received(1).GetChangeFeedAsync(0, 10, CancellationToken.None);
-        await _metadataStore.DidNotReceiveWithAnyArgs().GetInstanceMetadataAsync(Arg.Any<VersionedInstanceIdentifier>(), default);
+        await _metadataStore.DidNotReceiveWithAnyArgs().GetInstanceMetadataAsync(Arg.Any<long>(), default);
 
         Assert.Empty(results);
     }
@@ -119,7 +118,7 @@ public class ChangeFeedServiceTests
         ChangeFeedEntry result = await _changeFeedService.GetChangeFeedLatestAsync(true, CancellationToken.None);
 
         await _changeFeedStore.Received(1).GetChangeFeedLatestAsync(CancellationToken.None);
-        await _metadataStore.DidNotReceiveWithAnyArgs().GetInstanceMetadataAsync(Arg.Any<VersionedInstanceIdentifier>(), default);
+        await _metadataStore.DidNotReceiveWithAnyArgs().GetInstanceMetadataAsync(Arg.Any<long>(), default);
 
         Assert.Null(result);
     }
@@ -132,7 +131,7 @@ public class ChangeFeedServiceTests
         IReadOnlyCollection<ChangeFeedEntry> results = await _changeFeedService.GetChangeFeedAsync(1, 10, true, CancellationToken.None);
 
         await _changeFeedStore.Received(1).GetChangeFeedAsync(1, 10, CancellationToken.None);
-        await _metadataStore.Received(9).GetInstanceMetadataAsync(Arg.Any<VersionedInstanceIdentifier>(), default);
+        await _metadataStore.Received(9).GetInstanceMetadataAsync(Arg.Any<long>(), default);
 
         Assert.Equal(_changeFeedEntries.Skip(1).Take(10), results);
     }
@@ -145,7 +144,7 @@ public class ChangeFeedServiceTests
         ChangeFeedEntry result = await _changeFeedService.GetChangeFeedLatestAsync(true, CancellationToken.None);
 
         await _changeFeedStore.Received(1).GetChangeFeedLatestAsync(CancellationToken.None);
-        await _metadataStore.DidNotReceiveWithAnyArgs().GetInstanceMetadataAsync(Arg.Any<VersionedInstanceIdentifier>(), default);
+        await _metadataStore.DidNotReceiveWithAnyArgs().GetInstanceMetadataAsync(Arg.Any<long>(), default);
 
         Assert.Equal(_changeFeedEntries.Last(), result);
     }

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Delete/DeleteServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Delete/DeleteServiceTests.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -135,11 +135,11 @@ public class DeleteServiceTests
 
         await _fileDataStore
             .DidNotReceiveWithAnyArgs()
-            .DeleteFileIfExistsAsync(versionedInstanceIdentifier: default, CancellationToken.None);
+            .DeleteFileIfExistsAsync(version: default, CancellationToken.None);
 
         await _metadataStore
             .DidNotReceiveWithAnyArgs()
-            .DeleteInstanceMetadataIfExistsAsync(versionedInstanceIdentifier: default, CancellationToken.None);
+            .DeleteInstanceMetadataIfExistsAsync(version: default, CancellationToken.None);
 
         _transactionScope.Received(1).Complete();
     }
@@ -157,7 +157,7 @@ public class DeleteServiceTests
                 .ReturnsForAnyArgs(responseList);
 
             _fileDataStore
-                .DeleteFileIfExistsAsync(Arg.Any<VersionedInstanceIdentifier>(), Arg.Any<CancellationToken>())
+                .DeleteFileIfExistsAsync(Arg.Any<long>(), Arg.Any<CancellationToken>())
                 .ThrowsForAnyArgs(new Exception("Generic exception"));
 
             (bool success, int retrievedInstanceCount) = await _deleteService.CleanupDeletedInstancesAsync(CancellationToken.None);
@@ -181,7 +181,7 @@ public class DeleteServiceTests
             .ReturnsForAnyArgs(responseList);
 
         _metadataStore
-            .DeleteInstanceMetadataIfExistsAsync(Arg.Any<VersionedInstanceIdentifier>(), Arg.Any<CancellationToken>())
+            .DeleteInstanceMetadataIfExistsAsync(Arg.Any<long>(), Arg.Any<CancellationToken>())
             .ThrowsForAnyArgs(new Exception("Generic exception"));
 
         (bool success, int retrievedInstanceCount) = await _deleteService.CleanupDeletedInstancesAsync(CancellationToken.None);
@@ -204,7 +204,7 @@ public class DeleteServiceTests
             .ReturnsForAnyArgs(responseList);
 
         _fileDataStore
-            .DeleteFileIfExistsAsync(Arg.Any<VersionedInstanceIdentifier>(), Arg.Any<CancellationToken>())
+            .DeleteFileIfExistsAsync(Arg.Any<long>(), Arg.Any<CancellationToken>())
             .ThrowsForAnyArgs(new Exception("Generic exception"));
 
         _indexDataStore
@@ -245,7 +245,7 @@ public class DeleteServiceTests
 
         await _fileDataStore
             .DidNotReceiveWithAnyArgs()
-            .DeleteFileIfExistsAsync(versionedInstanceIdentifier: default, CancellationToken.None);
+            .DeleteFileIfExistsAsync(version: default, CancellationToken.None);
     }
 
     [Theory]
@@ -281,11 +281,11 @@ public class DeleteServiceTests
 
             await _metadataStore
                 .Received(1)
-                .DeleteInstanceMetadataIfExistsAsync(deletedVersion, CancellationToken.None);
+                .DeleteInstanceMetadataIfExistsAsync(deletedVersion.Version, CancellationToken.None);
 
             await _fileDataStore
                 .Received(1)
-                .DeleteFileIfExistsAsync(deletedVersion, CancellationToken.None);
+                .DeleteFileIfExistsAsync(deletedVersion.Version, CancellationToken.None);
         }
 
         await _indexDataStore

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Query/QueryServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Query/QueryServiceTests.cs
@@ -177,7 +177,7 @@ public class QueryServiceTests
 
         await _queryStore.Received().GetStudyResultAsync(Arg.Any<int>(), Arg.Any<IReadOnlyCollection<long>>(), Arg.Any<CancellationToken>());
         await _queryStore.DidNotReceive().GetSeriesResultAsync(Arg.Any<int>(), Arg.Any<IReadOnlyCollection<long>>(), Arg.Any<CancellationToken>());
-        await _metadataStore.DidNotReceive().GetInstanceMetadataAsync(Arg.Any<VersionedInstanceIdentifier>(), Arg.Any<CancellationToken>());
+        await _metadataStore.DidNotReceive().GetInstanceMetadataAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -197,7 +197,7 @@ public class QueryServiceTests
 
         await _queryStore.Received().GetStudyResultAsync(Arg.Any<int>(), Arg.Any<IReadOnlyCollection<long>>(), Arg.Any<CancellationToken>());
         await _queryStore.Received().GetSeriesResultAsync(Arg.Any<int>(), Arg.Any<IReadOnlyCollection<long>>(), Arg.Any<CancellationToken>());
-        await _metadataStore.DidNotReceive().GetInstanceMetadataAsync(Arg.Any<VersionedInstanceIdentifier>(), Arg.Any<CancellationToken>());
+        await _metadataStore.DidNotReceive().GetInstanceMetadataAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
         Assert.Equal(2, response.ResponseDataset.Count());
         ValidationResponse(response.ResponseDataset, studyResults.Single(), seriesResults);
     }
@@ -215,7 +215,7 @@ public class QueryServiceTests
 
         await _queryStore.DidNotReceive().GetStudyResultAsync(Arg.Any<int>(), Arg.Any<IReadOnlyCollection<long>>(), Arg.Any<CancellationToken>());
         await _queryStore.Received().GetSeriesResultAsync(Arg.Any<int>(), Arg.Any<IReadOnlyCollection<long>>(), Arg.Any<CancellationToken>());
-        await _metadataStore.DidNotReceive().GetInstanceMetadataAsync(Arg.Any<VersionedInstanceIdentifier>(), Arg.Any<CancellationToken>());
+        await _metadataStore.DidNotReceive().GetInstanceMetadataAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -231,7 +231,7 @@ public class QueryServiceTests
 
         await _queryStore.DidNotReceive().GetStudyResultAsync(Arg.Any<int>(), Arg.Any<IReadOnlyCollection<long>>(), Arg.Any<CancellationToken>());
         await _queryStore.DidNotReceive().GetSeriesResultAsync(Arg.Any<int>(), Arg.Any<IReadOnlyCollection<long>>(), Arg.Any<CancellationToken>());
-        await _metadataStore.Received().GetInstanceMetadataAsync(Arg.Any<VersionedInstanceIdentifier>(), Arg.Any<CancellationToken>());
+        await _metadataStore.Received().GetInstanceMetadataAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -246,13 +246,13 @@ public class QueryServiceTests
         var studyResults = GenerateStudyResults(identifier.StudyInstanceUid);
         var metadataResult = GenerateMetadataStoreResponse(identifier);
         _queryStore.GetStudyResultAsync(Arg.Any<int>(), Arg.Any<IReadOnlyCollection<long>>(), Arg.Any<CancellationToken>()).Returns(studyResults);
-        _metadataStore.GetInstanceMetadataAsync(Arg.Any<VersionedInstanceIdentifier>(), Arg.Any<CancellationToken>()).Returns(metadataResult);
+        _metadataStore.GetInstanceMetadataAsync(Arg.Any<long>(), Arg.Any<CancellationToken>()).Returns(metadataResult);
 
         var response = await _queryService.QueryAsync(new QueryParameters(), CancellationToken.None);
 
         await _queryStore.Received().GetStudyResultAsync(Arg.Any<int>(), Arg.Any<IReadOnlyCollection<long>>(), Arg.Any<CancellationToken>());
         await _queryStore.DidNotReceive().GetSeriesResultAsync(Arg.Any<int>(), Arg.Any<IReadOnlyCollection<long>>(), Arg.Any<CancellationToken>());
-        await _metadataStore.Received().GetInstanceMetadataAsync(Arg.Any<VersionedInstanceIdentifier>(), Arg.Any<CancellationToken>());
+        await _metadataStore.Received().GetInstanceMetadataAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
         Assert.Single(response.ResponseDataset);
         ValidationResponse(response.ResponseDataset.Single(), studyResults.Single(), metadataResult);
     }
@@ -271,7 +271,7 @@ public class QueryServiceTests
 
         await _queryStore.DidNotReceive().GetStudyResultAsync(Arg.Any<int>(), Arg.Any<IReadOnlyCollection<long>>(), Arg.Any<CancellationToken>());
         await _queryStore.Received().GetSeriesResultAsync(Arg.Any<int>(), Arg.Any<IReadOnlyCollection<long>>(), Arg.Any<CancellationToken>());
-        await _metadataStore.Received().GetInstanceMetadataAsync(Arg.Any<VersionedInstanceIdentifier>(), Arg.Any<CancellationToken>());
+        await _metadataStore.Received().GetInstanceMetadataAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
     }
 
 

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveMetadataServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveMetadataServiceTests.cs
@@ -127,8 +127,8 @@ public class RetrieveMetadataServiceTests
     {
         List<VersionedInstanceIdentifier> versionedInstanceIdentifiers = SetupInstanceIdentifiersList(ResourceType.Study);
 
-        _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifiers.Last(), Arg.Any<CancellationToken>()).Throws(new InstanceNotFoundException());
-        _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifiers.First(), Arg.Any<CancellationToken>()).Returns(new DicomDataset());
+        _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifiers.Last().Version, Arg.Any<CancellationToken>()).Throws(new InstanceNotFoundException());
+        _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifiers.First().Version, Arg.Any<CancellationToken>()).Returns(new DicomDataset());
 
         string ifNoneMatch = null;
         RetrieveMetadataResponse response = await _retrieveMetadataService.RetrieveStudyInstanceMetadataAsync(_studyInstanceUid, ifNoneMatch, DefaultCancellationToken);
@@ -141,8 +141,8 @@ public class RetrieveMetadataServiceTests
     {
         List<VersionedInstanceIdentifier> versionedInstanceIdentifiers = SetupInstanceIdentifiersList(ResourceType.Study);
 
-        _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifiers.First(), DefaultCancellationToken).Returns(new DicomDataset());
-        _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifiers.Last(), DefaultCancellationToken).Returns(new DicomDataset());
+        _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifiers.First().Version, DefaultCancellationToken).Returns(new DicomDataset());
+        _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifiers.Last().Version, DefaultCancellationToken).Returns(new DicomDataset());
 
         string ifNoneMatch = null;
         RetrieveMetadataResponse response = await _retrieveMetadataService.RetrieveStudyInstanceMetadataAsync(_studyInstanceUid, ifNoneMatch, DefaultCancellationToken);
@@ -156,8 +156,8 @@ public class RetrieveMetadataServiceTests
     {
         List<VersionedInstanceIdentifier> versionedInstanceIdentifiers = SetupInstanceIdentifiersList(ResourceType.Series);
 
-        _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifiers.Last(), Arg.Any<CancellationToken>()).Throws(new InstanceNotFoundException());
-        _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifiers.First(), Arg.Any<CancellationToken>()).Returns(new DicomDataset());
+        _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifiers.Last().Version, Arg.Any<CancellationToken>()).Throws(new InstanceNotFoundException());
+        _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifiers.First().Version, Arg.Any<CancellationToken>()).Returns(new DicomDataset());
 
         string ifNoneMatch = null;
         RetrieveMetadataResponse response = await _retrieveMetadataService.RetrieveSeriesInstanceMetadataAsync(_studyInstanceUid, _seriesInstanceUid, ifNoneMatch, DefaultCancellationToken);
@@ -170,8 +170,8 @@ public class RetrieveMetadataServiceTests
     {
         List<VersionedInstanceIdentifier> versionedInstanceIdentifiers = SetupInstanceIdentifiersList(ResourceType.Series);
 
-        _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifiers.First(), DefaultCancellationToken).Returns(new DicomDataset());
-        _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifiers.Last(), DefaultCancellationToken).Returns(new DicomDataset());
+        _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifiers.First().Version, DefaultCancellationToken).Returns(new DicomDataset());
+        _metadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifiers.Last().Version, DefaultCancellationToken).Returns(new DicomDataset());
 
         string ifNoneMatch = null;
         RetrieveMetadataResponse response = await _retrieveMetadataService.RetrieveSeriesInstanceMetadataAsync(_studyInstanceUid, _seriesInstanceUid, ifNoneMatch, DefaultCancellationToken);
@@ -185,7 +185,7 @@ public class RetrieveMetadataServiceTests
     {
         VersionedInstanceIdentifier sopInstanceIdentifier = SetupInstanceIdentifiersList(ResourceType.Instance).First();
 
-        _metadataStore.GetInstanceMetadataAsync(sopInstanceIdentifier, Arg.Any<CancellationToken>()).Throws(new InstanceNotFoundException());
+        _metadataStore.GetInstanceMetadataAsync(sopInstanceIdentifier.Version, Arg.Any<CancellationToken>()).Throws(new InstanceNotFoundException());
 
         string ifNoneMatch = null;
         RetrieveMetadataResponse response = await _retrieveMetadataService.RetrieveSopInstanceMetadataAsync(_studyInstanceUid, _seriesInstanceUid, _sopInstanceUid, ifNoneMatch, DefaultCancellationToken);
@@ -198,7 +198,7 @@ public class RetrieveMetadataServiceTests
     {
         VersionedInstanceIdentifier sopInstanceIdentifier = SetupInstanceIdentifiersList(ResourceType.Instance).First();
 
-        _metadataStore.GetInstanceMetadataAsync(sopInstanceIdentifier, DefaultCancellationToken).Returns(new DicomDataset());
+        _metadataStore.GetInstanceMetadataAsync(sopInstanceIdentifier.Version, DefaultCancellationToken).Returns(new DicomDataset());
 
         string ifNoneMatch = null;
         RetrieveMetadataResponse response = await _retrieveMetadataService.RetrieveSopInstanceMetadataAsync(_studyInstanceUid, _seriesInstanceUid, _sopInstanceUid, ifNoneMatch, DefaultCancellationToken);

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveResourceServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveResourceServiceTests.cs
@@ -136,7 +136,13 @@ public class RetrieveResourceServiceTests
             x => StreamAndStoredFileFromDataset(GenerateDatasetsFromIdentifiers(x.VersionedInstanceIdentifier)).Result).ToList();
 
         _fileStore.GetFilePropertiesAsync(Arg.Any<long>(), DefaultCancellationToken).Returns(new FileProperties() { ContentLength = 1000 });
-        streamsAndStoredFiles.ForEach(x => _fileStore.GetStreamingFileAsync(0, DefaultCancellationToken).Returns(x.Value));
+        int count = 0;
+        foreach (var file in streamsAndStoredFiles)
+        {
+            _fileStore.GetStreamingFileAsync(count, DefaultCancellationToken).Returns(file.Value);
+            count++;
+        }
+        // streamsAndStoredFiles.ForEach(x => );
 
         RetrieveResourceResponse response = await _retrieveResourceService.GetInstanceResourceAsync(
                new RetrieveResourceRequest(_studyInstanceUid, new[] { AcceptHeaderHelpers.CreateAcceptHeaderForGetStudy() }),
@@ -231,7 +237,12 @@ public class RetrieveResourceServiceTests
             .ToList();
 
         _fileStore.GetFilePropertiesAsync(Arg.Any<long>(), DefaultCancellationToken).Returns(new FileProperties() { ContentLength = 1000 });
-        streamsAndStoredFiles.ForEach(x => _fileStore.GetStreamingFileAsync(0, DefaultCancellationToken).Returns(x.Value));
+        int count = 0;
+        foreach (var file in streamsAndStoredFiles)
+        {
+            _fileStore.GetStreamingFileAsync(count, DefaultCancellationToken).Returns(file.Value);
+            count++;
+        }
 
         RetrieveResourceResponse response = await _retrieveResourceService.GetInstanceResourceAsync(
                new RetrieveResourceRequest(
@@ -567,19 +578,19 @@ public class RetrieveResourceServiceTests
         {
             case ResourceType.Study:
                 dicomInstanceIdentifiersList.Add(new InstanceMetadata(new VersionedInstanceIdentifier(_studyInstanceUid, _firstSeriesInstanceUid, TestUidGenerator.Generate(), 0, partitionKey), instanceProperty));
-                dicomInstanceIdentifiersList.Add(new InstanceMetadata(new VersionedInstanceIdentifier(_studyInstanceUid, _firstSeriesInstanceUid, TestUidGenerator.Generate(), 0, partitionKey), instanceProperty));
-                dicomInstanceIdentifiersList.Add(new InstanceMetadata(new VersionedInstanceIdentifier(_studyInstanceUid, _secondSeriesInstanceUid, TestUidGenerator.Generate(), 0, partitionKey), instanceProperty));
+                dicomInstanceIdentifiersList.Add(new InstanceMetadata(new VersionedInstanceIdentifier(_studyInstanceUid, _firstSeriesInstanceUid, TestUidGenerator.Generate(), 1, partitionKey), instanceProperty));
+                dicomInstanceIdentifiersList.Add(new InstanceMetadata(new VersionedInstanceIdentifier(_studyInstanceUid, _secondSeriesInstanceUid, TestUidGenerator.Generate(), 2, partitionKey), instanceProperty));
                 _instanceStore.GetInstanceIdentifierWithPropertiesAsync(partitionKey, _studyInstanceUid, null, null, DefaultCancellationToken).Returns(dicomInstanceIdentifiersList);
                 break;
             case ResourceType.Series:
                 dicomInstanceIdentifiersList.Add(new InstanceMetadata(new VersionedInstanceIdentifier(_studyInstanceUid, _firstSeriesInstanceUid, TestUidGenerator.Generate(), 0, partitionKey), instanceProperty));
-                dicomInstanceIdentifiersList.Add(new InstanceMetadata(new VersionedInstanceIdentifier(_studyInstanceUid, _firstSeriesInstanceUid, TestUidGenerator.Generate(), 0, partitionKey), instanceProperty));
+                dicomInstanceIdentifiersList.Add(new InstanceMetadata(new VersionedInstanceIdentifier(_studyInstanceUid, _firstSeriesInstanceUid, TestUidGenerator.Generate(), 1, partitionKey), instanceProperty));
                 _instanceStore.GetInstanceIdentifierWithPropertiesAsync(partitionKey, _studyInstanceUid, _firstSeriesInstanceUid, null, DefaultCancellationToken).Returns(dicomInstanceIdentifiersList);
                 break;
             case ResourceType.Instance:
             case ResourceType.Frames:
                 dicomInstanceIdentifiersList.Add(new InstanceMetadata(new VersionedInstanceIdentifier(_studyInstanceUid, _firstSeriesInstanceUid, _sopInstanceUid, 0, partitionKey), instanceProperty));
-                dicomInstanceIdentifiersList.Add(new InstanceMetadata(new VersionedInstanceIdentifier(_studyInstanceUid, _firstSeriesInstanceUid, TestUidGenerator.Generate(), 0, partitionKey), instanceProperty));
+                dicomInstanceIdentifiersList.Add(new InstanceMetadata(new VersionedInstanceIdentifier(_studyInstanceUid, _firstSeriesInstanceUid, TestUidGenerator.Generate(), 1, partitionKey), instanceProperty));
                 _instanceStore.GetInstanceIdentifierWithPropertiesAsync(partitionKey, _studyInstanceUid, _firstSeriesInstanceUid, _sopInstanceUid, DefaultCancellationToken).Returns(dicomInstanceIdentifiersList.SkipLast(1));
                 var identifier = new InstanceIdentifier(_studyInstanceUid, _firstSeriesInstanceUid, _sopInstanceUid, partitionKey);
                 _instanceMetadataCache.GetAsync(Arg.Any<object>(), identifier, Arg.Any<Func<InstanceIdentifier, CancellationToken, Task<InstanceMetadata>>>(), Arg.Any<CancellationToken>()).Returns(dicomInstanceIdentifiersList.First());

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveResourceServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveResourceServiceTests.cs
@@ -104,7 +104,7 @@ public class RetrieveResourceServiceTests
     public async Task GivenStoredInstancesWhereOneIsMissingFile_WhenRetrieveRequestForStudy_ThenNotFoundIsThrown()
     {
         List<InstanceMetadata> instances = SetupInstanceIdentifiersList(ResourceType.Study);
-        _fileStore.GetFilePropertiesAsync(Arg.Any<VersionedInstanceIdentifier>(), DefaultCancellationToken).Returns(new FileProperties() { ContentLength = 1000 });
+        _fileStore.GetFilePropertiesAsync(Arg.Any<long>(), DefaultCancellationToken).Returns(new FileProperties() { ContentLength = 1000 });
 
         // For each instance identifier but the last, set up the fileStore to return a stream containing a file associated with the identifier.
         // For each instance identifier but the last, set up the fileStore to return a stream containing a file associated with the identifier.
@@ -112,12 +112,12 @@ public class RetrieveResourceServiceTests
         {
             InstanceMetadata instance = instances[i];
             KeyValuePair<DicomFile, Stream> stream = await StreamAndStoredFileFromDataset(GenerateDatasetsFromIdentifiers(instance.VersionedInstanceIdentifier), frames: 0, disposeStreams: false);
-            _fileStore.GetStreamingFileAsync(instance.VersionedInstanceIdentifier, DefaultCancellationToken).Returns(stream.Value);
+            _fileStore.GetStreamingFileAsync(instance.VersionedInstanceIdentifier.Version, DefaultCancellationToken).Returns(stream.Value);
             _retrieveTranscoder.TranscodeFileAsync(stream.Value, "*").Returns(stream.Value);
         }
 
         // For the last identifier, set up the fileStore to throw a store exception with the status code 404 (NotFound).
-        _fileStore.GetStreamingFileAsync(instances.Last().VersionedInstanceIdentifier, DefaultCancellationToken).Throws(new InstanceNotFoundException());
+        _fileStore.GetStreamingFileAsync(instances.Last().VersionedInstanceIdentifier.Version, DefaultCancellationToken).Throws(new InstanceNotFoundException());
 
         var response = await _retrieveResourceService.GetInstanceResourceAsync(
                                 new RetrieveResourceRequest(_studyInstanceUid, new[] { AcceptHeaderHelpers.CreateAcceptHeaderForGetStudy() }),
@@ -135,8 +135,8 @@ public class RetrieveResourceServiceTests
         var streamsAndStoredFiles = versionedInstanceIdentifiers.Select(
             x => StreamAndStoredFileFromDataset(GenerateDatasetsFromIdentifiers(x.VersionedInstanceIdentifier)).Result).ToList();
 
-        _fileStore.GetFilePropertiesAsync(Arg.Any<VersionedInstanceIdentifier>(), DefaultCancellationToken).Returns(new FileProperties() { ContentLength = 1000 });
-        streamsAndStoredFiles.ForEach(x => _fileStore.GetStreamingFileAsync(x.Key.Dataset.ToVersionedInstanceIdentifier(0), DefaultCancellationToken).Returns(x.Value));
+        _fileStore.GetFilePropertiesAsync(Arg.Any<long>(), DefaultCancellationToken).Returns(new FileProperties() { ContentLength = 1000 });
+        streamsAndStoredFiles.ForEach(x => _fileStore.GetStreamingFileAsync(0, DefaultCancellationToken).Returns(x.Value));
 
         RetrieveResourceResponse response = await _retrieveResourceService.GetInstanceResourceAsync(
                new RetrieveResourceRequest(_studyInstanceUid, new[] { AcceptHeaderHelpers.CreateAcceptHeaderForGetStudy() }),
@@ -165,8 +165,8 @@ public class RetrieveResourceServiceTests
         // For each instance identifier, set up the fileStore to return a stream containing a file associated with the identifier.
         var streamsAndStoredFile = await StreamAndStoredFileFromDataset(GenerateDatasetsFromIdentifiers(instanceMetadata.VersionedInstanceIdentifier));
 
-        _fileStore.GetFileAsync(streamsAndStoredFile.Key.Dataset.ToVersionedInstanceIdentifier(0), DefaultCancellationToken).Returns(streamsAndStoredFile.Value);
-        _fileStore.GetFilePropertiesAsync(instanceMetadata.VersionedInstanceIdentifier, DefaultCancellationToken).Returns(new FileProperties() { ContentLength = streamsAndStoredFile.Value.Length });
+        _fileStore.GetFileAsync(0, DefaultCancellationToken).Returns(streamsAndStoredFile.Value);
+        _fileStore.GetFilePropertiesAsync(instanceMetadata.VersionedInstanceIdentifier.Version, DefaultCancellationToken).Returns(new FileProperties() { ContentLength = streamsAndStoredFile.Value.Length });
         string transferSyntax = "1.2.840.10008.1.2.1";
         _retrieveTranscoder.TranscodeFileAsync(streamsAndStoredFile.Value, transferSyntax).Returns(streamsAndStoredFile.Value);
 
@@ -199,19 +199,19 @@ public class RetrieveResourceServiceTests
     public async Task GivenStoredInstancesWhereOneIsMissingFile_WhenRetrieveRequestForSeries_ThenNotFoundIsThrown()
     {
         List<InstanceMetadata> versionedInstanceIdentifiers = SetupInstanceIdentifiersList(ResourceType.Series);
-        _fileStore.GetFilePropertiesAsync(Arg.Any<VersionedInstanceIdentifier>(), DefaultCancellationToken).Returns(new FileProperties() { ContentLength = 1000 });
+        _fileStore.GetFilePropertiesAsync(Arg.Any<long>(), DefaultCancellationToken).Returns(new FileProperties() { ContentLength = 1000 });
 
         // For each instance identifier but the last, set up the fileStore to return a stream containing a file associated with the identifier.
         for (int i = 0; i < versionedInstanceIdentifiers.Count - 1; i++)
         {
             InstanceMetadata instance = versionedInstanceIdentifiers[i];
             KeyValuePair<DicomFile, Stream> stream = await StreamAndStoredFileFromDataset(GenerateDatasetsFromIdentifiers(instance.VersionedInstanceIdentifier), frames: 0, disposeStreams: false);
-            _fileStore.GetStreamingFileAsync(instance.VersionedInstanceIdentifier, DefaultCancellationToken).Returns(stream.Value);
+            _fileStore.GetStreamingFileAsync(instance.VersionedInstanceIdentifier.Version, DefaultCancellationToken).Returns(stream.Value);
             _retrieveTranscoder.TranscodeFileAsync(stream.Value, "*").Returns(stream.Value);
         }
 
         // For the last identifier, set up the fileStore to throw a store exception with the status code 404 (NotFound).
-        _fileStore.GetStreamingFileAsync(versionedInstanceIdentifiers.Last().VersionedInstanceIdentifier, DefaultCancellationToken).Throws(new InstanceNotFoundException());
+        _fileStore.GetStreamingFileAsync(versionedInstanceIdentifiers.Last().VersionedInstanceIdentifier.Version, DefaultCancellationToken).Throws(new InstanceNotFoundException());
 
         var response = await _retrieveResourceService.GetInstanceResourceAsync(
                                 new RetrieveResourceRequest(_studyInstanceUid, _firstSeriesInstanceUid, new[] { AcceptHeaderHelpers.CreateAcceptHeaderForGetSeries() }),
@@ -230,8 +230,8 @@ public class RetrieveResourceServiceTests
             .Select(x => StreamAndStoredFileFromDataset(GenerateDatasetsFromIdentifiers(x.VersionedInstanceIdentifier)).Result)
             .ToList();
 
-        _fileStore.GetFilePropertiesAsync(Arg.Any<VersionedInstanceIdentifier>(), DefaultCancellationToken).Returns(new FileProperties() { ContentLength = 1000 });
-        streamsAndStoredFiles.ForEach(x => _fileStore.GetStreamingFileAsync(x.Key.Dataset.ToVersionedInstanceIdentifier(0), DefaultCancellationToken).Returns(x.Value));
+        _fileStore.GetFilePropertiesAsync(Arg.Any<long>(), DefaultCancellationToken).Returns(new FileProperties() { ContentLength = 1000 });
+        streamsAndStoredFiles.ForEach(x => _fileStore.GetStreamingFileAsync(0, DefaultCancellationToken).Returns(x.Value));
 
         RetrieveResourceResponse response = await _retrieveResourceService.GetInstanceResourceAsync(
                new RetrieveResourceRequest(
@@ -270,7 +270,7 @@ public class RetrieveResourceServiceTests
         List<InstanceMetadata> versionedInstanceIdentifiers = SetupInstanceIdentifiersList(ResourceType.Instance);
 
         // For the first instance identifier, set up the fileStore to throw a store exception with the status code 404 (NotFound).
-        _fileStore.GetStreamingFileAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier, DefaultCancellationToken).Throws(new InstanceNotFoundException());
+        _fileStore.GetStreamingFileAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier.Version, DefaultCancellationToken).Throws(new InstanceNotFoundException());
 
         var response = await _retrieveResourceService.GetInstanceResourceAsync(
                     new RetrieveResourceRequest(_studyInstanceUid, _firstSeriesInstanceUid, _sopInstanceUid, new[] { AcceptHeaderHelpers.CreateAcceptHeaderForGetInstance() }),
@@ -286,10 +286,10 @@ public class RetrieveResourceServiceTests
         // Add multiple instances to validate that we return the requested instance and ignore the other(s).
         List<InstanceMetadata> versionedInstanceIdentifiers = SetupInstanceIdentifiersList(ResourceType.Instance);
 
-        _fileStore.GetFilePropertiesAsync(Arg.Any<VersionedInstanceIdentifier>(), DefaultCancellationToken).Returns(new FileProperties() { ContentLength = 1000 });
+        _fileStore.GetFilePropertiesAsync(Arg.Any<long>(), DefaultCancellationToken).Returns(new FileProperties() { ContentLength = 1000 });
         // For the first instance identifier, set up the fileStore to return a stream containing a file associated with the identifier.
         KeyValuePair<DicomFile, Stream> streamAndStoredFile = StreamAndStoredFileFromDataset(GenerateDatasetsFromIdentifiers(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier)).Result;
-        _fileStore.GetStreamingFileAsync(streamAndStoredFile.Key.Dataset.ToVersionedInstanceIdentifier(0), DefaultCancellationToken).Returns(streamAndStoredFile.Value);
+        _fileStore.GetStreamingFileAsync(0, DefaultCancellationToken).Returns(streamAndStoredFile.Value);
 
         RetrieveResourceResponse response = await _retrieveResourceService.GetInstanceResourceAsync(
                new RetrieveResourceRequest(
@@ -324,8 +324,8 @@ public class RetrieveResourceServiceTests
 
         // For the instance, set up the fileStore to return a stream containing the file associated with the identifier with 3 frames.
         Stream streamOfStoredFiles = StreamAndStoredFileFromDataset(GenerateDatasetsFromIdentifiers(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier), frames: 0).Result.Value;
-        _fileStore.GetFileAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier, DefaultCancellationToken).Returns(streamOfStoredFiles);
-        _fileStore.GetFilePropertiesAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier, DefaultCancellationToken).Returns(new FileProperties() { ContentLength = streamOfStoredFiles.Length });
+        _fileStore.GetFileAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier.Version, DefaultCancellationToken).Returns(streamOfStoredFiles);
+        _fileStore.GetFilePropertiesAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier.Version, DefaultCancellationToken).Returns(new FileProperties() { ContentLength = streamOfStoredFiles.Length });
 
         var retrieveResourceRequest = new RetrieveResourceRequest(_studyInstanceUid, _firstSeriesInstanceUid, _sopInstanceUid, framesToRequest, new[] { AcceptHeaderHelpers.CreateAcceptHeaderForGetFrame() });
         _dicomFrameHandler.GetFramesResourceAsync(streamOfStoredFiles, retrieveResourceRequest.Frames, true, "*").Throws(new FrameNotFoundException());
@@ -347,8 +347,8 @@ public class RetrieveResourceServiceTests
 
         // For the instance, set up the fileStore to return a stream containing the file associated with the identifier with 3 frames.
         Stream streamOfStoredFiles = StreamAndStoredFileFromDataset(GenerateDatasetsFromIdentifiers(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier), frames: 3).Result.Value;
-        _fileStore.GetFileAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier, DefaultCancellationToken).Returns(streamOfStoredFiles);
-        _fileStore.GetFilePropertiesAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier, DefaultCancellationToken).Returns(new FileProperties() { ContentLength = streamOfStoredFiles.Length });
+        _fileStore.GetFileAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier.Version, DefaultCancellationToken).Returns(streamOfStoredFiles);
+        _fileStore.GetFilePropertiesAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier.Version, DefaultCancellationToken).Returns(new FileProperties() { ContentLength = streamOfStoredFiles.Length });
 
         var retrieveResourceRequest = new RetrieveResourceRequest(_studyInstanceUid, _firstSeriesInstanceUid, _sopInstanceUid, framesToRequest, new[] { AcceptHeaderHelpers.CreateAcceptHeaderForGetFrame() });
         _dicomFrameHandler.GetFramesResourceAsync(streamOfStoredFiles, retrieveResourceRequest.Frames, true, "*").Throws(new FrameNotFoundException());
@@ -371,8 +371,8 @@ public class RetrieveResourceServiceTests
 
         // For the first instance identifier, set up the fileStore to return a stream containing a file associated with the identifier.
         KeyValuePair<DicomFile, Stream> streamAndStoredFile = StreamAndStoredFileFromDataset(GenerateDatasetsFromIdentifiers(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier), frames: 3).Result;
-        _fileStore.GetFileAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier, DefaultCancellationToken).Returns(streamAndStoredFile.Value);
-        _fileStore.GetFilePropertiesAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier, DefaultCancellationToken).Returns(new FileProperties() { ContentLength = streamAndStoredFile.Value.Length });
+        _fileStore.GetFileAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier.Version, DefaultCancellationToken).Returns(streamAndStoredFile.Value);
+        _fileStore.GetFilePropertiesAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier.Version, DefaultCancellationToken).Returns(new FileProperties() { ContentLength = streamAndStoredFile.Value.Length });
 
         // Setup frame handler to return the frames as streams from the file.
         Stream[] frames = framesToRequest.Select(f => GetFrameFromFile(streamAndStoredFile.Key.Dataset, f)).ToArray();
@@ -410,9 +410,9 @@ public class RetrieveResourceServiceTests
         // For each instance identifier, set up the fileStore to return a stream containing a file associated with the identifier.
         var streamsAndStoredFiles = versionedInstanceIdentifiers.Select(
             x => StreamAndStoredFileFromDataset(GenerateDatasetsFromIdentifiers(x.VersionedInstanceIdentifier, originalTransferSyntax)).Result).ToList();
-        streamsAndStoredFiles.ForEach(x => _fileStore.GetFileAsync(x.Key.Dataset.ToVersionedInstanceIdentifier(0), DefaultCancellationToken).Returns(x.Value));
-        streamsAndStoredFiles.ForEach(x => _fileStore.GetStreamingFileAsync(x.Key.Dataset.ToVersionedInstanceIdentifier(0), DefaultCancellationToken).Returns(x.Value));
-        _fileStore.GetFilePropertiesAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier, DefaultCancellationToken).Returns(new FileProperties() { ContentLength = streamsAndStoredFiles.First().Value.Length });
+        streamsAndStoredFiles.ForEach(x => _fileStore.GetFileAsync(0, DefaultCancellationToken).Returns(x.Value));
+        streamsAndStoredFiles.ForEach(x => _fileStore.GetStreamingFileAsync(0, DefaultCancellationToken).Returns(x.Value));
+        _fileStore.GetFilePropertiesAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier.Version, DefaultCancellationToken).Returns(new FileProperties() { ContentLength = streamsAndStoredFiles.First().Value.Length });
         streamsAndStoredFiles.ForEach(x => _retrieveTranscoder.TranscodeFileAsync(x.Value, requestedTransferSyntax).Returns(x.Value));
 
         // act
@@ -440,8 +440,8 @@ public class RetrieveResourceServiceTests
 
         // For the first instance identifier, set up the fileStore to return a stream containing a file associated with the identifier.
         KeyValuePair<DicomFile, Stream> streamAndStoredFile = StreamAndStoredFileFromDataset(GenerateDatasetsFromIdentifiers(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier, originalTransferSyntax), frames: 3).Result;
-        _fileStore.GetFileAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier, DefaultCancellationToken).Returns(streamAndStoredFile.Value);
-        _fileStore.GetFilePropertiesAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier, DefaultCancellationToken).Returns(new FileProperties() { ContentLength = streamAndStoredFile.Value.Length });
+        _fileStore.GetFileAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier.Version, DefaultCancellationToken).Returns(streamAndStoredFile.Value);
+        _fileStore.GetFilePropertiesAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier.Version, DefaultCancellationToken).Returns(new FileProperties() { ContentLength = streamAndStoredFile.Value.Length });
 
         // Setup frame handler to return the frames as streams from the file.
         Stream[] frames = framesToRequest.Select(f => GetFrameFromFile(streamAndStoredFile.Key.Dataset, f)).ToArray();
@@ -489,10 +489,10 @@ public class RetrieveResourceServiceTests
         // For each instance identifier, set up the fileStore to return a stream containing a file associated with the identifier.
         var streamsAndStoredFiles = versionedInstanceIdentifiers.Select(
             x => StreamAndStoredFileFromDataset(GenerateDatasetsFromIdentifiers(x.VersionedInstanceIdentifier, originalTransferSyntax)).Result).ToList();
-        streamsAndStoredFiles.ForEach(x => _fileStore.GetFileAsync(x.Key.Dataset.ToVersionedInstanceIdentifier(0), DefaultCancellationToken).Returns(x.Value));
-        streamsAndStoredFiles.ForEach(x => _fileStore.GetStreamingFileAsync(x.Key.Dataset.ToVersionedInstanceIdentifier(0), DefaultCancellationToken).Returns(x.Value));
-        _fileStore.GetFilePropertiesAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier, DefaultCancellationToken).Returns(new FileProperties() { ContentLength = streamsAndStoredFiles.First().Value.Length });
-        _fileStore.GetFilePropertiesAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier, DefaultCancellationToken).Returns(new FileProperties() { ContentLength = streamsAndStoredFiles.First().Value.Length });
+        streamsAndStoredFiles.ForEach(x => _fileStore.GetFileAsync(0, DefaultCancellationToken).Returns(x.Value));
+        streamsAndStoredFiles.ForEach(x => _fileStore.GetStreamingFileAsync(0, DefaultCancellationToken).Returns(x.Value));
+        _fileStore.GetFilePropertiesAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier.Version, DefaultCancellationToken).Returns(new FileProperties() { ContentLength = streamsAndStoredFiles.First().Value.Length });
+        _fileStore.GetFilePropertiesAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier.Version, DefaultCancellationToken).Returns(new FileProperties() { ContentLength = streamsAndStoredFiles.First().Value.Length });
         streamsAndStoredFiles.ForEach(x => _retrieveTranscoder.TranscodeFileAsync(x.Value, requestedTransferSyntax).Returns(x.Value));
 
         // act
@@ -529,7 +529,7 @@ public class RetrieveResourceServiceTests
         var framesToRequest = new List<int> { 1, 2 };
         // arrange fileSize to be greater than max supported
         long aboveMaxFileSize = new RetrieveConfiguration().MaxDicomFileSize + 1;
-        _fileStore.GetFilePropertiesAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier, DefaultCancellationToken).Returns(new FileProperties() { ContentLength = aboveMaxFileSize });
+        _fileStore.GetFilePropertiesAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier.Version, DefaultCancellationToken).Returns(new FileProperties() { ContentLength = aboveMaxFileSize });
 
         // act and assert
         await Assert.ThrowsAsync<NotAcceptableException>(() =>
@@ -554,7 +554,7 @@ public class RetrieveResourceServiceTests
         // assert
         var identifier = new InstanceIdentifier(_studyInstanceUid, _firstSeriesInstanceUid, _sopInstanceUid, DefaultPartition.Key);
         await _instanceMetadataCache.Received(1).GetAsync(Arg.Any<object>(), identifier, Arg.Any<Func<InstanceIdentifier, CancellationToken, Task<InstanceMetadata>>>(), Arg.Any<CancellationToken>());
-        await _framesRangeCache.Received(1).GetAsync(Arg.Any<object>(), Arg.Any<VersionedInstanceIdentifier>(), Arg.Any<Func<VersionedInstanceIdentifier, CancellationToken, Task<IReadOnlyDictionary<int, FrameRange>>>>(), Arg.Any<CancellationToken>());
+        await _framesRangeCache.Received(1).GetAsync(Arg.Any<object>(), Arg.Any<long>(), Arg.Any<Func<long, CancellationToken, Task<IReadOnlyDictionary<int, FrameRange>>>>(), Arg.Any<CancellationToken>());
     }
 
     private List<InstanceMetadata> SetupInstanceIdentifiersList(ResourceType resourceType, int partitionKey = DefaultPartition.Key, InstanceProperties instanceProperty = null)

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/StoreOrchestratorTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/StoreOrchestratorTests.cs
@@ -99,7 +99,7 @@ public class StoreOrchestratorTests
     public async Task GivenFailedToStoreFile_WhenStoringFile_ThenCleanupShouldBeAttempted()
     {
         _fileStore.StoreFileAsync(
-            Arg.Is<long>(identifier => DefaultVersionedInstanceIdentifier.Equals(identifier)),
+            Arg.Is<long>(identifier => DefaultVersionedInstanceIdentifier.Version.Equals(identifier)),
             _stream,
             cancellationToken: DefaultCancellationToken)
             .Throws(new Exception());

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/StoreOrchestratorTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/StoreOrchestratorTests.cs
@@ -99,7 +99,7 @@ public class StoreOrchestratorTests
     public async Task GivenFailedToStoreFile_WhenStoringFile_ThenCleanupShouldBeAttempted()
     {
         _fileStore.StoreFileAsync(
-            Arg.Is<VersionedInstanceIdentifier>(identifier => DefaultVersionedInstanceIdentifier.Equals(identifier)),
+            Arg.Is<long>(identifier => DefaultVersionedInstanceIdentifier.Equals(identifier)),
             _stream,
             cancellationToken: DefaultCancellationToken)
             .Throws(new Exception());

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/StoreOrchestratorTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/StoreOrchestratorTests.cs
@@ -99,7 +99,7 @@ public class StoreOrchestratorTests
     public async Task GivenFailedToStoreFile_WhenStoringFile_ThenCleanupShouldBeAttempted()
     {
         _fileStore.StoreFileAsync(
-            Arg.Is<long>(identifier => DefaultVersionedInstanceIdentifier.Version.Equals(identifier)),
+            DefaultVersionedInstanceIdentifier.Version,
             _stream,
             cancellationToken: DefaultCancellationToken)
             .Throws(new Exception());

--- a/src/Microsoft.Health.Dicom.Core/Features/ChangeFeed/ChangeFeedService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/ChangeFeed/ChangeFeedService.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -85,7 +85,7 @@ public class ChangeFeedService : IChangeFeedService
         }
 
         var identifier = new VersionedInstanceIdentifier(entry.StudyInstanceUid, entry.SeriesInstanceUid, entry.SopInstanceUid, entry.CurrentVersion.Value);
-        entry.Metadata = await _metadataStore.GetInstanceMetadataAsync(identifier, cancellationToken);
+        entry.Metadata = await _metadataStore.GetInstanceMetadataAsync(identifier.Version, cancellationToken);
         entry.IncludeMetadata = true;
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Common/IFileStore.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Common/IFileStore.cs
@@ -19,57 +19,53 @@ public interface IFileStore
     /// <summary>
     /// Asynchronously stores a file to the file store.
     /// </summary>
-    /// <param name="versionedInstanceIdentifier">The DICOM identifier.</param>
+    /// <param name="version">The DICOM instance version.</param>
     /// <param name="stream">The DICOM instance stream.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous add operation.</returns>
-    Task<Uri> StoreFileAsync(VersionedInstanceIdentifier versionedInstanceIdentifier, Stream stream, CancellationToken cancellationToken = default);
+    Task<Uri> StoreFileAsync(long version, Stream stream, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Asynchronously gets a file from the file store.
     /// </summary>
-    /// <param name="versionedInstanceIdentifier">The DICOM identifier.</param>
+    /// <param name="version">The DICOM instance version.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous get operation.</returns>
-    Task<Stream> GetFileAsync(VersionedInstanceIdentifier versionedInstanceIdentifier, CancellationToken cancellationToken = default);
+    Task<Stream> GetFileAsync(long version, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Asynchronously deletes a file from the file store if the file exists.
     /// </summary>
-    /// <param name="versionedInstanceIdentifier">The DICOM identifier.</param>
+    /// <param name="version">The DICOM instance version.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous delete operation.</returns>
-    Task DeleteFileIfExistsAsync(VersionedInstanceIdentifier versionedInstanceIdentifier, CancellationToken cancellationToken = default);
+    Task DeleteFileIfExistsAsync(long version, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Asynchronously get file properties
     /// </summary>
-    /// <param name="versionedInstanceIdentifier">The DICOM identifier.</param>
+    /// <param name="version">The DICOM instance version.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous get properties operation.</returns>
-    Task<FileProperties> GetFilePropertiesAsync(
-        VersionedInstanceIdentifier versionedInstanceIdentifier,
-        CancellationToken cancellationToken = default);
+    Task<FileProperties> GetFilePropertiesAsync(long version, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Asynchronously get a specific range of bytes from the blob
     /// </summary>
-    /// <param name="versionedInstanceIdentifier">The DICOM identifier.</param>
+    /// <param name="version">The DICOM instance version.</param>
     /// <param name="range">Byte range in Httprange format with offset and length</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>Stream representing the bytes requested</returns>
     Task<Stream> GetFileFrameAsync(
-        VersionedInstanceIdentifier versionedInstanceIdentifier,
+        long version,
         FrameRange range,
         CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Asynchronously gets a streaming file from the file store.
     /// </summary>
-    /// <param name="versionedInstanceIdentifier">The DICOM identifier.</param>
+    /// <param name="version">The DICOM instance version.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous get operation.</returns>
-    Task<Stream> GetStreamingFileAsync(
-        VersionedInstanceIdentifier versionedInstanceIdentifier,
-        CancellationToken cancellationToken = default);
+    Task<Stream> GetStreamingFileAsync(long version, CancellationToken cancellationToken = default);
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Common/IMetadataStore.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Common/IMetadataStore.cs
@@ -31,52 +31,52 @@ public interface IMetadataStore
     /// <summary>
     /// Asynchronously gets a DICOM instance metadata.
     /// </summary>
-    /// <param name="versionedInstanceIdentifier">The DICOM instance identifier.</param>
+    /// <param name="version">The DICOM instance version.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous get operation.</returns>
     Task<DicomDataset> GetInstanceMetadataAsync(
-        VersionedInstanceIdentifier versionedInstanceIdentifier,
+        long version,
         CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Asynchronously deletes a DICOM instance metadata.
     /// </summary>
-    /// <param name="versionedInstanceIdentifier">The DICOM instance identifier.</param>
+    /// <param name="version">The DICOM instance version.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous delete operation.</returns>
     Task DeleteInstanceMetadataIfExistsAsync(
-        VersionedInstanceIdentifier versionedInstanceIdentifier,
+        long version,
         CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Async store Frames range metadata
     /// </summary>
-    /// <param name="versionedInstanceIdentifier">The DICOM instance identifier.</param>
+    /// <param name="version">The DICOM instance version.</param>
     /// <param name="framesRange">Dictionary of frame id and byte range</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the async add of frame metadata</returns>
     Task StoreInstanceFramesRangeAsync(
-            VersionedInstanceIdentifier versionedInstanceIdentifier,
+            long version,
             IReadOnlyDictionary<int, FrameRange> framesRange,
             CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Async get Frames range metadata
     /// </summary>
-    /// <param name="versionedInstanceIdentifier">The DICOM instance identifier.</param>
+    /// <param name="version">The DICOM instance version.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>Dictionary of frame id and byte range</returns>
     Task<IReadOnlyDictionary<int, FrameRange>> GetInstanceFramesRangeAsync(
-        VersionedInstanceIdentifier versionedInstanceIdentifier,
+        long version,
         CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Asynchronously deletes a DICOM instance frameRange metadata.
     /// </summary>
-    /// <param name="versionedInstanceIdentifier">The DICOM instance identifier.</param>
+    /// <param name="version">The DICOM instance version.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous delete operation.</returns>
     Task DeleteInstanceFramesRangeAsync(
-        VersionedInstanceIdentifier versionedInstanceIdentifier,
+        long version,
         CancellationToken cancellationToken = default);
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Delete/DeleteService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Delete/DeleteService.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -106,9 +106,9 @@ public class DeleteService : IDeleteService
                     {
                         Task[] tasks = new[]
                         {
-                            _fileStore.DeleteFileIfExistsAsync(deletedInstanceIdentifier, cancellationToken),
-                            _metadataStore.DeleteInstanceMetadataIfExistsAsync(deletedInstanceIdentifier, cancellationToken),
-                            _metadataStore.DeleteInstanceFramesRangeAsync(deletedInstanceIdentifier, cancellationToken),
+                            _fileStore.DeleteFileIfExistsAsync(deletedInstanceIdentifier.Version, cancellationToken),
+                            _metadataStore.DeleteInstanceMetadataIfExistsAsync(deletedInstanceIdentifier.Version, cancellationToken),
+                            _metadataStore.DeleteInstanceFramesRangeAsync(deletedInstanceIdentifier.Version, cancellationToken),
                         };
 
                         await Task.WhenAll(tasks);

--- a/src/Microsoft.Health.Dicom.Core/Features/Indexing/InstanceReindexer.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Indexing/InstanceReindexer.cs
@@ -47,7 +47,7 @@ public class InstanceReindexer : IInstanceReindexer
         EnsureArg.IsNotNull(entries, nameof(entries));
         EnsureArg.IsNotNull(versionedInstanceId, nameof(versionedInstanceId));
 
-        DicomDataset dataset = await _metadataStore.GetInstanceMetadataAsync(versionedInstanceId, cancellationToken);
+        DicomDataset dataset = await _metadataStore.GetInstanceMetadataAsync(versionedInstanceId.Version, cancellationToken);
 
         // Only reindex on valid query tags
         IReadOnlyCollection<QueryTag> validQueryTags = await _dicomDatasetReindexValidator.ValidateAsync(

--- a/src/Microsoft.Health.Dicom.Core/Features/Query/QueryService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Query/QueryService.cs
@@ -138,7 +138,7 @@ public class QueryService : IQueryService
         if (getFullMetadata)
         {
             instanceMetadata = await Task.WhenAll(
-                queryResult.DicomInstances.Select(x => _metadataStore.GetInstanceMetadataAsync(x, cancellationToken)));
+                queryResult.DicomInstances.Select(x => _metadataStore.GetInstanceMetadataAsync(x.Version, cancellationToken)));
         }
         if (getSeriesResponse)
         {

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/FramesRangeCache.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/FramesRangeCache.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -12,7 +12,7 @@ using Microsoft.Health.Dicom.Core.Features.Model;
 
 namespace Microsoft.Health.Dicom.Core.Features.Retrieve;
 
-public class FramesRangeCache : EphemeralMemoryCache<VersionedInstanceIdentifier, IReadOnlyDictionary<int, FrameRange>>, IFramesRangeCache
+public class FramesRangeCache : EphemeralMemoryCache<long, IReadOnlyDictionary<int, FrameRange>>, IFramesRangeCache
 {
     public FramesRangeCache(IOptions<FramesRangeCacheConfiguration> configuration, ILoggerFactory loggerFactory, ILogger<FramesRangeCache> logger)
         : base(configuration, loggerFactory, logger)

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/IFramesRangeCache.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/IFramesRangeCache.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -15,7 +15,7 @@ public interface IFramesRangeCache
 {
     public Task<IReadOnlyDictionary<int, FrameRange>> GetAsync(
        object key,
-       VersionedInstanceIdentifier input,
-       Func<VersionedInstanceIdentifier, CancellationToken, Task<IReadOnlyDictionary<int, FrameRange>>> asyncFactory,
+       long input,
+       Func<long, CancellationToken, Task<IReadOnlyDictionary<int, FrameRange>>> asyncFactory,
        CancellationToken cancellationToken = default);
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveMetadataService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveMetadataService.cs
@@ -101,7 +101,7 @@ public class RetrieveMetadataService : IRetrieveMetadataService
         IAsyncEnumerable<DicomDataset> instanceMetadata = isCacheValid
             ? AsyncEnumerable.Empty<DicomDataset>()
             : instancesToRetrieve.SelectParallel(
-                (x, t) => new ValueTask<DicomDataset>(_metadataStore.GetInstanceMetadataAsync(x, t)),
+                (x, t) => new ValueTask<DicomDataset>(_metadataStore.GetInstanceMetadataAsync(x.Version, t)),
                 new ParallelEnumerationOptions { MaxDegreeOfParallelism = _options.MaxDegreeOfParallelism },
                 cancellationToken);
 

--- a/src/Microsoft.Health.Dicom.Core/Features/Store/StoreOrchestrator.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Store/StoreOrchestrator.cs
@@ -112,7 +112,7 @@ public class StoreOrchestrator : IStoreOrchestrator
         Stream stream = await dicomInstanceEntry.GetStreamAsync(cancellationToken);
 
         await _fileStore.StoreFileAsync(
-            versionedInstanceIdentifier,
+            versionedInstanceIdentifier.Version,
             stream,
             cancellationToken);
 
@@ -135,9 +135,7 @@ public class StoreOrchestrator : IStoreOrchestrator
 
         if (framesRange != null && framesRange.Count > 0)
         {
-            var identifier = dicomDataset.ToVersionedInstanceIdentifier(version);
-
-            await _metadataStore.StoreInstanceFramesRangeAsync(identifier, framesRange, cancellationToken);
+            await _metadataStore.StoreInstanceFramesRangeAsync(version, framesRange, cancellationToken);
             hasFrameMetadata = true;
         }
         return hasFrameMetadata;

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Features/RetrieveResourceServiceTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Features/RetrieveResourceServiceTests.cs
@@ -186,8 +186,6 @@ public class RetrieveResourceServiceTests : IClassFixture<DataStoreTestsFixture>
     {
         long version = await _indexDataStore.BeginCreateInstanceIndexAsync(1, dataset);
 
-        var versionedInstanceIdentifier = dataset.ToVersionedInstanceIdentifier(version);
-
         if (flagToStoreInstance)
         {
             var dicomFile = new DicomFile(dataset);
@@ -199,7 +197,7 @@ public class RetrieveResourceServiceTests : IClassFixture<DataStoreTestsFixture>
             dicomFile.Save(stream);
             stream.Position = 0;
             await _fileStore.StoreFileAsync(
-                versionedInstanceIdentifier,
+                version,
                 stream);
         }
 

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/DeleteServiceTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/DeleteServiceTests.cs
@@ -88,8 +88,8 @@ public class DeleteServiceTests : IClassFixture<DeleteServiceTestsFixture>
         Assert.True(success);
         Assert.Equal(1, retrievedInstanceCount);
 
-        await Assert.ThrowsAsync<ItemNotFoundException>(async () => await _fixture.MetadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifier.Version));
-        await Assert.ThrowsAsync<ItemNotFoundException>(async () => await _fixture.FileStore.GetFileAsync(versionedInstanceIdentifier.Version));
+        await Assert.ThrowsAsync<ItemNotFoundException>(() => _fixture.MetadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifier.Version));
+        await Assert.ThrowsAsync<ItemNotFoundException>(() => _fixture.FileStore.GetFileAsync(versionedInstanceIdentifier.Version));
 
         Assert.Empty(await _fixture.IndexDataStoreTestHelper.GetDeletedInstanceEntriesAsync(versionedInstanceIdentifier.StudyInstanceUid, versionedInstanceIdentifier.SeriesInstanceUid, versionedInstanceIdentifier.SopInstanceUid));
     }

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/DeleteServiceTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/DeleteServiceTests.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -58,9 +58,9 @@ public class DeleteServiceTests : IClassFixture<DeleteServiceTestsFixture>
 
         if (persistMetadata)
         {
-            await _fixture.MetadataStore.StoreInstanceMetadataAsync(newDataSet, versionedDicomInstanceIdentifier.Version);
+            await _fixture.MetadataStore.StoreInstanceMetadataAsync(newDataSet, version);
 
-            var metaEntry = await _fixture.MetadataStore.GetInstanceMetadataAsync(versionedDicomInstanceIdentifier);
+            var metaEntry = await _fixture.MetadataStore.GetInstanceMetadataAsync(version);
             Assert.Equal(versionedDicomInstanceIdentifier.SopInstanceUid, metaEntry.GetSingleValue<string>(DicomTag.SOPInstanceUID));
         }
 
@@ -70,12 +70,12 @@ public class DeleteServiceTests : IClassFixture<DeleteServiceTestsFixture>
 
             await using (MemoryStream stream = _fixture.RecyclableMemoryStreamManager.GetStream("GivenDeletedInstances_WhenCleanupCalled_FilesAndTriesAreRemoved.fileData", fileData, 0, fileData.Length))
             {
-                Uri fileLocation = await _fixture.FileStore.StoreFileAsync(versionedDicomInstanceIdentifier, stream);
+                Uri fileLocation = await _fixture.FileStore.StoreFileAsync(version, stream);
 
                 Assert.NotNull(fileLocation);
             }
 
-            var file = await _fixture.FileStore.GetFileAsync(versionedDicomInstanceIdentifier);
+            var file = await _fixture.FileStore.GetFileAsync(version);
 
             Assert.NotNull(file);
         }
@@ -88,8 +88,8 @@ public class DeleteServiceTests : IClassFixture<DeleteServiceTestsFixture>
         Assert.True(success);
         Assert.Equal(1, retrievedInstanceCount);
 
-        await Assert.ThrowsAsync<ItemNotFoundException>(async () => await _fixture.MetadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifier));
-        await Assert.ThrowsAsync<ItemNotFoundException>(async () => await _fixture.FileStore.GetFileAsync(versionedInstanceIdentifier));
+        await Assert.ThrowsAsync<ItemNotFoundException>(async () => await _fixture.MetadataStore.GetInstanceMetadataAsync(versionedInstanceIdentifier.Version));
+        await Assert.ThrowsAsync<ItemNotFoundException>(async () => await _fixture.FileStore.GetFileAsync(versionedInstanceIdentifier.Version));
 
         Assert.Empty(await _fixture.IndexDataStoreTestHelper.GetDeletedInstanceEntriesAsync(versionedInstanceIdentifier.StudyInstanceUid, versionedInstanceIdentifier.SeriesInstanceUid, versionedInstanceIdentifier.SopInstanceUid));
     }


### PR DESCRIPTION
## Description
Since we are using watermark for file name, we don't need VersionedInstanceIdentifier to be passed as an argument. Replaced VersionedInstanceIdentifier to watermark on all the methods

## Related issues
Addresses [issue #].

## Testing
Updated existing unit tests and E2E tests