### PR TITLE
Enable SQL Workload Identity

### DIFF
--- a/src/Microsoft.Health.Dicom.Azure/Registration/KeyVaultClientRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Azure/Registration/KeyVaultClientRegistrationExtensions.cs
@@ -10,6 +10,7 @@ using EnsureThat;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Health.Core.Extensions;
 using Microsoft.Health.Dicom.Azure;
 using Microsoft.Health.Dicom.Azure.KeyVault;
 using Microsoft.Health.Dicom.Core.Features.Common;
@@ -91,7 +92,9 @@ public static class KeyVaultClientRegistrationExtensions
 
             services.AddAzureClients(builder =>
             {
-                IAzureClientBuilder<SecretClient, SecretClientOptions> clientBuilder = builder.AddSecretClient(section);
+                IAzureClientBuilder<SecretClient, SecretClientOptions> clientBuilder = builder
+                    .AddSecretClient(section)
+                    .WithRetryableCredential(section);
 
                 if (configureOptions != null)
                     clientBuilder.ConfigureOptions(configureOptions);

--- a/src/Microsoft.Health.Dicom.SqlServer.UnitTests/Microsoft.Health.Dicom.SqlServer.UnitTests.csproj
+++ b/src/Microsoft.Health.Dicom.SqlServer.UnitTests/Microsoft.Health.Dicom.SqlServer.UnitTests.csproj
@@ -7,11 +7,15 @@
   <ItemGroup>
     <PackageReference Include="fo-dicom" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Health.SqlServer" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="System.Drawing.Common" PrivateAssets="All" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
-    <PackageReference Include="System.Drawing.Common" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Health.Dicom.SqlServer.UnitTests/Registration/DicomSqlServerRegistrationExtensionsTests.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer.UnitTests/Registration/DicomSqlServerRegistrationExtensionsTests.cs
@@ -1,0 +1,98 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Health.Dicom.Core.Registration;
+using Microsoft.Health.Dicom.SqlServer.Registration;
+using Microsoft.Health.SqlServer.Configs;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Dicom.SqlServer.UnitTests.Registration;
+
+public sealed class DicomSqlServerRegistrationExtensionsTests : IDisposable
+{
+    [Fact]
+    public void GivenWebServerBuilder_WhenUsingDefaults_ThenUseBuiltInAuthenticationProvider()
+    {
+        IServiceCollection services = new ServiceCollection();
+        IDicomServerBuilder builder = Substitute.For<IDicomServerBuilder>();
+        builder.Services.Returns(services);
+
+        IConfiguration configuration = new ConfigurationBuilder().Build();
+
+        builder.AddSqlServer(configuration);
+
+        Assert.IsType<ActiveDirectoryAuthenticationProvider>(SqlAuthenticationProvider.GetProvider(SqlAuthenticationMethod.ActiveDirectoryManagedIdentity));
+        Assert.IsType<ActiveDirectoryAuthenticationProvider>(SqlAuthenticationProvider.GetProvider(SqlAuthenticationMethod.ActiveDirectoryMSI));
+    }
+
+    [Fact]
+    public void GivenFunctionsBuilder_WhenUsingDefaults_ThenUseBuiltInAuthenticationProvider()
+    {
+        IServiceCollection services = new ServiceCollection();
+        IDicomFunctionsBuilder builder = Substitute.For<IDicomFunctionsBuilder>();
+        builder.Services.Returns(services);
+
+        IConfiguration configuration = new ConfigurationBuilder()
+            .Build();
+
+        builder.AddSqlServer(configuration.Bind);
+
+        Assert.IsType<ActiveDirectoryAuthenticationProvider>(SqlAuthenticationProvider.GetProvider(SqlAuthenticationMethod.ActiveDirectoryManagedIdentity));
+        Assert.IsType<ActiveDirectoryAuthenticationProvider>(SqlAuthenticationProvider.GetProvider(SqlAuthenticationMethod.ActiveDirectoryMSI));
+    }
+
+    [Fact]
+    public void GivenWebServerBuilder_WhenConfiguringWorkloadIdenity_ThenIncludeAuthenticationProvider()
+    {
+        IServiceCollection services = new ServiceCollection();
+        IDicomServerBuilder builder = Substitute.For<IDicomServerBuilder>();
+        builder.Services.Returns(services);
+
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new KeyValuePair<string, string>[]
+            {
+                new KeyValuePair<string, string>($"{SqlServerDataStoreConfiguration.SectionName}:EnableWorkloadIdentity", "true"),
+            })
+            .Build();
+
+        builder.AddSqlServer(configuration);
+
+        Assert.IsNotType<ActiveDirectoryAuthenticationProvider>(SqlAuthenticationProvider.GetProvider(SqlAuthenticationMethod.ActiveDirectoryManagedIdentity));
+        Assert.IsNotType<ActiveDirectoryAuthenticationProvider>(SqlAuthenticationProvider.GetProvider(SqlAuthenticationMethod.ActiveDirectoryMSI));
+    }
+
+    [Fact]
+    public void GivenFunctionBuilder_WhenConfiguringWorkloadIdenity_ThenIncludeAuthenticationProvider()
+    {
+        IServiceCollection services = new ServiceCollection();
+        IDicomFunctionsBuilder builder = Substitute.For<IDicomFunctionsBuilder>();
+        builder.Services.Returns(services);
+
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new KeyValuePair<string, string>[]
+            {
+                new KeyValuePair<string, string>("EnableWorkloadIdentity", "true"),
+            })
+            .Build();
+
+        builder.AddSqlServer(configuration.Bind);
+
+        Assert.IsNotType<ActiveDirectoryAuthenticationProvider>(SqlAuthenticationProvider.GetProvider(SqlAuthenticationMethod.ActiveDirectoryManagedIdentity));
+        Assert.IsNotType<ActiveDirectoryAuthenticationProvider>(SqlAuthenticationProvider.GetProvider(SqlAuthenticationMethod.ActiveDirectoryMSI));
+    }
+
+    public void Dispose()
+    {
+        ActiveDirectoryAuthenticationProvider provider = new();
+        SqlAuthenticationProvider.SetProvider(SqlAuthenticationMethod.ActiveDirectoryManagedIdentity, provider);
+        SqlAuthenticationProvider.SetProvider(SqlAuthenticationMethod.ActiveDirectoryMSI, provider);
+    }
+}


### PR DESCRIPTION
## Description
- Allow use of explicit workload identity for SQL connections
- Enable configuring retries for Key Vault credentials

## Related issues
[AB#98306](https://microsofthealth.visualstudio.com/Health/_workitems/edit/98306/)
[AB#103496](https://microsofthealth.visualstudio.com/Health/_workitems/edit/103496/)

## Testing
New unit tests
