### PR TITLE
Add xunit logging incase of transient tests

### DIFF
--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveRenderedServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/RetrieveRenderedServiceTests.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using FellowOakDicom.Imaging;
 using FellowOakDicom;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Dicom.Core.Configs;
 using Microsoft.Health.Dicom.Core.Exceptions;
@@ -29,6 +28,7 @@ using Xunit;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using Microsoft.Health.Dicom.Core.Web;
+using Xunit.Abstractions;
 
 namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Retrieve;
 public class RetrieveRenderedServiceTests
@@ -39,7 +39,7 @@ public class RetrieveRenderedServiceTests
     private readonly IDicomRequestContextAccessor _dicomRequestContextAccessor;
     private readonly RecyclableMemoryStreamManager _recyclableMemoryStreamManager;
     private readonly ILogger<RetrieveRenderedService> _logger;
-
+    private readonly ILoggerProvider _xunitLoggerProvider;
     private readonly string _studyInstanceUid = TestUidGenerator.Generate();
     private readonly string _firstSeriesInstanceUid = TestUidGenerator.Generate();
     private readonly string _secondSeriesInstanceUid = TestUidGenerator.Generate();
@@ -47,15 +47,20 @@ public class RetrieveRenderedServiceTests
     private static readonly CancellationToken DefaultCancellationToken = new CancellationTokenSource().Token;
 
 
-    public RetrieveRenderedServiceTests()
+    public RetrieveRenderedServiceTests(ITestOutputHelper output)
     {
         _instanceStore = Substitute.For<IInstanceStore>();
         _fileStore = Substitute.For<IFileStore>();
-        _logger = NullLogger<RetrieveRenderedService>.Instance;
         _dicomRequestContextAccessor = Substitute.For<IDicomRequestContextAccessor>();
         _dicomRequestContextAccessor.RequestContext.DataPartitionEntry = PartitionEntry.Default;
         var retrieveConfigurationSnapshot = Substitute.For<IOptionsSnapshot<RetrieveConfiguration>>();
         retrieveConfigurationSnapshot.Value.Returns(new RetrieveConfiguration());
+
+        var loggerFactory = new LoggerFactory();
+        _xunitLoggerProvider = new XUnitLoggerProvider(output);
+        loggerFactory.AddProvider(_xunitLoggerProvider);
+        _logger = loggerFactory.CreateLogger<RetrieveRenderedService>();
+
         _recyclableMemoryStreamManager = new RecyclableMemoryStreamManager();
         _retrieveRenderedService = new RetrieveRenderedService(
             _instanceStore,

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/XUnitLogger.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/XUnitLogger.cs
@@ -1,0 +1,37 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+
+using System;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+
+namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Retrieve;
+internal class XUnitLogger : ILogger
+{
+    private readonly ITestOutputHelper _testOutputHelper;
+    private readonly string _categoryName;
+
+    public XUnitLogger(ITestOutputHelper testOutputHelper, string categoryName)
+    {
+        _testOutputHelper = testOutputHelper;
+        _categoryName = categoryName;
+    }
+
+    public IDisposable BeginScope<TState>(TState state) => default;
+
+    public bool IsEnabled(LogLevel logLevel)
+        => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+    {
+        _testOutputHelper.WriteLine($"{_categoryName} [{eventId}] {formatter(state, exception)}");
+        if (exception != null)
+        {
+            _testOutputHelper.WriteLine(exception.ToString());
+        }
+    }
+}

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/XUnitLoggerProvider.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/XUnitLoggerProvider.cs
@@ -1,0 +1,25 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Retrieve;
+internal class XUnitLoggerProvider : ILoggerProvider
+{
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public XUnitLoggerProvider(ITestOutputHelper testOutputHelper)
+    {
+        _testOutputHelper = testOutputHelper;
+    }
+
+    public ILogger CreateLogger(string categoryName)
+        => new XUnitLogger(_testOutputHelper, categoryName);
+
+    public void Dispose()
+    {
+    }
+}

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Microsoft.Health.Dicom.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Microsoft.Health.Dicom.Core.UnitTests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.Primitives" />
     <PackageReference Include="Microsoft.Health.Abstractions" />


### PR DESCRIPTION
## Description
We saw a transient test for rendered endpoint before, add logging through xunit so can see logs in case of this occurring again in the future

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.
