### PR TITLE
fix matchCurrentValue to be expected regex format

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,7 @@
       "matchDatasources": [
         "docker"
       ],
-      "matchCurrentValue": "ubuntu:focal",
+      "matchCurrentValue": "/^ubuntu:focal$/",
       "matchFileNames": ["docker/sql/Dockerfile"]
     },
     {


### PR DESCRIPTION
## Description
fix matchCurrentValue to be expected regex format

## Related issues
Addresses [[AB#105417](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/105417)].

## Testing
testing my doing renovate dry runs
