### PR TITLE
update renovate rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,9 +12,15 @@
   "labels": [
     "dependencies"
   ],
+  "dryRun": "true",
   "packageRules": [
     {
-      "ignorePaths": ["docker/sql/"]
+      "enabled": false,
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchCurrentValue": "ubuntu:focal",
+      "matchFileNames": ["docker/sql/Dockerfile"]
     },
     {
       "groupName": "ApplicationInsights",


### PR DESCRIPTION
## Description
Update renove rules to:
- exclude fhir packages as they are used by cast and updating them will mean we will need to update cast as well
- exclude sql docker image as sql server only supports up to focal for now

set dry run to true to see rules work

## Related issues
Addresses [[AB#105417](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/105417)].

Currently Renovate doesn't seem to support disabling updates for "codenames", but I have requested the feature here: https://github.com/renovatebot/renovate/discussions/23415
## Testing
N/A
