### PR TITLE
Diagnostic logging for Dicom update

### DIFF
--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Update/UpdateInstanceOperationServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Update/UpdateInstanceOperationServiceTests.cs
@@ -7,10 +7,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using FellowOakDicom;
+using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.Dicom.Core.Exceptions;
 using Microsoft.Health.Dicom.Core.Features.Common;
 using Microsoft.Health.Dicom.Core.Features.Context;
@@ -30,13 +33,17 @@ public class UpdateInstanceOperationServiceTests
     private readonly IGuidFactory _guidFactory;
     private readonly IDicomOperationsClient _client;
     private readonly IDicomRequestContextAccessor _contextAccessor;
+    private readonly TelemetryClient _telemetryClient;
+    private readonly IOptions<JsonSerializerOptions> _jsonSerializerOptions;
 
     public UpdateInstanceOperationServiceTests()
     {
         _guidFactory = Substitute.For<IGuidFactory>();
         _client = Substitute.For<IDicomOperationsClient>();
         _contextAccessor = Substitute.For<IDicomRequestContextAccessor>();
-        _updateInstanceOperationService = new UpdateInstanceOperationService(_guidFactory, _client, _contextAccessor, NullLogger<UpdateInstanceOperationService>.Instance);
+        _telemetryClient = Substitute.For<TelemetryClient>();
+        _jsonSerializerOptions = Substitute.For<IOptions<JsonSerializerOptions>>();
+        _updateInstanceOperationService = new UpdateInstanceOperationService(_guidFactory, _client, _contextAccessor, _telemetryClient, _jsonSerializerOptions, NullLogger<UpdateInstanceOperationService>.Instance);
     }
 
     [Fact]

--- a/src/Microsoft.Health.Dicom.Core/Features/Diagnostic/LogForwarderExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Diagnostic/LogForwarderExtensions.cs
@@ -22,6 +22,8 @@ internal static class LogForwarderExtensions
     private const string StudyInstanceUID = $"{Prefix}studyInstanceUID";
     private const string SeriesInstanceUID = $"{Prefix}seriesInstanceUID";
     private const string SOPInstanceUID = $"{Prefix}sopInstanceUID";
+    private const string InputPayload = $"{Prefix}input";
+    private const string OperationId = $"{Prefix}operationId";
 
     /// <summary>
     /// Emits a trace log with forwarding flag set and adds properties from instanceIdentifier as properties to telemetry.
@@ -66,11 +68,11 @@ internal static class LogForwarderExtensions
         EnsureArg.IsNotNull(message, nameof(message));
         EnsureArg.IsNotNull(jsonSerializerOptions?.Value, nameof(jsonSerializerOptions));
 
-        string property = JsonSerializer.Serialize(value, jsonSerializerOptions.Value);
+        string input = JsonSerializer.Serialize(value, jsonSerializerOptions.Value);
 
         var telemetry = new TraceTelemetry(message);
-        telemetry.Properties.Add(nameof(T), property);
-        telemetry.Properties.Add("operation_id", operationId);
+        telemetry.Properties.Add(InputPayload, input);
+        telemetry.Properties.Add(OperationId, operationId);
         telemetry.Properties.Add(ForwardLogFlag, bool.TrueString);
 
         telemetryClient.TrackTrace(telemetry);

--- a/src/Microsoft.Health.Dicom.Core/Features/Diagnostic/LogForwarderExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Diagnostic/LogForwarderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -7,6 +7,7 @@ using EnsureThat;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.Health.Dicom.Core.Features.Model;
+using Newtonsoft.Json;
 
 namespace Microsoft.Health.Dicom.Core.Features.Diagnostic;
 
@@ -41,6 +42,35 @@ internal static class LogForwarderExtensions
         telemetry.Properties.Add(SeriesInstanceUID, instanceIdentifier.SeriesInstanceUid);
         telemetry.Properties.Add(SOPInstanceUID, instanceIdentifier.SopInstanceUid);
         telemetry.Properties.Add(ForwardLogFlag, bool.TrueString);
+
+        telemetryClient.TrackTrace(telemetry);
+    }
+
+    /// <summary>
+    /// Emits a trace log with forwarding flag set and adds properties from instanceIdentifier as properties to telemetry.
+    /// </summary>
+    /// <param name="telemetryClient">client to use to emit the trace</param>
+    /// <param name="message">message to set on the trace log</param>
+    /// <param name="operationId">operation id</param>
+    /// <param name="value">Object to pass to the forward logger</param>
+    public static void ForwardLogTrace<T>(
+        this TelemetryClient telemetryClient,
+        string message,
+        string operationId,
+        T value)
+    {
+        EnsureArg.IsNotNull(telemetryClient, nameof(telemetryClient));
+        EnsureArg.IsNotNull(message, nameof(message));
+
+        string property = JsonConvert.SerializeObject(value, Formatting.None,
+            new JsonSerializerSettings
+            {
+                ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+            });
+
+        var telemetry = new TraceTelemetry(message);
+        telemetry.Properties.Add(nameof(T), property);
+        telemetry.Properties.Add("operation_id", operationId);
 
         telemetryClient.TrackTrace(telemetry);
     }

