### PR TITLE
delta is content length, not dimension

### DIFF
--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveRenderedService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveRenderedService.cs
@@ -92,8 +92,8 @@ public class RetrieveRenderedService : IRetrieveRenderedService
             _logger.LogInformation(
                 "Retrieving rendered Instance for watermark {Watermark} of size {ContentLength}", instance.VersionedInstanceIdentifier.Version, fileProperties.ContentLength);
             _retrieveMeter.RetrieveInstanceCount.Add(
-                1,
-                RetrieveMeter.RetrieveInstanceCountTelemetryDimension(fileProperties.ContentLength, isRendered: true));
+                fileProperties.ContentLength,
+                RetrieveMeter.RetrieveInstanceCountTelemetryDimension(isRendered: true));
 
             using Stream stream = await _blobDataStore.GetFileAsync(instance.VersionedInstanceIdentifier.Version, instance.VersionedInstanceIdentifier.Partition, instance.InstanceProperties.fileProperties, cancellationToken);
             sw.Start();

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveResourceService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/RetrieveResourceService.cs
@@ -251,8 +251,8 @@ public class RetrieveResourceService : IRetrieveResourceService
             "Retrieving Instance for watermark {Watermark} of size {ContentLength}, isTranscoding is {NeedsTranscoding}",
             version, size, needsTranscoding);
         _retrieveMeter.RetrieveInstanceCount.Add(
-            1,
-            RetrieveMeter.RetrieveInstanceCountTelemetryDimension(size, isTranscoding: needsTranscoding, hasFrameMetadata: hasFrameMetadata));
+            size,
+            RetrieveMeter.RetrieveInstanceCountTelemetryDimension(isTranscoding: needsTranscoding, hasFrameMetadata: hasFrameMetadata));
     }
 
     private void SetTranscodingBillingProperties(long bytesTranscoded)

--- a/src/Microsoft.Health.Dicom.Core/Features/Telemetry/RetrieveMeter.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Telemetry/RetrieveMeter.cs
@@ -24,10 +24,9 @@ public sealed class RetrieveMeter : IDisposable
 
     public Counter<long> RetrieveInstanceCount { get; }
 
-    public static KeyValuePair<string, object>[] RetrieveInstanceCountTelemetryDimension(long contentLength, bool isTranscoding = false, bool hasFrameMetadata = false, bool isRendered = false) =>
+    public static KeyValuePair<string, object>[] RetrieveInstanceCountTelemetryDimension(bool isTranscoding = false, bool hasFrameMetadata = false, bool isRendered = false) =>
         new[]
         {
-            new KeyValuePair<string, object>("ContentLength", contentLength),
             new KeyValuePair<string, object>("IsTranscoding", isTranscoding),
             new KeyValuePair<string, object>("IsRendered", isRendered),
             new KeyValuePair<string, object>("HasFrameMetadata", hasFrameMetadata),


### PR DESCRIPTION
## Description
adjusts retrieve metric to track content length as delta, not dimension.

## Related issues
Addresses [[AB#106470](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/106470)].

## Testing
n/a
