### PR TITLE
Update Renovate Config for Focal Ubuntu Base Image in SQL Image

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,10 +14,6 @@
   ],
   "packageRules": [
     {
-      "ignorePaths": ["docker/sql/"],
-      "matchDatasources": ["docker"]
-    },
-    {
       "groupName": "ApplicationInsights",
       "matchPackagePatterns": [
         "ApplicationInsights"
@@ -68,6 +64,16 @@
       "groupName": "OpenTelemetry",
       "matchPackagePrefixes": [
         "OpenTelemetry"
+      ]
+    },
+    {
+      "allowedVersions": "/^focal/",
+      "groupName": "SQL Base Image",
+      "includePaths": [
+        "docker/sql/Dockerfile"
+      ],
+      "matchPackageNames": [
+        "ubuntu"
       ]
     },
     {


### PR DESCRIPTION
## Description
Allow Renovate to update the Ubuntu base image for the SQL dockerfile as long as it uses Focal Fossa

## Related issues
N/A

## Testing
N/A
