### PR TITLE
idp-when partitions not enabled, do not use default ms partition

### DIFF
--- a/src/Microsoft.Health.Dicom.Blob.UnitTests/Features/Storage/BlobFileStoreTests.cs
+++ b/src/Microsoft.Health.Dicom.Blob.UnitTests/Features/Storage/BlobFileStoreTests.cs
@@ -166,7 +166,7 @@ public class BlobFileStoreTests
     public void GivenExternalStore_WhenGetServiceStorePathWithPartitionsDisabled_ThenPathReturnedDoesNotUsePartition()
     {
         InitializeExternalBlobFileStore(out BlobFileStore _, out ExternalBlobClient client, partitionsEnabled: false);
-        Assert.Equal(DefaultStorageDirectory + "/", client.GetServiceStorePath("foo"));
+        Assert.Equal(DefaultStorageDirectory, client.GetServiceStorePath("foo"));
     }
 
     [Fact]

--- a/src/Microsoft.Health.Dicom.Blob/Features/ExternalStore/ExternalBlobClient.cs
+++ b/src/Microsoft.Health.Dicom.Blob/Features/ExternalStore/ExternalBlobClient.cs
@@ -97,6 +97,6 @@ internal class ExternalBlobClient : IBlobClient
     {
         return _isPartitionEnabled ?
             _externalStoreOptions.StorageDirectory + partitionName + "/" :
-            _externalStoreOptions.StorageDirectory + "/";
+            _externalStoreOptions.StorageDirectory;
     }
 }


### PR DESCRIPTION
## Description
IDP - when partitions not enabled, do not use default ms partition in blob path.

## Related issues
Addresses [[AB#105115](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/105115)].

## Testing
Updated unit test