--- a/src/Microsoft.Health.Dicom.Core/Features/Diagnostic/LogForwarderExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Diagnostic/LogForwarderExtensions.cs
@@ -71,6 +71,7 @@ internal static class LogForwarderExtensions
         var telemetry = new TraceTelemetry(message);
         telemetry.Properties.Add(nameof(T), property);
         telemetry.Properties.Add("operation_id", operationId);
+        telemetry.Properties.Add(ForwardLogFlag, bool.TrueString);
 
         telemetryClient.TrackTrace(telemetry);
     }

--- a/src/Microsoft.Health.Dicom.Core/Features/Diagnostic/LogForwarderExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Diagnostic/LogForwarderExtensions.cs
@@ -3,11 +3,9 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Text.Json;
 using EnsureThat;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.Extensions.Options;
 using Microsoft.Health.Dicom.Core.Features.Model;
 
 namespace Microsoft.Health.Dicom.Core.Features.Diagnostic;
@@ -55,20 +53,15 @@ internal static class LogForwarderExtensions
     /// <param name="telemetryClient">client to use to emit the trace</param>
     /// <param name="message">message to set on the trace log</param>
     /// <param name="operationId">operation id</param>
-    /// <param name="value">Object to pass to the forward logger</param>
-    /// <param name="jsonSerializerOptions">Json serialization options</param>
-    public static void ForwardLogTrace<T>(
+    /// <param name="input">Input payload to pass to the forward logger</param>
+    public static void ForwardLogTrace(
         this TelemetryClient telemetryClient,
         string message,
         string operationId,
-        T value,
-        IOptions<JsonSerializerOptions> jsonSerializerOptions)
+        string input)
     {
         EnsureArg.IsNotNull(telemetryClient, nameof(telemetryClient));
         EnsureArg.IsNotNull(message, nameof(message));
-        EnsureArg.IsNotNull(jsonSerializerOptions?.Value, nameof(jsonSerializerOptions));
-
-        string input = JsonSerializer.Serialize(value, jsonSerializerOptions.Value);
 
         var telemetry = new TraceTelemetry(message);
         telemetry.Properties.Add(InputPayload, input);

--- a/src/Microsoft.Health.Dicom.Core/Features/Update/UpdateInstanceOperationService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Update/UpdateInstanceOperationService.cs
@@ -100,7 +100,9 @@ public class UpdateInstanceOperationService : IUpdateInstanceOperationService
         try
         {
             var operation = await _client.StartUpdateOperationAsync(operationId, updateSpecification, partitionKey, cancellationToken);
-            _telemetryClient.ForwardLogTrace("Dicom update operation", operationId.ToString(), updateSpecification, _jsonSerializerOptions);
+
+            string input = JsonSerializer.Serialize(updateSpecification, _jsonSerializerOptions.Value);
+            _telemetryClient.ForwardLogTrace("Dicom update operation", operationId.ToString(), input);
             return new UpdateInstanceResponse(operation);
         }
         catch (Exception ex)

--- a/src/Microsoft.Health.Dicom.Core/Features/Update/UpdateInstanceOperationService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Update/UpdateInstanceOperationService.cs
@@ -102,7 +102,7 @@ public class UpdateInstanceOperationService : IUpdateInstanceOperationService
             var operation = await _client.StartUpdateOperationAsync(operationId, updateSpecification, partitionKey, cancellationToken);
 
             string input = JsonSerializer.Serialize(updateSpecification, _jsonSerializerOptions.Value);
-            _telemetryClient.ForwardLogTrace("Dicom update operation", operationId.ToString(), input);
+            _telemetryClient.ForwardOperationLogTrace("Dicom update operation", operationId.ToString(), input);
             return new UpdateInstanceResponse(operation);
         }
         catch (Exception ex)

--- a/src/Microsoft.Health.Dicom.Core/Features/Update/UpdateInstanceOperationService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Update/UpdateInstanceOperationService.cs
@@ -100,7 +100,7 @@ public class UpdateInstanceOperationService : IUpdateInstanceOperationService
         try
         {
             var operation = await _client.StartUpdateOperationAsync(operationId, updateSpecification, partitionKey, cancellationToken);
-            _telemetryClient.ForwardLogTrace("Message from UpdateInstanceOperationService operation", operationId.ToString(), updateSpecification, _jsonSerializerOptions);
+            _telemetryClient.ForwardLogTrace("Dicom update operation", operationId.ToString(), updateSpecification, _jsonSerializerOptions);
             return new UpdateInstanceResponse(operation);
         }
         catch (Exception ex)


### PR DESCRIPTION
## Description
Enable diagnostic logging for Dicom update
Updated tests

## Related issues
Addresses [103949](https://microsofthealth.visualstudio.com/Health/_workitems/edit/103949)

## Testing
Manually testing Dicom update feature.