### PR TITLE
Encode String in error message

### DIFF
--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Filters/QueryModelStateValidatorAttributeTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Filters/QueryModelStateValidatorAttributeTests.cs
@@ -1,0 +1,56 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Health.Dicom.Api.Features.Filters;
+using Microsoft.Health.Dicom.Core.Exceptions;
+using Xunit;
+
+namespace Microsoft.Health.Dicom.Api.UnitTests.Features.Filters;
+
+public class QueryModelStateValidatorAttributeTests
+{
+    private readonly QueryModelStateValidatorAttribute _validator;
+    private readonly ActionExecutingContext _context;
+
+    public QueryModelStateValidatorAttributeTests()
+    {
+        _context = CreateContext();
+        _validator = new QueryModelStateValidatorAttribute();
+        _context.ModelState.AddModelError("frames", "This Error Message Should Not be escaped");
+    }
+
+    [Fact]
+    public void Givenvaliderrormessage_shouldnotbeescaped()
+    {
+        var ex = Assert.Throws<InvalidQueryStringValuesException>(() => _validator.OnActionExecuting(_context));
+        Assert.Equal("The query parameter 'frames' is invalid. This Error Message Should Not be escaped", ex.Message);
+    }
+
+    [Fact]
+    public void Giveninvvaliderrormessage_shouldbeescaped()
+    {
+        _context.ModelState.Clear();
+        _context.ModelState.AddModelError("frames", "This Shoud be <> escaped");
+        var ex = Assert.Throws<InvalidQueryStringValuesException>(() => _validator.OnActionExecuting(_context));
+        Console.Write(ex.Message);
+        Assert.Equal("The query parameter 'frames' is invalid. This Shoud be &lt;&gt; escaped", ex.Message);
+    }
+
+    private static ActionExecutingContext CreateContext()
+    {
+        return new ActionExecutingContext(
+            new ActionContext(new DefaultHttpContext(), new RouteData(), new ActionDescriptor()),
+            new List<IFilterMetadata>(),
+            new Dictionary<string, object>(),
+            null);
+    }
+}

--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Filters/QueryModelStateValidatorAttributeTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Filters/QueryModelStateValidatorAttributeTests.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -41,7 +40,6 @@ public class QueryModelStateValidatorAttributeTests
         _context.ModelState.Clear();
         _context.ModelState.AddModelError("frames", "This Shoud be <> escaped");
         var ex = Assert.Throws<InvalidQueryStringValuesException>(() => _validator.OnActionExecuting(_context));
-        Console.Write(ex.Message);
         Assert.Equal("The query parameter 'frames' is invalid. This Shoud be &lt;&gt; escaped", ex.Message);
     }
 

--- a/src/Microsoft.Health.Dicom.Api/Features/Filters/QueryModelStateValidatorAttribute.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Filters/QueryModelStateValidatorAttribute.cs
@@ -1,9 +1,11 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
 using System.Linq;
+using System.Text.RegularExpressions;
+using System.Web;
 using EnsureThat;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -19,7 +21,14 @@ public sealed class QueryModelStateValidatorAttribute : ActionFilterAttribute
         if (!context.ModelState.IsValid)
         {
             (string key, ModelStateEntry value) = context.ModelState.Where(x => x.Value.Errors.Count > 0).First();
-            throw new InvalidQueryStringValuesException(key, value.Errors[0].ErrorMessage);
+
+            string errorMessage = value.Errors[0].ErrorMessage;
+            if (Regex.IsMatch(errorMessage, @"<[^>]*>"))
+            {
+                errorMessage = HttpUtility.HtmlEncode(errorMessage);
+            }
+
+            throw new InvalidQueryStringValuesException(key, errorMessage);
         }
     }
 }

--- a/src/Microsoft.Health.Dicom.Api/Features/Filters/QueryModelStateValidatorAttribute.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Filters/QueryModelStateValidatorAttribute.cs
@@ -10,12 +10,11 @@ using EnsureThat;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Health.Dicom.Core.Exceptions;
-using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.Health.Dicom.Api.Features.Filters;
 
 public sealed class QueryModelStateValidatorAttribute : ActionFilterAttribute
