### PR TITLE
Correcting naming of Original to Any

### DIFF
--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Extensions/MediaTypeHeaderValueExtensionsTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Extensions/MediaTypeHeaderValueExtensionsTests.cs
@@ -71,7 +71,7 @@ public class MediaTypeHeaderValueExtensionsTests
     public void GivenSinglePartHeader_WhenGetAcceptHeader_ShouldSucceed()
     {
         string mediaType = KnownContentTypes.ApplicationDicom;
-        string transferSyntax = DicomTransferSyntaxUids.Original;
+        string transferSyntax = DicomTransferSyntaxUids.Any;
         double quality = 0.9;
         MediaTypeHeaderValue headerValue = CreateMediaTypeHeaderValue(mediaType, string.Empty, transferSyntax, quality);
         AcceptHeader acceptHeader = headerValue.ToAcceptHeader();
@@ -85,7 +85,7 @@ public class MediaTypeHeaderValueExtensionsTests
     public void GivenMultiPartRelatedHeader_WhenGetAcceptHeader_ShouldSucceed()
     {
         string type = KnownContentTypes.ApplicationOctetStream;
-        string transferSyntax = DicomTransferSyntaxUids.Original;
+        string transferSyntax = DicomTransferSyntaxUids.Any;
 
         double quality = 0.9;
         MediaTypeHeaderValue headerValue = CreateMediaTypeHeaderValue(KnownContentTypes.MultipartRelated, type, transferSyntax, quality);
@@ -116,7 +116,7 @@ public class MediaTypeHeaderValueExtensionsTests
     {
         string mediaType = "multipart/form-data";
         string type = KnownContentTypes.ApplicationDicom;
-        string transferSyntax = DicomTransferSyntaxUids.Original;
+        string transferSyntax = DicomTransferSyntaxUids.Any;
         double quality = 0.9;
         MediaTypeHeaderValue headerValue = CreateMediaTypeHeaderValue(mediaType, type, transferSyntax, quality);
         AcceptHeader acceptHeader = headerValue.ToAcceptHeader();

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/AcceptHeaderDescriptorTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/AcceptHeaderDescriptorTests.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -183,15 +183,15 @@ public class AcceptHeaderDescriptorTests
     {
         Assert.False(ValidStudyAcceptHeaderDescriptor.IsTransferSyntaxMandatory);
         Assert.NotNull(ValidStudyAcceptHeaderDescriptor.TransferSyntaxWhenMissing);
-        Assert.NotEqual(DicomTransferSyntaxUids.Original, ValidStudyAcceptHeaderDescriptor.TransferSyntaxWhenMissing);
+        Assert.NotEqual(DicomTransferSyntaxUids.Any, ValidStudyAcceptHeaderDescriptor.TransferSyntaxWhenMissing);
 
         Assert.Equal(
-            DicomTransferSyntaxUids.Original,
+            DicomTransferSyntaxUids.Any,
             ValidStudyAcceptHeaderDescriptor.GetTransferSyntax(
                 new(
                     ValidStudyAcceptHeaderDescriptor.MediaType,
                     ValidStudyAcceptHeaderDescriptor.PayloadType,
-                    transferSyntax: DicomTransferSyntaxUids.Original)
+                    transferSyntax: DicomTransferSyntaxUids.Any)
             )
         );
     }

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/AcceptHeaderHandlerTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/AcceptHeaderHandlerTests.cs
@@ -141,7 +141,7 @@ public class AcceptHeaderHandlerTests
         AcceptHeader requestedAcceptHeader1 = new AcceptHeader(
             ValidStudyAcceptHeaderDescriptor.MediaType,
             ValidStudyAcceptHeaderDescriptor.PayloadType,
-            DicomTransferSyntaxUids.Original,
+            DicomTransferSyntaxUids.Any,
             quality: 0.3
         );
 
@@ -178,7 +178,7 @@ public class AcceptHeaderHandlerTests
         AcceptHeader requestedAcceptHeader2 = new AcceptHeader(
                 payloadType: PayloadTypes.SinglePart,
                 mediaType: KnownContentTypes.ApplicationOctetStream,
-                transferSyntax: DicomTransferSyntaxUids.Original);
+                transferSyntax: DicomTransferSyntaxUids.Any);
 
 
         AcceptHeader matchedAcceptHeader = _handler.GetValidAcceptHeader(

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/FrameHandlerTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/FrameHandlerTests.cs
@@ -90,7 +90,7 @@ public class FrameHandlerTests
 
     public static IEnumerable<object[]> TestDataForInvokingTranscoderOrNotTests()
     {
-        yield return new object[] { true, DicomTransferSyntaxUids.Original, false };
+        yield return new object[] { true, DicomTransferSyntaxUids.Any, false };
         yield return new object[] { false, DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID, false }; // Created Dataset is on transferSyntax ExplicitVRLittleEndian
         yield return new object[] { false, DicomTransferSyntax.JPEGProcess1.UID.UID, true };
     }

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/FrameHandlerTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/FrameHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -68,13 +68,13 @@ public class FrameHandlerTests
 
     [Theory]
     [MemberData(nameof(TestDataForInvokingTranscoderOrNotTests))]
-    public async Task GivenDicomFileWithFrames_WhenRetrievingWithTransferSyntax_ThenTranscoderShouldBeInvokedAsExpected(bool originalTransferSyntaxRequested, string requestedRepresentation, bool shouldBeInvoked)
+    public async Task GivenDicomFileWithFrames_WhenRetrievingWithTransferSyntax_ThenTranscoderShouldBeInvokedAsExpected(bool originalTransferSyntaxSelected, string requestedRepresentation, bool shouldBeInvoked)
     {
         (DicomFile file, Stream stream) = StreamAndStoredFileFromDataset(GenerateDatasetsFromIdentifiers(), 1).Result;
         ITranscoder transcoder = Substitute.For<ITranscoder>();
         transcoder.TranscodeFrame(Arg.Any<DicomFile>(), Arg.Any<int>(), Arg.Any<string>()).Returns(_recyclableMemoryStreamManager.GetStream());
         FrameHandler frameHandler = new FrameHandler(transcoder, _recyclableMemoryStreamManager);
-        IReadOnlyCollection<Stream> result = await frameHandler.GetFramesResourceAsync(stream, new int[] { 0 }, originalTransferSyntaxRequested, requestedRepresentation);
+        IReadOnlyCollection<Stream> result = await frameHandler.GetFramesResourceAsync(stream, new int[] { 0 }, originalTransferSyntaxSelected, requestedRepresentation);
 
         // Call Position of LazyTransformReadOnlyStream so that transcoder.TranscodeFrame is invoked
         long pos = result.First().Position;

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/AcceptHeaderHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/AcceptHeaderHandler.cs
@@ -101,7 +101,7 @@ public class AcceptHeaderHandler : IAcceptHeaderHandler
     private static bool IsHigherPriorityTransferSyntax(AcceptHeader header, AcceptHeader selectedHeader)
     {
         bool isQualityGreater = (header.Quality ?? AcceptHeader.DefaultQuality) >= (selectedHeader.Quality ?? AcceptHeader.DefaultQuality);
-        return (header.TransferSyntax.Value == DicomTransferSyntaxUids.Original && isQualityGreater);
+        return (header.TransferSyntax.Value == DicomTransferSyntaxUids.Any && isQualityGreater);
     }
 
     private static List<AcceptHeaderDescriptor> DescriptorsForGetNonFrameResource(PayloadTypes payloadTypes)
@@ -113,7 +113,7 @@ public class AcceptHeaderHandler : IAcceptHeaderHandler
                 mediaType: KnownContentTypes.ApplicationDicom,
                 isTransferSyntaxMandatory: false,
                 transferSyntaxWhenMissing: DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID,
-                acceptableTransferSyntaxes: GetAcceptableTransferSyntaxSet(DicomTransferSyntaxUids.Original,
+                acceptableTransferSyntaxes: GetAcceptableTransferSyntaxSet(DicomTransferSyntaxUids.Any,
                     DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID, DicomTransferSyntax.JPEG2000Lossless.UID.UID))
         };
     }
@@ -127,7 +127,7 @@ public class AcceptHeaderHandler : IAcceptHeaderHandler
                 mediaType: KnownContentTypes.ApplicationOctetStream,
                 isTransferSyntaxMandatory: false,
                 transferSyntaxWhenMissing: DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID,
-                acceptableTransferSyntaxes: GetAcceptableTransferSyntaxSet(DicomTransferSyntaxUids.Original,
+                acceptableTransferSyntaxes: GetAcceptableTransferSyntaxSet(DicomTransferSyntaxUids.Any,
                     DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID)),
             new AcceptHeaderDescriptor(
                 payloadType: PayloadTypes.MultipartRelated,

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/FrameHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/FrameHandler.cs
@@ -31,7 +31,7 @@ public class FrameHandler : IFrameHandler
         _recyclableMemoryStreamManager = recyclableMemoryStreamManager;
     }
 
-    public async Task<IReadOnlyCollection<Stream>> GetFramesResourceAsync(Stream stream, IEnumerable<int> frames, bool originalTransferSyntaxRequested, string requestedRepresentation)
+    public async Task<IReadOnlyCollection<Stream>> GetFramesResourceAsync(Stream stream, IEnumerable<int> frames, bool originalTransferSyntaxSelected, string requestedTransferSyntax)
     {
         EnsureArg.IsNotNull(stream, nameof(stream));
         EnsureArg.IsNotNull(frames, nameof(frames));
@@ -41,11 +41,11 @@ public class FrameHandler : IFrameHandler
         // Validate requested frame index exists in file and retrieve the pixel data associated with the file.
         DicomPixelData pixelData = dicomFile.GetPixelDataAndValidateFrames(frames);
 
-        if (!originalTransferSyntaxRequested && !dicomFile.Dataset.InternalTransferSyntax.Equals(DicomTransferSyntax.Parse(requestedRepresentation)))
+        if (!originalTransferSyntaxSelected && !dicomFile.Dataset.InternalTransferSyntax.Equals(DicomTransferSyntax.Parse(requestedTransferSyntax)))
         {
             return frames.Select(frame => new LazyTransformReadOnlyStream<DicomFile>(
                     dicomFile,
-                    df => _transcoder.TranscodeFrame(df, frame, requestedRepresentation)))
+                    df => _transcoder.TranscodeFrame(df, frame, requestedTransferSyntax)))
             .ToArray();
         }
         else

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/IFrameHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/IFrameHandler.cs
@@ -11,5 +11,5 @@ namespace Microsoft.Health.Dicom.Core.Features.Retrieve;
 
 public interface IFrameHandler
 {
-    Task<IReadOnlyCollection<Stream>> GetFramesResourceAsync(Stream stream, IEnumerable<int> frames, bool originalTransferSyntaxRequested, string requestedRepresentation);
+    Task<IReadOnlyCollection<Stream>> GetFramesResourceAsync(Stream stream, IEnumerable<int> frames, bool originalTransferSyntaxSelected, string requestedTransferSyntax);
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveResourceService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveResourceService.cs
@@ -89,7 +89,7 @@ public class RetrieveResourceService : IRetrieveResourceService
                 message.AcceptHeaders);
 
             string requestedTransferSyntax = validAcceptHeader.TransferSyntax.Value;
