### PR TITLE
Fix Transient Export Test Failures

### DIFF
--- a/build/ci/run-e2e-tests.yml
+++ b/build/ci/run-e2e-tests.yml
@@ -39,11 +39,8 @@ jobs:
         $end = $start.AddHours(1)
         $cxt = New-AzStorageContext -StorageAccountName '$(azureStorageAccountName)' -StorageAccountKey $primaryKey
         $token = New-AzStorageAccountSASToken -Service Blob -ResourceType Container,Object -Permission 'rwdl' -Start $start -ExpiryTime $end -Context $cxt
-
-        $blobContainerName = (New-Guid).ToString('D')
         $connectionString = "BlobEndpoint=https://$(azureStorageAccountName).blob.core.windows.net;SharedAccessSignature=$token"
 
-        Write-Host "##vso[task.setvariable variable=Tests__Export__BlobContainerName]$blobContainerName"
         Write-Host "##vso[task.setvariable variable=Tests__Export__ConnectionString]$connectionString"
 
   - bash: |

--- a/src/Microsoft.Health.Dicom.Client/Models/ChangeFeedAction.cs
+++ b/src/Microsoft.Health.Dicom.Client/Models/ChangeFeedAction.cs
@@ -9,4 +9,5 @@ public enum ChangeFeedAction
 {
     Create = 0,
     Delete = 1,
+    Update = 2,
 }

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/ExportTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/ExportTests.cs
@@ -176,7 +176,7 @@ public class ExportTests : IClassFixture<WebJobsIntegrationTestFixture<WebStartu
         => CreateContainerClient().CreateIfNotExistsAsync(PublicAccessType.None);
 
     public Task DisposeAsync()
-        => Task.WhenAll(_instanceManager.DisposeAsync().AsTask(), CreateContainerClient().DeleteAsync());
+        => Task.WhenAll(_instanceManager.DisposeAsync().AsTask(), CreateContainerClient().DeleteIfExistsAsync());
 
     private BlobContainerClient CreateContainerClient()
     {
@@ -237,11 +237,13 @@ public class ExportTests : IClassFixture<WebJobsIntegrationTestFixture<WebStartu
 
     private class AzureBlobConnectionOptions
     {
-        public Uri BlobContainerUri { get; set; }
+        public string BlobContainerName { get; set; } = Guid.NewGuid().ToString("D");
+
+        public Uri BlobContainerUri => BlobServiceUri == null ? null : new Uri(BlobServiceUri, BlobContainerName);
+
+        public Uri BlobServiceUri { get; set; }
 
         public string ConnectionString { get; set; } = "UseDevelopmentStorage=true";
-
-        public string BlobContainerName { get; set; } = "export-e2e-test";
 
         public bool UseManagedIdentity { get; set; }
     }

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/ExportTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/ExportTests.cs
@@ -174,14 +174,6 @@ public class ExportTests : IClassFixture<WebJobsIntegrationTestFixture<WebStartu
     public Task DisposeAsync()
         => _instanceManager.DisposeAsync().AsTask();
 
-    private static ExportTestOptions GetTestOptions(IConfiguration configuration)
-    {
-        var options = new ExportTestOptions();
-        configuration.GetSection("Tests:Export").Bind(options);
-
-        return options;
-    }
-
     private static async Task AssertEqualBinaryAsync(DicomDataset expected, Stream actual)
     {
         using var buffer = new MemoryStream();
@@ -211,6 +203,17 @@ public class ExportTests : IClassFixture<WebJobsIntegrationTestFixture<WebStartu
             identifer.SeriesInstanceUid,
             identifer.SopInstanceUid);
 
+    private static ExportTestOptions GetTestOptions(IConfiguration configuration)
+    {
+        var options = new ExportTestOptions();
+        configuration.GetSection("Tests:Export").Bind(options);
+
+        if (string.IsNullOrEmpty(options.BlobContainerName))
+            options.BlobContainerName = Guid.NewGuid().ToString("D");
+
+        return options;
+    }
+
     private sealed class ExportTestOptions : AzureBlobConnectionOptions
     {
         public AzureBlobConnectionOptions Sink { get; set; }
@@ -229,7 +232,7 @@ public class ExportTests : IClassFixture<WebJobsIntegrationTestFixture<WebStartu
 
     private class AzureBlobConnectionOptions
     {
-        public string BlobContainerName { get; } = Guid.NewGuid().ToString("D");
+        public string BlobContainerName { get; set; }
 
         public Uri BlobContainerUri => BlobServiceUri == null ? null : new Uri(BlobServiceUri, BlobContainerName);
 


### PR DESCRIPTION
## Description
Use pseudo-random name for export container to avoid delete latency issues when running back-to-back tests on the same container

## Related issues
[AB#103616](https://microsofthealth.visualstudio.com/Health/_workitems/edit/103616)

## Testing
Ad-hoc CI: https://microsofthealthoss.visualstudio.com/DicomServer/_build/results?buildId=31223&view=results