-{ 
+{
     private static readonly Regex HtmlCharacters = new Regex("<[^>]*>", RegexOptions.Compiled);
 
     public override void OnActionExecuting(ActionExecutingContext context)
@@ -26,7 +25,7 @@ public sealed class QueryModelStateValidatorAttribute : ActionFilterAttribute
             (string key, ModelStateEntry value) = context.ModelState.Where(x => x.Value.Errors.Count > 0).First();
 
             string errorMessage = value.Errors[0].ErrorMessage;
-            if (!errorMessage.IsNullOrEmpty() && HtmlCharacters.IsMatch(errorMessage))
+            if (!string.IsNullOrEmpty(errorMessage) && HtmlCharacters.IsMatch(errorMessage))
             {
                 errorMessage = HttpUtility.HtmlEncode(errorMessage);
             }

--- a/src/Microsoft.Health.Dicom.Api/Features/Filters/QueryModelStateValidatorAttribute.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Filters/QueryModelStateValidatorAttribute.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Health.Dicom.Api.Features.Filters;
 
 public sealed class QueryModelStateValidatorAttribute : ActionFilterAttribute
 {
+    private static readonly Regex HtmlCharacters = new Regex("<[^>]*>", RegexOptions.Compiled);
+
     public override void OnActionExecuting(ActionExecutingContext context)
     {
         EnsureArg.IsNotNull(context, nameof(context));
@@ -23,7 +25,7 @@ public sealed class QueryModelStateValidatorAttribute : ActionFilterAttribute
             (string key, ModelStateEntry value) = context.ModelState.Where(x => x.Value.Errors.Count > 0).First();
 
             string errorMessage = value.Errors[0].ErrorMessage;
-            if (Regex.IsMatch(errorMessage, @"<[^>]*>"))
+            if (HtmlCharacters.IsMatch(errorMessage))
             {
                 errorMessage = HttpUtility.HtmlEncode(errorMessage);
             }

--- a/src/Microsoft.Health.Dicom.Api/Features/Filters/QueryModelStateValidatorAttribute.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Filters/QueryModelStateValidatorAttribute.cs
@@ -10,11 +10,12 @@ using EnsureThat;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Health.Dicom.Core.Exceptions;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.Health.Dicom.Api.Features.Filters;
 
 public sealed class QueryModelStateValidatorAttribute : ActionFilterAttribute
-{
+{ 
     private static readonly Regex HtmlCharacters = new Regex("<[^>]*>", RegexOptions.Compiled);
 
     public override void OnActionExecuting(ActionExecutingContext context)
@@ -25,7 +26,7 @@ public sealed class QueryModelStateValidatorAttribute : ActionFilterAttribute
             (string key, ModelStateEntry value) = context.ModelState.Where(x => x.Value.Errors.Count > 0).First();
 
             string errorMessage = value.Errors[0].ErrorMessage;
-            if (HtmlCharacters.IsMatch(errorMessage))
+            if (!errorMessage.IsNullOrEmpty() && HtmlCharacters.IsMatch(errorMessage))
             {
                 errorMessage = HttpUtility.HtmlEncode(errorMessage);
             }

--- a/src/Microsoft.Health.Dicom.Core/Exceptions/InvalidQueryStringValuesException.cs
+++ b/src/Microsoft.Health.Dicom.Core/Exceptions/InvalidQueryStringValuesException.cs
@@ -1,16 +1,17 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
 using System.Globalization;
+using System.Web;
 
 namespace Microsoft.Health.Dicom.Core.Exceptions;
 
 public class InvalidQueryStringValuesException : ValidationException
 {
     public InvalidQueryStringValuesException(string key, string error)
-        : base(string.Format(CultureInfo.InvariantCulture, DicomCoreResource.InvalidQueryStringValue, key, error))
+        : base(string.Format(CultureInfo.InvariantCulture, DicomCoreResource.InvalidQueryStringValue, key, HttpUtility.UrlEncode(error)))
     {
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Exceptions/InvalidQueryStringValuesException.cs
+++ b/src/Microsoft.Health.Dicom.Core/Exceptions/InvalidQueryStringValuesException.cs
@@ -4,14 +4,13 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Globalization;
-using System.Web;
 
 namespace Microsoft.Health.Dicom.Core.Exceptions;
 
 public class InvalidQueryStringValuesException : ValidationException
 {
     public InvalidQueryStringValuesException(string key, string error)
-        : base(string.Format(CultureInfo.InvariantCulture, DicomCoreResource.InvalidQueryStringValue, key, HttpUtility.UrlEncode(error)))
+        : base(string.Format(CultureInfo.InvariantCulture, DicomCoreResource.InvalidQueryStringValue, key, error))
     {
     }
 }

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/WorkItemTransactionTests.Query.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/WorkItemTransactionTests.Query.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using System.Web;
 using FellowOakDicom;
 using Microsoft.Health.Dicom.Client;
 using Microsoft.Health.Dicom.Core;
@@ -146,6 +147,6 @@ public partial class WorkItemTransactionTests
             () => _client.QueryWorkitemAsync("PatientName=Foo&limit=500"));
 
         Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
-        Assert.Equal(exception.ResponseMessage, string.Format(CultureInfo.CurrentCulture, DicomCoreResource.InvalidQueryStringValue, "Limit", "The field Limit must be between 1 and 200."));
+        Assert.Equal(string.Format(CultureInfo.CurrentCulture, DicomCoreResource.InvalidQueryStringValue, "Limit", HttpUtility.UrlEncode("The field Limit must be between 1 and 200.")), exception.ResponseMessage);
     }
 }

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/WorkItemTransactionTests.Query.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/WorkItemTransactionTests.Query.cs
@@ -8,7 +8,6 @@ using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-using System.Web;
 using FellowOakDicom;
 using Microsoft.Health.Dicom.Client;
 using Microsoft.Health.Dicom.Core;
@@ -147,6 +146,6 @@ public partial class WorkItemTransactionTests
             () => _client.QueryWorkitemAsync("PatientName=Foo&limit=500"));
 
         Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
-        Assert.Equal(string.Format(CultureInfo.CurrentCulture, DicomCoreResource.InvalidQueryStringValue, "Limit", HttpUtility.UrlEncode("The field Limit must be between 1 and 200.")), exception.ResponseMessage);
+        Assert.Equal(exception.ResponseMessage, string.Format(CultureInfo.CurrentCulture, DicomCoreResource.InvalidQueryStringValue, "Limit", "The field Limit must be between 1 and 200."));
     }
 }


### PR DESCRIPTION
## Description
Encode string in error message to prevent cross scripting attacks

When validating a frame number passed in as part of the url we check if the input is a valid number. If its not we throw an error message that contains the invalid input that they passed directly. Since we did not encode the response we were susceptible to sending anything malicious back to the user 

_When a web application is vulnerable to this type of attack, it will pass unvalidated input sent through requests to the client. Reflected attacks are delivered to the victim in various ways, such as in an e-mail message, or through some specially crafted URI. When a user is tricked into clicking on the malicious link, the injected code travels to the vulnerable web site, which reflects the attack back to the user’s browser. The browser then executes the offending code because it came from a "trusted" server._

By encoding the response we escape characters in their input before returning error message back to the user

## Related issues
[AB#105701](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/105701)

## Testing
Describe how this change was tested.
