### PR TITLE
Fix Export E2E Test Cleanup

### DIFF
--- a/build/ci/run-e2e-tests.yml
+++ b/build/ci/run-e2e-tests.yml
@@ -43,8 +43,8 @@ jobs:
         $blobContainerName = (New-Guid).ToString('D')
         $connectionString = "BlobEndpoint=https://$(azureStorageAccountName).blob.core.windows.net;SharedAccessSignature=$token"
 
-        Write-Host "##vso[task.setvariable variable=Tests__Export__ConnectionString]$blobContainerName"
-        Write-Host "##vso[task.setvariable variable=Tests__Export__BlobContainerName]$connectionString"
+        Write-Host "##vso[task.setvariable variable=Tests__Export__BlobContainerName]$blobContainerName"
+        Write-Host "##vso[task.setvariable variable=Tests__Export__ConnectionString]$connectionString"
 
   - bash: |
       echo "##vso[task.setvariable variable=testEnvironmentUrl]$(testServerUrl)"

--- a/build/ci/run-e2e-tests.yml
+++ b/build/ci/run-e2e-tests.yml
@@ -40,8 +40,11 @@ jobs:
         $cxt = New-AzStorageContext -StorageAccountName '$(azureStorageAccountName)' -StorageAccountKey $primaryKey
         $token = New-AzStorageAccountSASToken -Service Blob -ResourceType Container,Object -Permission 'rwdl' -Start $start -ExpiryTime $end -Context $cxt
 
+        $blobContainerName = (New-Guid).ToString('D')
         $connectionString = "BlobEndpoint=https://$(azureStorageAccountName).blob.core.windows.net;SharedAccessSignature=$token"
-        Write-Host "##vso[task.setvariable variable=Tests__Export__ConnectionString]$connectionString"
+
+        Write-Host "##vso[task.setvariable variable=Tests__Export__ConnectionString]$blobContainerName"
+        Write-Host "##vso[task.setvariable variable=Tests__Export__BlobContainerName]$connectionString"
 
   - bash: |
       echo "##vso[task.setvariable variable=testEnvironmentUrl]$(testServerUrl)"


### PR DESCRIPTION
## Description
The Export E2E test in our CI pipeline may have problems creating the blob container if the Azure Storage service takes awhile to complete a deletion. This change will instead use a dynamic blob container name such that we do not need to wait on the sometimes asynchronous deletion of containers.

## Related issues
N/A

## Testing
Ad-hoc CI: https://microsofthealthoss.visualstudio.com/DicomServer/_build/results?buildId=30935&view=results
