### PR TITLE
Support get frame for both original and current version

### DIFF
--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveResourceServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveResourceServiceTests.cs
@@ -420,8 +420,8 @@ public class RetrieveResourceServiceTests
         // For each instance identifier, set up the fileStore to return a stream containing a file associated with the identifier.
         var streamsAndStoredFiles = versionedInstanceIdentifiers.Select(
             x => RetrieveHelpers.StreamAndStoredFileFromDataset(RetrieveHelpers.GenerateDatasetsFromIdentifiers(x.VersionedInstanceIdentifier, originalTransferSyntax), _recyclableMemoryStreamManager).Result).ToList();
-        streamsAndStoredFiles.ForEach(x => _fileStore.GetFileAsync(0, DefaultCancellationToken).Returns(x.Value));
-        streamsAndStoredFiles.ForEach(x => _fileStore.GetStreamingFileAsync(0, DefaultCancellationToken).Returns(x.Value));
+        streamsAndStoredFiles.ForEach(x => _fileStore.GetFileAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier.Version, DefaultCancellationToken).Returns(x.Value));
+        streamsAndStoredFiles.ForEach(x => _fileStore.GetStreamingFileAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier.Version, DefaultCancellationToken).Returns(x.Value));
         _fileStore.GetFilePropertiesAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier.Version, DefaultCancellationToken).Returns(new FileProperties() { ContentLength = streamsAndStoredFiles.First().Value.Length });
         streamsAndStoredFiles.ForEach(x => _retrieveTranscoder.TranscodeFileAsync(x.Value, requestedTransferSyntax).Returns(x.Value));
 
@@ -499,8 +499,8 @@ public class RetrieveResourceServiceTests
         // For each instance identifier, set up the fileStore to return a stream containing a file associated with the identifier.
         var streamsAndStoredFiles = versionedInstanceIdentifiers.Select(
             x => RetrieveHelpers.StreamAndStoredFileFromDataset(RetrieveHelpers.GenerateDatasetsFromIdentifiers(x.VersionedInstanceIdentifier, originalTransferSyntax), _recyclableMemoryStreamManager).Result).ToList();
-        streamsAndStoredFiles.ForEach(x => _fileStore.GetFileAsync(0, DefaultCancellationToken).Returns(x.Value));
-        streamsAndStoredFiles.ForEach(x => _fileStore.GetStreamingFileAsync(0, DefaultCancellationToken).Returns(x.Value));
+        streamsAndStoredFiles.ForEach(x => _fileStore.GetFileAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier.Version, DefaultCancellationToken).Returns(x.Value));
+        streamsAndStoredFiles.ForEach(x => _fileStore.GetStreamingFileAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier.Version, DefaultCancellationToken).Returns(x.Value));
         _fileStore.GetFilePropertiesAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier.Version, DefaultCancellationToken).Returns(new FileProperties() { ContentLength = streamsAndStoredFiles.First().Value.Length });
         _fileStore.GetFilePropertiesAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier.Version, DefaultCancellationToken).Returns(new FileProperties() { ContentLength = streamsAndStoredFiles.First().Value.Length });
         streamsAndStoredFiles.ForEach(x => _retrieveTranscoder.TranscodeFileAsync(x.Value, requestedTransferSyntax).Returns(x.Value));

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveResourceServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveResourceServiceTests.cs
@@ -299,7 +299,7 @@ public class RetrieveResourceServiceTests
         _fileStore.GetFilePropertiesAsync(Arg.Any<long>(), DefaultCancellationToken).Returns(new FileProperties() { ContentLength = 1000 });
         // For the first instance identifier, set up the fileStore to return a stream containing a file associated with the identifier.
         KeyValuePair<DicomFile, Stream> streamAndStoredFile = RetrieveHelpers.StreamAndStoredFileFromDataset(RetrieveHelpers.GenerateDatasetsFromIdentifiers(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier), _recyclableMemoryStreamManager).Result;
