### PR TITLE
Disable Test Parallelization for SQL Auth Tests

### DIFF
--- a/src/Microsoft.Health.Dicom.SqlServer.UnitTests/Registration/DicomSqlServerRegistrationExtensionsTests.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer.UnitTests/Registration/DicomSqlServerRegistrationExtensionsTests.cs
@@ -16,6 +16,7 @@ using Xunit;
 
 namespace Microsoft.Health.Dicom.SqlServer.UnitTests.Registration;
 
+[Collection("SQL Authentication Collection")]
 public sealed class DicomSqlServerRegistrationExtensionsTests : IDisposable
 {
     [Fact]

--- a/src/Microsoft.Health.Dicom.SqlServer.UnitTests/SqlAuthenticationCollection.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer.UnitTests/SqlAuthenticationCollection.cs
@@ -1,0 +1,13 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Xunit;
+
+namespace Microsoft.Health.Dicom.SqlServer.UnitTests;
+
+[CollectionDefinition("SQL Authentication Collection", DisableParallelization = true)]
+public class SqlAuthenticationCollection
+{
+}


### PR DESCRIPTION
## Description
Prevent SQL auth tests from running concurrently with other tests due to their manipulation of `static` state

## Related issues
N/A

## Testing
N/A
