### PR TITLE
Make GetReferencedInstancesAndAccessMacroRequirements part of OutputInformationSequence

### DIFF
--- a/src/Microsoft.Health.Dicom.Core/Features/Workitem/WorkitemDatasetValidatorExtension.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Workitem/WorkitemDatasetValidatorExtension.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -533,11 +533,9 @@ internal static class WorkitemDatasetValidatorExtension
                 new RequirementDetail(DicomTag.PerformedWorkitemCodeSequence, requestType == WorkitemRequestType.Add ? RequirementCode.NotAllowed : RequirementCode.ThreeOne, GetUPSCodeSequenceMacroRequirements()),
                 new RequirementDetail(DicomTag.PerformedProcessingParametersSequence, requestType == WorkitemRequestType.Add ? RequirementCode.NotAllowed : RequirementCode.ThreeOne, GetUPSContentItemMacroRequirements()),
                 new RequirementDetail(DicomTag.PerformedProcedureStepEndDateTime, requestType == WorkitemRequestType.Add ? RequirementCode.NotAllowed : RequirementCode.ThreeOne),
-                new RequirementDetail(DicomTag.OutputInformationSequence, requestType == WorkitemRequestType.Add ? RequirementCode.NotAllowed : RequirementCode.TwoTwo),
+                new RequirementDetail(DicomTag.OutputInformationSequence, requestType == WorkitemRequestType.Add ? RequirementCode.NotAllowed : RequirementCode.TwoTwo, GetReferencedInstancesAndAccessMacroRequirements())
             }),
         };
-
-        requirements.UnionWith(GetReferencedInstancesAndAccessMacroRequirements());
 
         return requirements;
     }

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/Audit/AuditTests.Workitem.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/Audit/AuditTests.Workitem.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -119,11 +119,17 @@ public partial class AuditTests
         var updateWorkitemRequestDicomDataset = new DicomDataset
         {
             { DicomTag.WorklistLabel, "WORKITEM-TEST" },
-            { DicomTag.TypeOfInstances, "SAMPLETYPEOFINST" },
-            new DicomSequence(DicomTag.ReferencedSOPSequence, new DicomDataset
+            new DicomSequence(DicomTag.UnifiedProcedureStepPerformedProcedureSequence, new DicomDataset
             {
-                { DicomTag.ReferencedSOPClassUID, "1.2.3" },
-                { DicomTag.ReferencedSOPInstanceUID, "1.2.3" }
+                new DicomSequence(DicomTag.OutputInformationSequence, new DicomDataset
+                {
+                    { DicomTag.TypeOfInstances, "SAMPLETYPEOFINST" },
+                    new DicomSequence(DicomTag.ReferencedSOPSequence, new DicomDataset
+                    {
+                        { DicomTag.ReferencedSOPClassUID, "1.2.3" },
+                        { DicomTag.ReferencedSOPInstanceUID, "1.2.3" }
+                    })
+                })
             }),
         };
 

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/WorkItemTransactionTests.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/WorkItemTransactionTests.cs
@@ -41,11 +41,17 @@ public partial class WorkItemTransactionTests : IClassFixture<HttpIntegrationTes
         var updateDicomDataset = new DicomDataset
         {
             { DicomTag.WorklistLabel, newWorklistLabel },
-            { DicomTag.TypeOfInstances, "SAMPLETYPEOFINST" },
-            new DicomSequence(DicomTag.ReferencedSOPSequence, new DicomDataset
+            new DicomSequence(DicomTag.UnifiedProcedureStepPerformedProcedureSequence, new DicomDataset
             {
-                { DicomTag.ReferencedSOPClassUID, "1.2.3" },
-                { DicomTag.ReferencedSOPInstanceUID, "1.2.3" }
+                new DicomSequence(DicomTag.OutputInformationSequence, new DicomDataset
+                {
+                    { DicomTag.TypeOfInstances, "SAMPLETYPEOFINST" },
+                    new DicomSequence(DicomTag.ReferencedSOPSequence, new DicomDataset
+                    {
+                        { DicomTag.ReferencedSOPClassUID, "1.2.3" },
+                        { DicomTag.ReferencedSOPInstanceUID, "1.2.3" }
+                    })
+                })
             }),
         };
         await UpdateWorkitemAndValidate(workitemUid, newWorklistLabel, updateDicomDataset)
@@ -81,7 +87,15 @@ public partial class WorkItemTransactionTests : IClassFixture<HttpIntegrationTes
                 { DicomTag.CodeMeaning, "Sample-PerformedWorkitem-CodeMeaning" }
             }),
             { DicomTag.PerformedProcedureStepEndDateTime, DateTime.UtcNow },
