### PR TITLE
replace linux_dicom-cast image with dicom-cast

### DIFF
--- a/converter/dicom-cast/samples/templates/default-azuredeploy.json
+++ b/converter/dicom-cast/samples/templates/default-azuredeploy.json
@@ -11,7 +11,7 @@
             }
         },
         "image": {
-            "defaultValue": "dicomoss.azurecr.io/linux_dicom-cast",
+            "defaultValue": "dicomoss.azurecr.io/dicom-cast",
             "type": "String",
             "metadata": {
                 "description": "Container image to deploy. Should be of the form repoName/imagename:tag for images stored in public Docker Hub, or a fully qualified URI for other registries. Images from private registries require additional registry credentials."

--- a/converter/dicom-cast/samples/templates/deploy-with-healthcareapis.json
+++ b/converter/dicom-cast/samples/templates/deploy-with-healthcareapis.json
@@ -52,7 +52,7 @@
       }
     },
     "image": {
-      "defaultValue": "dicomoss.azurecr.io/linux_dicom-cast",
+      "defaultValue": "dicomoss.azurecr.io/dicom-cast",
       "type": "string",
       "metadata": {
         "description": "Container image to deploy. Should be of the form repoName/imagename:tag for images stored in public Docker Hub, or a fully qualified URI for other registries. Images from private registries require additional registry credentials."

--- a/samples/templates/dicomcast-fhir-dicom-azuredeploy.json
+++ b/samples/templates/dicomcast-fhir-dicom-azuredeploy.json
@@ -218,7 +218,7 @@
             }
         },
         "image": {
-            "defaultValue": "dicomoss.azurecr.io/linux_dicom-cast",
+            "defaultValue": "dicomoss.azurecr.io/dicom-cast",
             "type": "String",
             "metadata": {
                 "description": "Container image to deploy. Should be of the form repoName/imagename:tag for images stored in public Docker Hub, or a fully qualified URI for other registries. Images from private registries require additional registry credentials."

--- a/samples/templates/dicomcast-quick-deploy.json
+++ b/samples/templates/dicomcast-quick-deploy.json
@@ -119,7 +119,7 @@
                 },
                 "parameters":{
                     "serviceName":{"value": "[concat(parameters('serviceName'),'-dcast')]"},
-                    "image":{"value": "dicomoss.azurecr.io/linux_dicom-cast"},
+                    "image":{"value": "dicomoss.azurecr.io/dicom-cast"},
                     "storageAccountSku":{"value": "Standard_LRS"},
                     "deployApplicationInsights":{"value": true},
                     "applicationInsightsLocation":{"value": "[resourceGroup().location]"},


### PR DESCRIPTION
## Description
linux_dicom-cast is no longer updated, and dicom-cast image should be used in its place

## Related issues
Addresses [#105670].
