### PR TITLE
Pass HasFrameMetadata boolean correctly

### DIFF
--- a/src/Microsoft.Health.Dicom.Core/Features/Store/StoreOrchestrator.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Store/StoreOrchestrator.cs
@@ -97,7 +97,7 @@ public class StoreOrchestrator : IStoreOrchestrator
 
             bool hasFrameMetadata = await frameRangeTask;
 
-            await _indexDataStore.EndCreateInstanceIndexAsync(partition.Key, dicomDataset, version, queryTags, ShouldStoreFileProperties(fileProperties), hasFrameMetadata, cancellationToken: cancellationToken);
+            await _indexDataStore.EndCreateInstanceIndexAsync(partition.Key, dicomDataset, version, queryTags, ShouldStoreFileProperties(fileProperties), hasFrameMetadata: hasFrameMetadata, cancellationToken: cancellationToken);
 
             _logger.LogInformation("Successfully stored the DICOM instance: '{DicomInstance}'.", dicomInstanceIdentifier);
 


### PR DESCRIPTION
## Description
Correctly pass HasFrameMetadata boolean when creating the instance

## Related issues
Addresses [[AB#109143](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/109143)].

## Testing
Describe how this change was tested.
