### PR TITLE
Allow DICOM update API only in V2

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Controllers/StoreController.cs
+++ b/src/Microsoft.Health.Dicom.Api/Controllers/StoreController.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Api.Features.Audit;
 using Microsoft.Health.Dicom.Api.Extensions;
+using Microsoft.Health.Dicom.Api.Features.Conventions;
 using Microsoft.Health.Dicom.Api.Features.Filters;
 using Microsoft.Health.Dicom.Api.Features.Routing;
 using Microsoft.Health.Dicom.Core.Configs;
@@ -93,6 +94,7 @@ public class StoreController : ControllerBase
     }
 
     [HttpPost]
+    [IntroducedInApiVersion(2)]
     [Consumes(KnownContentTypes.ApplicationJson)]
     [ProducesResponseType(typeof(OperationReference), (int)HttpStatusCode.Accepted)]
     [ProducesResponseType(typeof(DicomDataset), (int)HttpStatusCode.BadRequest)]

--- a/src/Microsoft.Health.Dicom.Api/Features/Conventions/IntroducedInApiVersionAttribute.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Conventions/IntroducedInApiVersionAttribute.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Health.Dicom.Api.Features.Conventions;
 /// Don't use any attribute if you want to introduce the controller in all available versions.
 /// Did not use ApiVersionAttribute as base because it is a collection of versions and we need just one version here.
 /// </summary>
-[AttributeUsage(AttributeTargets.Class)]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
 internal sealed class IntroducedInApiVersionAttribute : Attribute
 {
     public int? Version { get; init; }


### PR DESCRIPTION
## Description
Allow DICOM update API only in V2

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.