-        _fileStore.GetStreamingFileAsync(0, DefaultCancellationToken).Returns(streamAndStoredFile.Value);
+        _fileStore.GetStreamingFileAsync(versionedInstanceIdentifiers.First().VersionedInstanceIdentifier.Version, DefaultCancellationToken).Returns(streamAndStoredFile.Value);
 
         RetrieveResourceResponse response = await _retrieveResourceService.GetInstanceResourceAsync(
                new RetrieveResourceRequest(

--- a/src/Microsoft.Health.Dicom.Tests.Common/Samples.cs
+++ b/src/Microsoft.Health.Dicom.Tests.Common/Samples.cs
@@ -141,14 +141,15 @@ public static class Samples
     }
 
     public static DicomFile CreateRandomDicomFileWithPixelData(
-    string studyInstanceUid = null,
-    string seriesInstanceUid = null,
-    string sopInstanceUid = null,
-    int rows = 50,
-    int columns = 50,
-    int frames = 1)
+        string studyInstanceUid = null,
+        string seriesInstanceUid = null,
+        string sopInstanceUid = null,
+        int rows = 50,
+        int columns = 50,
+        int frames = 1,
+        DicomTransferSyntax dicomTransferSyntax = null)
     {
-        var result = new DicomFile(CreateRandomInstanceDataset(studyInstanceUid, seriesInstanceUid, sopInstanceUid));
+        var result = new DicomFile(CreateRandomInstanceDataset(studyInstanceUid, seriesInstanceUid, sopInstanceUid, dicomTransferSyntax: dicomTransferSyntax));
         AppendRandomPixelData(rows, columns, frames, result);
         return result;
     }

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Instance.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Instance.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -121,6 +121,26 @@ public partial class RetrieveTransactionResourceTests
         await _instancesManager.StoreAsync(new[] { dicomFile });
 
         using DicomWebResponse<DicomFile> instancesInStudy = await _client.RetrieveInstanceAsync(studyInstanceUid, seriesInstanceUid, sopInstanceUid, dicomTransferSyntax: "*");
+        Assert.Equal(dicomFile.ToByteArray(), (await instancesInStudy.GetValueAsync()).ToByteArray());
+    }
+
+    [Fact]
+    public async Task GivenSupportedInternalTransferSyntax_WhenRetrieveInstanceWithOriginalTransferSyntax_ThenServerShouldReturnOriginalContent()
+    {
+        var studyInstanceUid = TestUidGenerator.Generate();
+        var seriesInstanceUid = TestUidGenerator.Generate();
+        var sopInstanceUid = TestUidGenerator.Generate();
+
+        DicomFile dicomFile = Samples.CreateRandomDicomFileWith8BitPixelData(
+            studyInstanceUid,
+            seriesInstanceUid,
+            sopInstanceUid,
+            transferSyntax: DicomTransferSyntax.ImplicitVRLittleEndian.UID.UID,
+            encode: false);
+
+        await _instancesManager.StoreAsync(new[] { dicomFile });
+
+        using DicomWebResponse<DicomFile> instancesInStudy = await _client.RetrieveInstanceAsync(studyInstanceUid, seriesInstanceUid, sopInstanceUid, dicomTransferSyntax: DicomTransferSyntax.JPEG2000Lossless.UID.UID);
         Assert.Equal(dicomFile.ToByteArray(), (await instancesInStudy.GetValueAsync()).ToByteArray());
     }
 

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Instance.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Instance.cs
@@ -1,4 +1,4 @@
-// -------------------------------------------------------------------------------------------------
+﻿// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -121,26 +121,6 @@ public partial class RetrieveTransactionResourceTests
         await _instancesManager.StoreAsync(new[] { dicomFile });
 
         using DicomWebResponse<DicomFile> instancesInStudy = await _client.RetrieveInstanceAsync(studyInstanceUid, seriesInstanceUid, sopInstanceUid, dicomTransferSyntax: "*");
-        Assert.Equal(dicomFile.ToByteArray(), (await instancesInStudy.GetValueAsync()).ToByteArray());
-    }
-
-    [Fact]
-    public async Task GivenSupportedInternalTransferSyntax_WhenRetrieveInstanceWithOriginalTransferSyntax_ThenServerShouldReturnOriginalContent()
-    {
-        var studyInstanceUid = TestUidGenerator.Generate();
-        var seriesInstanceUid = TestUidGenerator.Generate();
-        var sopInstanceUid = TestUidGenerator.Generate();
-
-        DicomFile dicomFile = Samples.CreateRandomDicomFileWith8BitPixelData(
-            studyInstanceUid,
-            seriesInstanceUid,
-            sopInstanceUid,
-            transferSyntax: DicomTransferSyntax.ImplicitVRLittleEndian.UID.UID,
-            encode: false);
-
-        await _instancesManager.StoreAsync(new[] { dicomFile });
-
-        using DicomWebResponse<DicomFile> instancesInStudy = await _client.RetrieveInstanceAsync(studyInstanceUid, seriesInstanceUid, sopInstanceUid, dicomTransferSyntax: DicomTransferSyntax.JPEG2000Lossless.UID.UID);
         Assert.Equal(dicomFile.ToByteArray(), (await instancesInStudy.GetValueAsync()).ToByteArray());
     }
 


### PR DESCRIPTION
## Description
This PR includes changes to support get frame with and without transcoding for both current and original version

## Related issues
Addresses [[AB#102007](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/102007)].

## Testing
New unit tests and E2E tests are added.
