### PR TITLE
Prioritize original transfer syntax when multiple accepts with no quality provided

### DIFF
--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/AcceptHeaderHandlerTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/AcceptHeaderHandlerTests.cs
@@ -5,11 +5,13 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using FellowOakDicom;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Dicom.Core.Exceptions;
 using Microsoft.Health.Dicom.Core.Features.Retrieve;
 using Microsoft.Health.Dicom.Core.Messages;
 using Microsoft.Health.Dicom.Core.Messages.Retrieve;
+using Microsoft.Health.Dicom.Core.Web;
 using Xunit;
 
 namespace Microsoft.Health.Dicom.Core.UnitTests.Features.Retrieve;
@@ -139,7 +141,7 @@ public class AcceptHeaderHandlerTests
         AcceptHeader requestedAcceptHeader1 = new AcceptHeader(
             ValidStudyAcceptHeaderDescriptor.MediaType,
             ValidStudyAcceptHeaderDescriptor.PayloadType,
-            ValidStudyAcceptHeaderDescriptor.AcceptableTransferSyntaxes.First(),
+            DicomTransferSyntaxUids.Original,
             quality: 0.3
         );
 
@@ -160,6 +162,28 @@ public class AcceptHeaderHandlerTests
         AcceptHeader matchedAcceptHeader = _handler.GetValidAcceptHeader(
             ResourceType.Study,
             new[] { requestedAcceptHeader1, requestedAcceptHeader2, requestedAcceptHeader3 }
+        );
+
+        Assert.Equivalent(requestedAcceptHeader2, matchedAcceptHeader, strict: true);
+    }
+
+    [Fact]
+    public void GivenMultipleMatchedAcceptHeaderNoQuality_WhenTransferSyntaxRequested_ThenShouldReturnOriginal()
+    {
+        AcceptHeader requestedAcceptHeader1 = new AcceptHeader(
+                payloadType: PayloadTypes.MultipartRelated,
+                mediaType: KnownContentTypes.ImageJpeg2000,
+                transferSyntax: DicomTransferSyntax.JPEG2000Lossless.UID.UID);
+
+        AcceptHeader requestedAcceptHeader2 = new AcceptHeader(
+                payloadType: PayloadTypes.SinglePart,
+                mediaType: KnownContentTypes.ApplicationOctetStream,
+                transferSyntax: DicomTransferSyntaxUids.Original);
+
+
+        AcceptHeader matchedAcceptHeader = _handler.GetValidAcceptHeader(
+            ResourceType.Frames,
+            new[] { requestedAcceptHeader1, requestedAcceptHeader2 }
         );
 
         Assert.Equivalent(requestedAcceptHeader2, matchedAcceptHeader, strict: true);

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/AcceptHeaderHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/AcceptHeaderHandler.cs
@@ -69,7 +69,7 @@ public class AcceptHeaderHandler : IAcceptHeaderHandler
         List<AcceptHeaderDescriptor> descriptors = _acceptableDescriptors[resourceType];
 
         AcceptHeader selectedHeader = null;
-        // we will return the highest priority media type we support, breaking ties by favoring the original media type.
+        // we will return the highest priority media type we support
         foreach (AcceptHeader header in orderedHeaders)
         {
             foreach (AcceptHeaderDescriptor descriptor in descriptors)

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/AcceptHeaderHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/AcceptHeaderHandler.cs
@@ -59,7 +59,7 @@ public class AcceptHeaderHandler : IAcceptHeaderHandler
     public AcceptHeader GetValidAcceptHeader(ResourceType resourceType, IReadOnlyCollection<AcceptHeader> acceptHeaders)
     {
         EnsureArg.IsNotNull(acceptHeaders, nameof(acceptHeaders));
-        List<AcceptHeader> orderedHeaders = acceptHeaders.OrderByDescending(x => x.Quality ?? 0.000).ToList();
+        List<AcceptHeader> orderedHeaders = acceptHeaders.OrderByDescending(x => x.Quality ?? AcceptHeader.DefaultQuality).ToList();
 
         _logger.LogInformation(
             "Getting transfer syntax for retrieving {ResourceType} with accept headers {AcceptHeaders}.",
@@ -69,7 +69,7 @@ public class AcceptHeaderHandler : IAcceptHeaderHandler
         List<AcceptHeaderDescriptor> descriptors = _acceptableDescriptors[resourceType];
 
         AcceptHeader selectedHeader = null;
-        // since these are ordered by quality already, we can return the first acceptable header
+        // we will return the highest priority media type we support, breaking ties by favoring the original media type.
         foreach (AcceptHeader header in orderedHeaders)
         {
             foreach (AcceptHeaderDescriptor descriptor in descriptors)
@@ -100,7 +100,7 @@ public class AcceptHeaderHandler : IAcceptHeaderHandler
     // if no quality provided prioritize returning original transfer syntax
     private static bool IsHigherPriorityTransferSyntax(AcceptHeader header, AcceptHeader selectedHeader)
     {
-        bool isQualityGreater = (header.Quality ?? 0.000) >= (selectedHeader.Quality ?? 0.000);
+        bool isQualityGreater = (header.Quality ?? AcceptHeader.DefaultQuality) >= (selectedHeader.Quality ?? AcceptHeader.DefaultQuality);
         return (header.TransferSyntax.Value == DicomTransferSyntaxUids.Original && isQualityGreater);
     }
 

--- a/src/Microsoft.Health.Dicom.Core/Messages/Retrieve/AcceptHeader.cs
+++ b/src/Microsoft.Health.Dicom.Core/Messages/Retrieve/AcceptHeader.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -11,7 +11,7 @@ namespace Microsoft.Health.Dicom.Core.Messages.Retrieve;
 public class AcceptHeader
 {
     public const double DefaultQuality = 1.0;
-    public AcceptHeader(StringSegment mediaType, PayloadTypes payloadType, StringSegment transferSyntax = default, double? quality = DefaultQuality)
+    public AcceptHeader(StringSegment mediaType, PayloadTypes payloadType, StringSegment transferSyntax = default, double? quality = null)
     {
         MediaType = mediaType;
         PayloadType = payloadType;

--- a/src/Microsoft.Health.Dicom.Core/Messages/Retrieve/AcceptHeader.cs
+++ b/src/Microsoft.Health.Dicom.Core/Messages/Retrieve/AcceptHeader.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Health.Dicom.Core.Messages.Retrieve;
 public class AcceptHeader
 {
     public const double DefaultQuality = 1.0;
-    public AcceptHeader(StringSegment mediaType, PayloadTypes payloadType, StringSegment transferSyntax = default, double? quality = null)
+    public AcceptHeader(StringSegment mediaType, PayloadTypes payloadType, StringSegment transferSyntax = default, double? quality = DefaultQuality)
     {
         MediaType = mediaType;
         PayloadType = payloadType;


### PR DESCRIPTION
## Description
SLIM viewer sends multiple accept headers to get frames. Original is the last, this causes us to pick another accept and fail because today our code needs entire file to do transcoding and will throw when file size is greater than 100M.

This fix will make us prioritize picking original if available in the accept list.

## Related issues
https://github.com/ImagingDataCommons/dicom-microscopy-viewer/issues/95

## Testing
Added unit tests
