### PR TITLE
Add flag to ignore errors in parsing malformed dicom json

### DIFF
--- a/converter/dicom-cast/samples/templates/default-azuredeploy.json
+++ b/converter/dicom-cast/samples/templates/default-azuredeploy.json
@@ -115,6 +115,13 @@
                 "description": "Enforce validation of all tag values and do not store to FHIR even if only non-required tags are invalid"
             }
         },
+        "ignoreJsonParsingErrors": {
+            "defaultValue": false,
+            "type": "Bool",
+            "metadata": {
+                "description": "Ignore json parsing errors for DICOM instances with malformed DICOM json"
+            }
+        },
         "additionalEnvironmentVariables": {
             "defaultValue": [],
             "type": "array",
@@ -149,6 +156,10 @@
             {
                 "name": "DicomCast__Features__EnforceValidationOfTagValues",
                 "value": "[parameters('enforceValidationOfTagValues')]"
+            },
+            {
+                "name": "DicomCast__Features__IgnoreJsonParsingErrors",
+                "value": "[parameters('ignoreJsonParsingErrors')]"
             },
             {
               "name": "Patient__PatientSystemId",

--- a/converter/dicom-cast/samples/templates/deploy-with-healthcareapis.json
+++ b/converter/dicom-cast/samples/templates/deploy-with-healthcareapis.json
@@ -144,6 +144,13 @@
       "metadata": {
         "description": "Enforce validation of all tag values and do not store to FHIR even if only non-required tags are invalid"
       }
+    },
+    "ignoreJsonParsingErrors": {
+      "defaultValue": false,
+      "type": "Bool",
+      "metadata": {
+          "description": "Ignore json parsing errors for DICOM instances with malformed DICOM json"
+      }
     }
   },
   "variables": {
@@ -259,6 +266,9 @@
           },
           "enforceValidationOfTagValues": {
             "value": "[parameters('enforceValidationOfTagValues')]"
+          },
+          "ignoreJsonParsingErrors": {
+            "value": "[parameters('ignoreJsonParsingErrors')]"
           },
           "additionalEnvironmentVariables": {
             "value": "[variables('authenticationArray')]"

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/ChangeFeedProcessorTests.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/ChangeFeedProcessorTests.cs
@@ -5,11 +5,14 @@
 
 using System;
 using System.Diagnostics;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Internal;
 using Microsoft.Health.Dicom.Client.Models;
+using Microsoft.Health.DicomCast.Core.Configurations;
 using Microsoft.Health.DicomCast.Core.Exceptions;
 using Microsoft.Health.DicomCast.Core.Features.DicomWeb.Service;
 using Microsoft.Health.DicomCast.Core.Features.ExceptionStorage;
@@ -19,6 +22,7 @@ using Microsoft.Health.DicomCast.Core.Features.Worker;
 using Microsoft.Health.DicomCast.Core.Features.Worker.FhirTransaction;
 using Microsoft.Health.Test.Utilities;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Polly.Timeout;
 using Xunit;
 
@@ -32,15 +36,21 @@ public class ChangeFeedProcessorTests
     private readonly IFhirTransactionPipeline _fhirTransactionPipeline = Substitute.For<IFhirTransactionPipeline>();
     private readonly ISyncStateService _syncStateService = Substitute.For<ISyncStateService>();
     private readonly IExceptionStore _exceptionStore = Substitute.For<IExceptionStore>();
+    private readonly IOptions<DicomCastConfiguration> _config = Substitute.For<IOptions<DicomCastConfiguration>>();
+    private readonly DicomCastConfiguration _dicomCastConfiguration = new DicomCastConfiguration();
     private readonly ChangeFeedProcessor _changeFeedProcessor;
 
     public ChangeFeedProcessorTests()
     {
+        _dicomCastConfiguration.Features.IgnoreJsonParsingErrors = true;
+        _config.Value.Returns(_dicomCastConfiguration);
+
         _changeFeedProcessor = new ChangeFeedProcessor(
             _changeFeedRetrieveService,
             _fhirTransactionPipeline,
             _syncStateService,
             _exceptionStore,
+            _config,
             NullLogger<ChangeFeedProcessor>.Instance);
 
         SetupSyncState();
@@ -77,6 +87,68 @@ public class ChangeFeedProcessorTests
         await _fhirTransactionPipeline.Received(1).ProcessAsync(changeFeeds[0], DefaultCancellationToken);
         await _fhirTransactionPipeline.Received(1).ProcessAsync(changeFeeds[1], DefaultCancellationToken);
         await _fhirTransactionPipeline.Received(1).ProcessAsync(changeFeeds[2], DefaultCancellationToken);
+    }
+
+    [Fact]
+    public async Task GivenMalformedChangeFeedEntries_WhenProcessed_BadEntryShouldBeSkipped()
+    {
+        const long Latest = 3L;
+        ChangeFeedEntry[] changeFeeds1 = new[]
+        {
+            ChangeFeedGenerator.Generate(1),
+        };
+        ChangeFeedEntry[] changeFeeds2 = new[]
+        {
+            ChangeFeedGenerator.Generate(Latest),
+        };
+
+        // Arrange
+        _changeFeedRetrieveService.RetrieveLatestSequenceAsync(DefaultCancellationToken).Returns(Latest);
+
+        // group of 10 has a json issue
+        _changeFeedRetrieveService.RetrieveChangeFeedAsync(0, ChangeFeedProcessor.DefaultLimit, DefaultCancellationToken).ThrowsAsync(new JsonException());
+
+        // get the items individually from the change feed
+        _changeFeedRetrieveService.RetrieveChangeFeedAsync(0, 1, DefaultCancellationToken).Returns(changeFeeds1);
+        _changeFeedRetrieveService.RetrieveChangeFeedAsync(1, 1, DefaultCancellationToken).ThrowsAsync(new JsonException());
+        _changeFeedRetrieveService.RetrieveChangeFeedAsync(2, 1, DefaultCancellationToken).Returns(changeFeeds2);
+        _changeFeedRetrieveService.RetrieveChangeFeedAsync(Latest, 1, DefaultCancellationToken).Returns(Array.Empty<ChangeFeedEntry>());
+
+        _changeFeedRetrieveService.RetrieveChangeFeedAsync(Latest, ChangeFeedProcessor.DefaultLimit, DefaultCancellationToken).Returns(Array.Empty<ChangeFeedEntry>());
+
+        // Act
+        await ExecuteProcessAsync();
+
+        // Assert
+        await _changeFeedRetrieveService.Received(2).RetrieveLatestSequenceAsync(DefaultCancellationToken);
+
+        await _changeFeedRetrieveService.ReceivedWithAnyArgs(6).RetrieveChangeFeedAsync(default, default, default);
+        await _changeFeedRetrieveService.Received(1).RetrieveChangeFeedAsync(0, ChangeFeedProcessor.DefaultLimit, DefaultCancellationToken);
+        await _changeFeedRetrieveService.Received(1).RetrieveChangeFeedAsync(0, 1, DefaultCancellationToken);
+        await _changeFeedRetrieveService.Received(1).RetrieveChangeFeedAsync(1, 1, DefaultCancellationToken);
+        await _changeFeedRetrieveService.Received(1).RetrieveChangeFeedAsync(2, 1, DefaultCancellationToken);
+        await _changeFeedRetrieveService.Received(1).RetrieveChangeFeedAsync(Latest, 1, DefaultCancellationToken);
+        await _changeFeedRetrieveService.Received(1).RetrieveChangeFeedAsync(Latest, ChangeFeedProcessor.DefaultLimit, DefaultCancellationToken);
+
+        await _fhirTransactionPipeline.ReceivedWithAnyArgs(2).ProcessAsync(default, default);
+        await _fhirTransactionPipeline.Received(1).ProcessAsync(changeFeeds1[0], DefaultCancellationToken);
+        await _fhirTransactionPipeline.Received(1).ProcessAsync(changeFeeds2[0], DefaultCancellationToken);
+    }
+
+    [Fact]
+    public async Task GivenMalformedChangeFeedEntries_WhenProcessedAndNotIgnoringErrors_ExceptionIsThrown()
+    {
+        const long Latest = 3L;
+        _dicomCastConfiguration.Features.IgnoreJsonParsingErrors = false;
+
+        // Arrange
+        _changeFeedRetrieveService.RetrieveLatestSequenceAsync(DefaultCancellationToken).Returns(Latest);
+
+        // group of 10 has a json issue
+        _changeFeedRetrieveService.RetrieveChangeFeedAsync(0, ChangeFeedProcessor.DefaultLimit, DefaultCancellationToken).ThrowsAsync(new JsonException());
+
+        // Act
+        await Assert.ThrowsAsync<JsonException>(() => ExecuteProcessAsync());
     }
 
     [Fact]

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/ChangeFeedProcessorTests.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core.UnitTests/Features/Worker/ChangeFeedProcessorTests.cs
@@ -105,7 +105,7 @@ public class ChangeFeedProcessorTests
         // Arrange
         _changeFeedRetrieveService.RetrieveLatestSequenceAsync(DefaultCancellationToken).Returns(Latest);
 
-        // group of 10 has a json issue
+        // call to retrieve batch has json exception
         _changeFeedRetrieveService.RetrieveChangeFeedAsync(0, ChangeFeedProcessor.DefaultLimit, DefaultCancellationToken).ThrowsAsync(new JsonException());
 
         // get the items individually from the change feed
@@ -144,7 +144,7 @@ public class ChangeFeedProcessorTests
         // Arrange
         _changeFeedRetrieveService.RetrieveLatestSequenceAsync(DefaultCancellationToken).Returns(Latest);
 
-        // group of 10 has a json issue
+        // call to retrieve batch has json exception
         _changeFeedRetrieveService.RetrieveChangeFeedAsync(0, ChangeFeedProcessor.DefaultLimit, DefaultCancellationToken).ThrowsAsync(new JsonException());
 
         // Act

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Configurations/FeatureConfiguration.cs
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Core/Configurations/FeatureConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -16,4 +16,9 @@ public class FeatureConfiguration
     /// Generate observations from dcm
     /// </summary>
     public bool GenerateObservations { get; set; }
+
+    /// <summary>
+    /// Ignore json parsing errors from DicomWebClient
+    /// </summary>
+    public bool IgnoreJsonParsingErrors { get; set; }
 }

