### PR TITLE
Add cmk validation to background service health check

### DIFF
--- a/src/Microsoft.Health.Dicom.Core/Features/HealthCheck/BackgroundServiceHealthCheck.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/HealthCheck/BackgroundServiceHealthCheck.cs
@@ -4,25 +4,31 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Health.Core.Features.Health;
 using Microsoft.Health.Dicom.Core.Configs;
 using Microsoft.Health.Dicom.Core.Exceptions;
 using Microsoft.Health.Dicom.Core.Features.Store;
 using Microsoft.Health.Dicom.Core.Features.Telemetry;
+using Microsoft.Health.Encryption.Customer.Health;
 
 namespace Microsoft.Health.Dicom.Core.Features.HealthCheck;
 
 public class BackgroundServiceHealthCheck : IHealthCheck
 {
+    private const string DegradedDescription = "The health of the background service has degraded.";
+
     private readonly IIndexDataStore _indexDataStore;
     private readonly DeletedInstanceCleanupConfiguration _deletedInstanceCleanupConfiguration;
     private readonly DeleteMeter _deleteMeter;
     private readonly BackgroundServiceHealthCheckCache _backgroundServiceHealthCheckCache;
+    private readonly ValueCache<CustomerKeyHealth> _customerKeyHealthCache;
     private readonly ILogger<BackgroundServiceHealthCheck> _logger;
 
     public BackgroundServiceHealthCheck(
@@ -30,18 +36,21 @@ public class BackgroundServiceHealthCheck : IHealthCheck
         IOptions<DeletedInstanceCleanupConfiguration> deletedInstanceCleanupConfiguration,
         DeleteMeter deleteMeter,
         BackgroundServiceHealthCheckCache backgroundServiceHealthCheckCache,
+        ValueCache<CustomerKeyHealth> customerKeyHealthCache,
         ILogger<BackgroundServiceHealthCheck> logger)
     {
         EnsureArg.IsNotNull(indexDataStore, nameof(indexDataStore));
         EnsureArg.IsNotNull(deletedInstanceCleanupConfiguration?.Value, nameof(deletedInstanceCleanupConfiguration));
         EnsureArg.IsNotNull(deleteMeter, nameof(deleteMeter));
         EnsureArg.IsNotNull(backgroundServiceHealthCheckCache, nameof(backgroundServiceHealthCheckCache));
+        EnsureArg.IsNotNull(customerKeyHealthCache, nameof(customerKeyHealthCache));
         EnsureArg.IsNotNull(logger, nameof(logger));
 
         _indexDataStore = indexDataStore;
         _deletedInstanceCleanupConfiguration = deletedInstanceCleanupConfiguration.Value;
         _deleteMeter = deleteMeter;
         _backgroundServiceHealthCheckCache = backgroundServiceHealthCheckCache;
+        _customerKeyHealthCache = customerKeyHealthCache;
         _logger = logger;
     }
 
@@ -49,6 +58,17 @@ public class BackgroundServiceHealthCheck : IHealthCheck
     {
         try
         {
+            CustomerKeyHealth cmkStatus = await _customerKeyHealthCache.GetAsync(cancellationToken).ConfigureAwait(false);
+            if (!cmkStatus.IsHealthy)
+            {
+                // if the customer-managed key is inaccessible, the data store will also be inaccessible
+                return new HealthCheckResult(
+                    HealthStatus.Degraded,
+                    DegradedDescription,
+                    cmkStatus.Exception,
+                    new Dictionary<string, object> { { "Reason", cmkStatus.Reason } });
+            }
+
             Task<DateTimeOffset> oldestWaitingToBeDeleted = _backgroundServiceHealthCheckCache.GetOrAddOldestTimeAsync(_indexDataStore.GetOldestDeletedAsync, cancellationToken);
             Task<int> numReachedMaxedRetry = _backgroundServiceHealthCheckCache.GetOrAddNumExhaustedDeletionAttemptsAsync(
                 t => _indexDataStore.RetrieveNumExhaustedDeletedInstanceAttemptsAsync(_deletedInstanceCleanupConfiguration.MaxRetries, t),

--- a/src/Microsoft.Health.Dicom.Core/Microsoft.Health.Dicom.Core.csproj
+++ b/src/Microsoft.Health.Dicom.Core/Microsoft.Health.Dicom.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Common primitives and utilities used by Microsoft's DICOMweb APIs.</Description>
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.Extensions.Primitives" />
     <PackageReference Include="Microsoft.Health.Abstractions" />
     <PackageReference Include="Microsoft.Health.Core" />
+    <PackageReference Include="Microsoft.Health.Encryption" />
     <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Health.Operations" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />


### PR DESCRIPTION
## Description
When CMK is misconfigured, BackgroundServiceHealthCheck will fail because the SQL index store is inaccessible.

{"Timestamp":"2023-09-26T22:08:26.4293469+00:00","Level":"Error","MessageTemplate":
"Health check {HealthCheckName} with status {HealthStatus} completed after {ElapsedMilliseconds}ms with message '{HealthCheckDescription}'",
"Properties":{"HealthCheckName":"BackgroundServiceHealthCheck","HealthStatus":"Unhealthy","ElapsedMilliseconds":0.4778,"HealthCheckDescription":"Unhealthy service.","EventId":{"Id":103,"Name":"HealthCheckEnd"},"SourceContext":"Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService","resourceId":"/subscriptions/8ccee270-9421-44ca-bdb5-efa2eceef8dc/resourceGroups/julie-int-demo/providers/Microsoft.HealthcareApis/workspaces/juliedemows/dicomservices/julievalidation","resourceType":"Microsoft.HealthcareApis/workspaces/dicomservices","resourceName":"juliedemows/julievalidation","subscriptionId":"8ccee270-9421-44ca-bdb5-efa2eceef8dc","workspaceResourceId":"/subscriptions/8ccee270-9421-44ca-bdb5-efa2eceef8dc/resourceGroups/julie-int-demo/providers/Microsoft.HealthcareApis/workspaces/juliedemows","assemblyInformation":"0.1.4345+Branch.main.Sha.400d742d6e7ef4558f59b0fd89834e27ad826d31.400d742d6e7ef4558f59b0fd89834e27ad826d31","assemblyInformationOSS":"10.0.574+Branch.main.Sha.ee01239096ab0eedb43e8ee487997a852d4b5967.ee01239096ab0eedb43e8ee487997a852d4b5967","ImageRepository":"mshapisg2ciacr.azurecr.io","ImageName":"dicom-service","ImageTag":"0.1.4345"}}


## Related issues
Addresses [109383].

## Testing
Deployed to dev cluster - BackgroundServiceHealthCheck reports degraded when CMK is misconfigured