### PR TITLE
Ensure all validators handle null same way

### DIFF
--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/StoreDatasetValidatorTestsV1.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/StoreDatasetValidatorTestsV1.cs
@@ -256,6 +256,22 @@ public class StoreDatasetValidatorTestsV1
         };
     }
 
+    [Fact]
+    public async Task GivenNonRequiredTagNull_ExpectTagValidatedAndNoErrorProduced()
+    {
+        DicomDataset dicomDataset = Samples.CreateRandomInstanceDataset(validateItems: false);
+        dicomDataset.Add(DicomTag.ContentDate, new string[] { null });
+        dicomDataset.AddOrUpdate(DicomTag.PatientName, new string[] { null });
+        dicomDataset.Add(DicomTag.WindowCenterWidthExplanation, new string[] { null });
+
+        var result = await _dicomDatasetValidator.ValidateAsync(
+            dicomDataset,
+            null,
+            new CancellationToken());
+
+        Assert.Empty(result.InvalidTagErrors);
+    }
+
     [Theory]
     [MemberData(nameof(GetDuplicatedDicomIdentifierValues))]
     public async Task GivenDuplicatedIdentifiers_WhenValidated_ThenDatasetValidationExceptionShouldBeThrown(string firstDicomTagInString, string secondDicomTagInString)

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/StoreDatasetValidatorTestsV2.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Store/StoreDatasetValidatorTestsV2.cs
@@ -129,8 +129,6 @@ public class StoreDatasetValidatorTestsV2
         Assert.Empty(result.InvalidTagErrors);
     }
 
-
-
     [Theory]
     [InlineData("123,345")]
     public async Task GivenV2Enabled_WhenPatientIDPAddedWithComma_ExpectTagValidatedAndNoErrorProduced(string value)
@@ -138,6 +136,22 @@ public class StoreDatasetValidatorTestsV2
         DicomDataset dicomDataset = Samples.CreateRandomInstanceDataset(
             validateItems: false,
             patientId: value);
