### PR TITLE
allow partitions to lock when joining to delete instance

### DIFF
--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/42.diff.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/42.diff.sql
@@ -21,7 +21,7 @@ BEGIN
                         d.OriginalWatermark
     FROM   dbo.DeletedInstance AS d WITH (UPDLOCK, READPAST)
            INNER JOIN
-           dbo.Partition AS p WITH (NOLOCK)
+           dbo.Partition AS p
            ON p.PartitionKey = d.PartitionKey
     WHERE  RetryCount <= @maxRetries
            AND CleanupAfter < SYSUTCDATETIME();

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/42.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Migrations/42.sql
@@ -2630,7 +2630,7 @@ BEGIN
                         d.OriginalWatermark
     FROM   dbo.DeletedInstance AS d WITH (UPDLOCK, READPAST)
            INNER JOIN
-           dbo.Partition AS p WITH (NOLOCK)
+           dbo.Partition AS p
            ON p.PartitionKey = d.PartitionKey
     WHERE  RetryCount <= @maxRetries
            AND CleanupAfter < SYSUTCDATETIME();

--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Sql/Sprocs/RetrieveDeletedInstanceV42.sql
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Schema/Sql/Sprocs/RetrieveDeletedInstanceV42.sql
@@ -23,7 +23,7 @@ BEGIN
 
     SELECT  TOP (@count) p.PartitionName, d.PartitionKey, d.StudyInstanceUid, d.SeriesInstanceUid, d.SopInstanceUid, d.Watermark, d.OriginalWatermark
     FROM    dbo.DeletedInstance as d WITH (UPDLOCK, READPAST)
-    INNER JOIN dbo.Partition as p WITH (NOLOCK)
+    INNER JOIN dbo.Partition as p
     ON p.PartitionKey = d.PartitionKey
     WHERE   RetryCount <= @maxRetries
     AND     CleanupAfter < SYSUTCDATETIME()


### PR DESCRIPTION
## Description
allow partitions to lock when joining to delete instance so we get latest data

## Related issues
Addresses [[AB#105059](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/105059)].

## Testing
n/a