### PR TITLE
fix retrieve metric

### DIFF
--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveRenderedService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveRenderedService.cs
@@ -93,7 +93,7 @@ public class RetrieveRenderedService : IRetrieveRenderedService
                 "Retrieving rendered Instance for watermark {Watermark} of size {ContentLength}", instance.VersionedInstanceIdentifier.Version, fileProperties.ContentLength);
             _retrieveMeter.RetrieveInstanceCount.Add(
                 1,
-                RetrieveMeter.RetrieveInstanceCountTelemetryDimension(fileProperties.ContentLength, _retrieveConfiguration.MaxDicomFileSize, isRendered: true));
+                RetrieveMeter.RetrieveInstanceCountTelemetryDimension(fileProperties.ContentLength, isRendered: true));
 
             using Stream stream = await _blobDataStore.GetFileAsync(instance.VersionedInstanceIdentifier.Version, instance.VersionedInstanceIdentifier.Partition.Name, cancellationToken);
             sw.Start();

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveResourceService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveResourceService.cs
@@ -150,7 +150,7 @@ public class RetrieveResourceService : IRetrieveResourceService
             }
 
             // no transcoding
-            IAsyncEnumerable<RetrieveResourceInstance> responses = GetAsyncEnumerableStreams(retrieveInstances, isOriginalTransferSyntaxRequested, requestedTransferSyntax, message.IsOriginalVersionRequested, version, cancellationToken);
+            IAsyncEnumerable<RetrieveResourceInstance> responses = GetAsyncEnumerableStreams(retrieveInstances, isOriginalTransferSyntaxRequested, requestedTransferSyntax, message.IsOriginalVersionRequested, version, instance.InstanceProperties.HasFrameMetadata, cancellationToken);
             return new RetrieveResourceResponse(responses, validAcceptHeader.MediaType.ToString(), validAcceptHeader.IsSinglePart);
         }
         catch (DataStoreException e)
@@ -252,7 +252,7 @@ public class RetrieveResourceService : IRetrieveResourceService
             version, size, needsTranscoding);
         _retrieveMeter.RetrieveInstanceCount.Add(
             1,
-            RetrieveMeter.RetrieveInstanceCountTelemetryDimension(size, _retrieveConfiguration.MaxDicomFileSize, isTranscoding: needsTranscoding, hasFrameMetadata: hasFrameMetadata));
+            RetrieveMeter.RetrieveInstanceCountTelemetryDimension(size, isTranscoding: needsTranscoding, hasFrameMetadata: hasFrameMetadata));
     }
 
     private void SetTranscodingBillingProperties(long bytesTranscoded)
@@ -297,6 +297,7 @@ public class RetrieveResourceService : IRetrieveResourceService
         string requestedTransferSyntax,
         bool isOriginalVersionRequested,
         long requestedVersion,
+        bool hasFrameMetadata,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         long streamTotalLength = 0;
@@ -312,7 +313,7 @@ public class RetrieveResourceService : IRetrieveResourceService
                     GetResponseTransferSyntax(isOriginalTransferSyntaxRequested, requestedTransferSyntax, instanceMetadata),
                     fileProperties.ContentLength);
         }
-        LogFileSize(streamTotalLength, requestedVersion, needsTranscoding: false, hasFrameMetadata: true);
+        LogFileSize(streamTotalLength, requestedVersion, needsTranscoding: false, hasFrameMetadata: hasFrameMetadata);
     }
 
     private static async IAsyncEnumerable<RetrieveResourceInstance> GetAsyncEnumerableFrameStreams(

--- a/src/Microsoft.Health.Dicom.Core/Features/Telemetry/RetrieveMeter.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Telemetry/RetrieveMeter.cs
@@ -24,11 +24,10 @@ public sealed class RetrieveMeter : IDisposable
 
     public Counter<long> RetrieveInstanceCount { get; }
 
-    public static KeyValuePair<string, object>[] RetrieveInstanceCountTelemetryDimension(long contentLength, long maxFileSize, bool isTranscoding = false, bool hasFrameMetadata = false, bool isRendered = false) =>
+    public static KeyValuePair<string, object>[] RetrieveInstanceCountTelemetryDimension(long contentLength, bool isTranscoding = false, bool hasFrameMetadata = false, bool isRendered = false) =>
         new[]
         {
             new KeyValuePair<string, object>("ContentLength", contentLength),
-            new KeyValuePair<string, object>("MaxFileSize", maxFileSize),
             new KeyValuePair<string, object>("IsTranscoding", isTranscoding),
             new KeyValuePair<string, object>("IsRendered", isRendered),
             new KeyValuePair<string, object>("HasFrameMetadata", hasFrameMetadata),


### PR DESCRIPTION
## Description
do not emit MaxFileSize and use first instance's properties to see if it has metadata

## Related issues
Addresses [[AB#106470](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/106470)].

## Testing
n/a