+
+        var result = await _dicomDatasetValidator.ValidateAsync(
+            dicomDataset,
+            null,
+            new CancellationToken());
+
+        Assert.Empty(result.InvalidTagErrors);
+    }
+
+    [Fact]
+    public async Task GivenV2Enabled_WhenNonRequiredTagNull_ExpectTagValidatedAndNoErrorProduced()
+    {
+        DicomDataset dicomDataset = Samples.CreateRandomInstanceDataset(validateItems: false);
+        dicomDataset.Add(DicomTag.AcquisitionDateTime, new string[] { null });
+        dicomDataset.AddOrUpdate(DicomTag.PatientName, new string[] { null });
+        dicomDataset.Add(DicomTag.WindowCenterWidthExplanation, new string[] { null });
 
         var result = await _dicomDatasetValidator.ValidateAsync(
             dicomDataset,

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Validation/DateValidationTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Validation/DateValidationTests.cs
@@ -26,6 +26,7 @@ public class DateValidationTests
 
     [Theory]
     [InlineData("20210313")]
+    [InlineData(null)]
     public void GivenDAValidateValue_WhenValidating_ThenShouldPass(string value)
     {
         DicomDate element = new DicomDate(DicomTag.Date, value);

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Validation/EncodedStringElementValidationTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Validation/EncodedStringElementValidationTests.cs
@@ -45,6 +45,7 @@ public class EncodedStringElementValidationTests
         new object[] { new DicomDateTime(DicomTag.EffectiveDateTime, DateTimeOffset.UtcNow.ToString("yyyyMMddHHmmss'.'ffffff'+'0000", CultureInfo.InvariantCulture)) },
         new object[] { new DicomIntegerString(DicomTag.PixelAspectRatio, "0012345") },
         new object[] { new DicomTime(DicomTag.Time, DateTime.UtcNow.ToString("HHmmss'.'fffff", CultureInfo.InvariantCulture)) },
+        new object[] { new DicomTime(DicomTag.Time, (string)null )},
     };
 
     public static object[][] InvalidElements = new object[][]

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Validation/FoDicomValidationTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Validation/FoDicomValidationTests.cs
@@ -1,0 +1,29 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using FellowOakDicom;
+using Microsoft.Health.Dicom.Tests.Common;
+using Xunit;
+
+namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Validation;
+
+/// <summary>
+/// This is a temporary test to show the difference in validation based on how the method is called
+/// </summary>
+public class FoDicomValidationTests
+{
+    [Fact]
+    public void WhenValidatingDirectly_ExpectNullsAccepted_AndOtherwiseNullRefThrown()
+    {
+        string nullValue = null;
+        DicomDataset dicomDataset = Samples.CreateRandomInstanceDataset(validateItems: false);
+        dicomDataset.Add(DicomTag.AcquisitionDateTime, nullValue);
+
+        DicomElement de = dicomDataset.GetDicomItem<DicomElement>(DicomTag.AcquisitionDateTime);
+        de.Validate();
+        Assert.Throws<NullReferenceException>(() => de.ValueRepresentation.ValidateString(nullValue));
+    }
+}

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Validation/LongStringValidationTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Validation/LongStringValidationTests.cs
@@ -17,6 +17,7 @@ public class LongStringValidationTests
     public void GivenValidateLongString_WhenValidating_ThenShouldPass()
     {
         new LongStringValidation().Validate(new DicomLongString(DicomTag.WindowCenterWidthExplanation, "012345678912"));
+        new LongStringValidation().Validate(new DicomLongString(DicomTag.WindowCenterWidthExplanation, (string)null));
     }
 
     [Fact]

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Validation/PersonNameValidationTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Validation/PersonNameValidationTests.cs
@@ -16,8 +16,8 @@ public class PersonNameValidationTests
     [Fact]
     public void GivenValidatePersonName_WhenValidating_ThenShouldPass()
     {
-        DicomElement element = new DicomPersonName(DicomTag.PatientName, "abc^xyz=abc^xyz^xyz^xyz^xyz=abc^xyz");
-        new PersonNameValidation().Validate(element);
+        new PersonNameValidation().Validate(new DicomPersonName(DicomTag.PatientName, "abc^xyz=abc^xyz^xyz^xyz^xyz=abc^xyz"));
+        new PersonNameValidation().Validate(new DicomPersonName(DicomTag.PatientName, (string)null));
     }
 
     [Fact]

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Validation/ReindexDatasetValidatorTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Validation/ReindexDatasetValidatorTests.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FellowOakDicom;
-using Microsoft.Health.Dicom.Core.Exceptions;
 using Microsoft.Health.Dicom.Core.Extensions;
 using Microsoft.Health.Dicom.Core.Features.ExtendedQueryTag;
 using Microsoft.Health.Dicom.Core.Features.Indexing;
@@ -22,12 +21,11 @@ namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Validation;
 public class ReindexDatasetValidatorTests
 {
     private readonly IReindexDatasetValidator _datasetValidator;
-    private readonly IElementMinimumValidator _validator;
+    private readonly IElementMinimumValidator _validator = new ElementMinimumValidator();
     private readonly IExtendedQueryTagErrorsService _tagErrorsService;
 
     public ReindexDatasetValidatorTests()
     {
-        _validator = Substitute.For<IElementMinimumValidator>();
         _tagErrorsService = Substitute.For<IExtendedQueryTagErrorsService>();
         _datasetValidator = new ReindexDatasetValidator(_validator, _tagErrorsService);
 
@@ -49,11 +47,6 @@ public class ReindexDatasetValidatorTests
         var queryTag1 = new QueryTag(new ExtendedQueryTagStoreEntry(1, tag1.GetPath(), element1.ValueRepresentation.Code, null, QueryTagLevel.Instance, ExtendedQueryTagStatus.Ready, QueryStatus.Enabled, 0));
         var queryTag2 = new QueryTag(new ExtendedQueryTagStoreEntry(2, tag2.GetPath(), element2.ValueRepresentation.Code, null, QueryTagLevel.Instance, ExtendedQueryTagStatus.Ready, QueryStatus.Enabled, 0));
 
-        // Throw exception when validate element1
-        _validator
-            .When(x => x.Validate(element1))
-            .Throw(new ElementValidationException(tag1.GetFriendlyName(), DicomVR.DT, ValidationErrorCode.DateTimeIsInvalid));
-
         using var source = new CancellationTokenSource();
 
         // only return querytag2
@@ -64,5 +57,27 @@ public class ReindexDatasetValidatorTests
         await _tagErrorsService
             .Received(1)
             .AddExtendedQueryTagErrorAsync(queryTag1.ExtendedQueryTagStoreEntry.Key, ValidationErrorCode.DateTimeIsInvalid, 1, source.Token);
+    }
+
+    [Fact]
+    public async Task GivenANullValue_WhenValidate_ThenReturnStoredFailure()
+    {
+        string nullValue = null;
+        DicomTag tag1 = DicomTag.AcquisitionDateTime;
+        DicomElement element1 = new DicomDateTime(tag1, nullValue);
+
+        DicomDataset ds = Samples.CreateRandomInstanceDataset();
+#pragma warning disable CS0618
+        ds.AutoValidate = false;
+#pragma warning restore CS0618
+        ds.Add(element1);
+
+        var queryTag1 = new QueryTag(new ExtendedQueryTagStoreEntry(1, tag1.GetPath(), element1.ValueRepresentation.Code, null, QueryTagLevel.Instance, ExtendedQueryTagStatus.Ready, QueryStatus.Enabled, 0));
+
+        using var source = new CancellationTokenSource();
+
+        IReadOnlyCollection<QueryTag> validQueryTags = await _datasetValidator.ValidateAsync(ds, 1, new[] { queryTag1 }, source.Token);
+
+        Assert.Same(queryTag1, validQueryTags.Single());
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Store/StoreDatasetValidator.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Store/StoreDatasetValidator.cs
@@ -212,7 +212,7 @@ public class StoreDatasetValidator : IStoreDatasetValidator
             try
             {
                 string value = dicomDataset.GetString(de.Tag);
-                if (value.EndsWith('\0'))
+                if (value != null && value.EndsWith('\0'))
                 {
                     ValidateWithoutNullPadding(value, de, queryTags);
                 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Validation/EncodedStringElementValidation.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Validation/EncodedStringElementValidation.cs
@@ -35,6 +35,11 @@ internal class EncodedStringElementValidation : IElementValidation
     {
         string value = element.GetFirstValueOrDefault<string>();
 
+        if (string.IsNullOrEmpty(value))
+        {
+            return;
+        }
+
         try
         {
             validate(value);


### PR DESCRIPTION
## Description
Check for value being null before checking if it ends in null padding in string.
MinimumValidator also checks for nulls before calling validate to ensure we have consistency.

Issue submitted to fo-dicom. Depending on how we call validation, sometimes nulls are handled gracefully: https://github.com/fo-dicom/fo-dicom/issues/1590

## Related issues
Addresses [[AB#103623](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/103623)].

## Testing
added unit tests