-            new DicomSequence(DicomTag.OutputInformationSequence, new DicomDataset()),
+            new DicomSequence(DicomTag.OutputInformationSequence, new DicomDataset
+                {
+                    { DicomTag.TypeOfInstances, "SAMPLETYPEOFINST" },
+                    new DicomSequence(DicomTag.ReferencedSOPSequence, new DicomDataset
+                    {
+                        { DicomTag.ReferencedSOPClassUID, "1.2.3" },
+                        { DicomTag.ReferencedSOPInstanceUID, "1.2.3" }
+                    })
+                }),
         });
 
         await UpdateWorkitemAndValidate(workitemUid, newWorklistLabel, updateDicomDataset, transactionUid)

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/WorkitemTransactionTests.Update.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/WorkitemTransactionTests.Update.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -31,11 +31,17 @@ public partial class WorkItemTransactionTests
         var updateDicomDataset = new DicomDataset
         {
             { DicomTag.WorklistLabel, newWorklistLabel },
-            { DicomTag.TypeOfInstances, "SAMPLETYPEOFINST" },
-            new DicomSequence(DicomTag.ReferencedSOPSequence, new DicomDataset
+            new DicomSequence(DicomTag.UnifiedProcedureStepPerformedProcedureSequence, new DicomDataset
             {
-                { DicomTag.ReferencedSOPClassUID, "1.2.3" },
-                { DicomTag.ReferencedSOPInstanceUID, "1.2.3" }
+                new DicomSequence(DicomTag.OutputInformationSequence, new DicomDataset
+                {
+                    { DicomTag.TypeOfInstances, "SAMPLETYPEOFINST" },
+                    new DicomSequence(DicomTag.ReferencedSOPSequence, new DicomDataset
+                    {
+                        { DicomTag.ReferencedSOPClassUID, "1.2.3" },
+                        { DicomTag.ReferencedSOPInstanceUID, "1.2.3" }
+                    })
+                })
             }),
         };
 
@@ -80,11 +86,17 @@ public partial class WorkItemTransactionTests
         var updateDicomDataset = new DicomDataset
         {
             { DicomTag.WorklistLabel, newWorklistLabel },
-            { DicomTag.TypeOfInstances, "SAMPLETYPEOFINST" },
-            new DicomSequence(DicomTag.ReferencedSOPSequence, new DicomDataset
+            new DicomSequence(DicomTag.UnifiedProcedureStepPerformedProcedureSequence, new DicomDataset
             {
-                { DicomTag.ReferencedSOPClassUID, "1.2.3" },
-                { DicomTag.ReferencedSOPInstanceUID, "1.2.3" }
+                new DicomSequence(DicomTag.OutputInformationSequence, new DicomDataset
+                {
+                    { DicomTag.TypeOfInstances, "SAMPLETYPEOFINST" },
+                    new DicomSequence(DicomTag.ReferencedSOPSequence, new DicomDataset
+                    {
+                        { DicomTag.ReferencedSOPClassUID, "1.2.3" },
+                        { DicomTag.ReferencedSOPInstanceUID, "1.2.3" }
+                    })
+                })
             }),
         };
 


### PR DESCRIPTION
## Description
- Make GetReferencedInstancesAndAccessMacroRequirements part of OutputInformationSequence.
- Make ReferencedSOPSequence not mandatory while creating the workitem

There is a discrepancy between [Table CC.2.5-3. UPS SOP Class N-CREATE/N-SET/N-GET/C-FIND Attributes](https://dicom.nema.org/medical/dicom/current/output/chtml/part04/sect_CC.2.5.html#table_CC.2.5-3) and [Table C.30.3-1 specifies the Attributes that describe the performance and results of a Unified Procedure Step (UPS)](https://dicom.nema.org/dicom/2013/output/chtml/part03/sect_C.30.html#table_C.30.3-1).

To finalize, Referenced Instances and Access Macro Attributes will be part of Output Information Sequence and not under Unified Procedure Step Performed Procedure Sequence and Output Information Sequence will be under Unified Procedure Step Performed Procedure Sequence.

## Related issues
Addresses [[AB#106446](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/106446)].

## Testing
Updated tests to ensure the correct behaviour
