### PR TITLE
Handle Task Canceled exception and output 400 instead of 503

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
@@ -19,6 +19,7 @@ using Microsoft.Health.Api.Features.Audit;
 using Microsoft.Health.Dicom.Core.Exceptions;
 using NotSupportedException = Microsoft.Health.Dicom.Core.Exceptions.NotSupportedException;
 using ComponentModelValidationException = System.ComponentModel.DataAnnotations.ValidationException;
+using System.Linq;
 
 namespace Microsoft.Health.Dicom.Api.Features.Exceptions;
 
@@ -86,6 +87,7 @@ public class ExceptionHandlingMiddleware
             case ConnectionResetException:
             case OperationCanceledException:
             case DataStoreException e when e.InnerException is TaskCanceledException:
+            case DataStoreException ex when ex.InnerException is AggregateException && (ex.InnerException as AggregateException).InnerExceptions.Any(x => x is TaskCanceledException):
             case BadHttpRequestException:
             case IOException io when io.Message.Equals("The request stream was aborted.", StringComparison.OrdinalIgnoreCase):
                 statusCode = HttpStatusCode.BadRequest;

--- a/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
@@ -86,8 +86,7 @@ public class ExceptionHandlingMiddleware
             case AuditHeaderTooLargeException:
             case ConnectionResetException:
             case OperationCanceledException:
-            case DataStoreException e when e.InnerException is TaskCanceledException:
-            case DataStoreException ex when ex.InnerException is AggregateException && (ex.InnerException as AggregateException).InnerExceptions.Any(x => x is TaskCanceledException):
+            case DataStoreException e when IsTaskCanceledException(e.InnerException):
             case BadHttpRequestException:
             case IOException io when io.Message.Equals("The request stream was aborted.", StringComparison.OrdinalIgnoreCase):
                 statusCode = HttpStatusCode.BadRequest;
@@ -154,6 +153,11 @@ public class ExceptionHandlingMiddleware
         }
 
         return GetContentResult(statusCode, message);
+    }
+
+    private static bool IsTaskCanceledException(Exception ex)
+    {
+        return ex is TaskCanceledException || (ex is AggregateException aggEx && aggEx.InnerExceptions.Any(x => x is TaskCanceledException));
     }
 
     private static IActionResult GetContentResult(HttpStatusCode statusCode, string message)


### PR DESCRIPTION
## Description
Handle Task Canceled exception and output 400 instead of 503. Currently when the blob storage is down and the user has canceled the current request, we send 503 instead of 400.

This PR handles the scenario of aggregate exception when one of the innerException is TaskCanceledException.

## Related issues
Addresses [[AB#110186](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/110186)].

## Testing
Unit test has been for this scenario.
