### PR TITLE
set v2 as current api

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Features/Conventions/ApiVersionsConvention.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Conventions/ApiVersionsConvention.cs
@@ -30,14 +30,17 @@ internal class ApiVersionsConvention : IControllerConvention
         // this will result in null minor instead of 0 minor. There is no constructor on ApiVersion that allows this directly
         ApiVersion.Parse("1.0-prerelease"),
         ApiVersion.Parse("1"),
+        ApiVersion.Parse("2"),
     };
 
+    /// <summary>
+    /// Add upcoming API versions here so they can be used for private previews.
+    /// When upcomingVersion is ready for GA, move upcomingVersion to allSupportedVersion and remove from here.
+    /// </summary>
     private static readonly IReadOnlyList<ApiVersion> UpcomingVersion = new List<ApiVersion>()
-    {
-        ApiVersion.Parse("2")
-    };
+    { };
 
-    private const int CurrentVersion = 1;
+    private const int CurrentVersion = 2;
     private readonly bool _isLatestApiVersionEnabled;
 
     public ApiVersionsConvention(IOptions<FeatureConfiguration> featureConfiguration)
@@ -61,7 +64,7 @@ internal class ApiVersionsConvention : IControllerConvention
         {
             versions = GetAllSupportedVersions(controllerIntroducedInVersion.Value, CurrentVersion);
         }
-        // when upcomingVersion is ready for GA, move upcomingVerion to allSupportedVersion and remove this logic
+
         versions = _isLatestApiVersionEnabled == true ? versions.Union(UpcomingVersion) : versions;
 
         controller.HasApiVersions(versions);


### PR DESCRIPTION
## Description
Upgrades V2 as current. 

## Related issues
Addresses [[AB#102958](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/102958)].