-            bool isOriginalTransferSyntaxRequested = DicomTransferSyntaxUids.IsOriginalTransferSyntaxRequested(requestedTransferSyntax);
+            bool isOriginalTransferSyntaxRequested = DicomTransferSyntaxUids.IsAnyTransferSyntaxRequested(requestedTransferSyntax);
 
             if (message.ResourceType == ResourceType.Frames)
             {

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveResourceService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveResourceService.cs
@@ -113,7 +113,7 @@ public class RetrieveResourceService : IRetrieveResourceService
             _dicomRequestContextAccessor.RequestContext.PartCount = retrieveInstances.Count();
 
             // we will only support retrieving multiple instance if requested in original format, since we can do lazyStreams
-            if (retrieveInstances.Count() > 1 && needsTranscoding)
+            if (retrieveInstances.Count() > 1 && !isAnyTransferSyntaxRequested)
             {
                 throw new NotAcceptableException(
                     string.Format(CultureInfo.CurrentCulture, DicomCoreResource.RetrieveServiceMultiInstanceTranscodingNotSupported, requestedTransferSyntax));

--- a/src/Microsoft.Health.Dicom.Core/Web/DicomTransferSyntaxUids.cs
+++ b/src/Microsoft.Health.Dicom.Core/Web/DicomTransferSyntaxUids.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -11,12 +11,12 @@ namespace Microsoft.Health.Dicom.Core;
 
 public static class DicomTransferSyntaxUids
 {
-    public const string Original = "*";
+    public const string Any = "*";
     public const string ExplicitVRLittleEndian = "1.2.840.10008.1.2.1";
 
-    public static bool IsOriginalTransferSyntaxRequested(string transferSyntax)
+    public static bool IsAnyTransferSyntaxRequested(string transferSyntax)
     {
-        return Original.Equals(transferSyntax, StringComparison.Ordinal);
+        return Any.Equals(transferSyntax, StringComparison.Ordinal);
     }
 
     public static bool AreEqual(string transferSyntaxA, string transferSyntaxB)


### PR DESCRIPTION
## Description
When transfer syntax is requested, the client can send `*` to specify that any transfer syntax is acceptable:
>The wildcard value "*" indicates that the user agent will accept any Transfer Syntax. [Standard](https://dicom.nema.org/medical/dicom/current/output/html/part18.html#sect_8.7.3.5.2)

Our service currently returns the original transfer syntax in this case, but we should use the same semantics as the standard in our code to minimize confusion and be able to handle different behavior in the future.