--- a/converter/dicom-cast/src/Microsoft.Health.DicomCast.Hosting/appsettings.json
+++ b/converter/dicom-cast/src/Microsoft.Health.DicomCast.Hosting/appsettings.json
@@ -35,7 +35,8 @@
   "DicomCast": {
     "Features": {
       "EnforceValidationOfTagValues": false,
-      "GenerateObservations": true
+      "GenerateObservations": true,
+      "IgnoreJsonParsingErrors": false
     }
   },
   "RetryConfiguration": {

--- a/docs/concepts/dicom-cast.md
+++ b/docs/concepts/dicom-cast.md
@@ -19,6 +19,9 @@ The current implementation of DICOM Cast supports:
 - Configuration to ignore invalid tags when syncing data from the change feed to FHIR resource types.
     - If `EnforceValidationOfTagValues` is enabled then the change feed entry will not be written to the FHIR server unless every tag that is mapped (see below for mappings) is valid
     - If `EnforceValidationOfTagValues` is disabled (default) then as if a value is invalid, but not required to be mapped (see below for required tags for Patient and Imaging Study) then that particular tag will not be mapped but the rest of the change feed entry will be mapped to FHIR resources. If a required tag is invalid then the change feed entry will not be written to FHIR Server
+- Configuration to ignore Json parsing errors from DicomWebClient due to malformed DICOM json
+  - If `IgnoreJsonParsingErrors` is enabled, then the malformed changefeed entry will be skipped. This error will NOT be logged in the exceptions table due to not being able to parse out the Study, Series, and Instance UID necessary for an entry to the table
+  - If `IgnoreJsonParsingErrors` is disabled, an exception will be thrown when DICOM Cast tries to handle the malformed DICOM json
 - Storage of errors to Azure Table Storage
     - Errors when processing change feed entries are persisted in Azure Table Storage in different tables depending on the cause of the error.
         - `InvalidDicomTagExceptionTable`: Stores information about any tags that had invalid values. Entries in here does not necessarily mean that the entire change feed entry was not stored in FHIR, but that the particular value had a validation issue.

--- a/samples/templates/dicomcast-fhir-dicom-azuredeploy.json
+++ b/samples/templates/dicomcast-fhir-dicom-azuredeploy.json
@@ -292,6 +292,13 @@
             "metadata": {
                 "description": "Enforce validation of all tag values when syncing from Dicom to FHIR using dicom-cast and do not store to FHIR even if only non-required tags are invalid"
             }
+        },
+        "ignoreJsonParsingErrors": {
+            "defaultValue": false,
+            "type": "Bool",
+            "metadata": {
+                "description": "Ignore json parsing errors for DICOM instances with malformed DICOM json"
+            }
         }
     },
     "variables": {
@@ -401,7 +408,8 @@
                     "restartPolicy": { "value": "[parameters('dicomCastRestartPolicy')]" },
                     "dicomWebEndpoint": { "value": "[concat('https://',parameters('dicomServiceName'),'.azurewebsites.net')]" },
                     "fhirEndpoint": { "value": "[concat('https://',parameters('fhirServiceName'),'.azurewebsites.net')]" },
-                    "enforceValidationOfTagValues": { "value": "[parameters('enforceValidationOfTagValues')]" }
+                    "enforceValidationOfTagValues": { "value": "[parameters('enforceValidationOfTagValues')]" },
+                    "ignoreJsonParsingErrors": { "value": "[parameters('ignoreJsonParsingErrors')]" }
                 }
             }
         }

--- a/samples/templates/dicomcast-quick-deploy.json
+++ b/samples/templates/dicomcast-quick-deploy.json
@@ -131,7 +131,8 @@
                     "fhirEndpoint":{"value": "[concat('https://',parameters('serviceName'),'-fhir','.azurewebsites.net')]"},
                     "patientSystemId": { "value": "[parameters('patientSystemId')]" },
                     "isIssuerIdUsed": { "value": "[parameters('isIssuerIdUsed')]" },
-                    "enforceValidationOfTagValues":{"value": false}
+                    "enforceValidationOfTagValues":{"value": false},
+                    "ignoreJsonParsingErrors": {"value": false}
                     }
                 }
             }


### PR DESCRIPTION
## Description
Customer is experiencing an issue where DICOM Cast will crash when it encounters a DICOM instance that the DicomWebClient is unable to parse. This will add an option to skip instances like that by ignoring JsonExceptions.

## Related issues
Addresses #[105044].

## Testing
Tested locally
