### PR TITLE
allow file properties to be null for external store, temporarily

### DIFF
--- a/src/Microsoft.Health.Dicom.Blob/Features/ExternalStore/ExternalBlobClient.cs
+++ b/src/Microsoft.Health.Dicom.Blob/Features/ExternalStore/ExternalBlobClient.cs
@@ -111,10 +111,14 @@ internal class ExternalBlobClient : IBlobClient
 
     public BlobRequestConditions GetConditions(FileProperties fileProperties)
     {
-        EnsureArg.IsNotNull(fileProperties);
-        return new BlobRequestConditions // ensure file has not been changed since we last worked with it
+        if (fileProperties != null)
         {
-            IfMatch = new ETag(fileProperties.ETag),
-        };
+            return new BlobRequestConditions // ensure file has not been changed since we last worked with it
+            {
+                IfMatch = new ETag(fileProperties.ETag),
+            };
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Description
allow file properties to be null for external store, temporarily

## Related issues
Addresses [[AB#110009](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/110009)].
related PR: https://github.com/microsoft/dicom-server/pull/3108
