### PR TITLE
Update v2-conformance-statement for leniency

### DIFF
--- a/docs/resources/v2-conformance-statement.md
+++ b/docs/resources/v2-conformance-statement.md
@@ -414,7 +414,9 @@ The following `Accept` header(s) are supported for searching:
 ### Search Changes From V1
 If an instance returned validation warnings for [searchable attributes](#searchable-attributes) at the time the [instance was stored](#store-changes-from-v1), those attributes may not be used to search for the stored instance. However, any [searchable attributes](#searchable-attributes) that failed validation will be able to return results if the values are overwritten by instances in the same study/series that are stored after the failed one, or if the values are already stored correctly by a previous instance. If the attribute values are not overwritten, then they will not produce any search results.
 
-To correct an attribute, delete the stored instance and upload the corrected data or a new instance with corrected data could be uploaded.
+An attribute can be corrected in the following ways:
+- Delete the stored instance and upload a new instance with the corrected data
+- Upload a new instance in the same study/series with corrected data
 
 ### Supported Search Parameters
 

--- a/docs/resources/v2-conformance-statement.md
+++ b/docs/resources/v2-conformance-statement.md
@@ -412,8 +412,9 @@ The following `Accept` header(s) are supported for searching:
 - `application/dicom+json`
 
 ### Search Changes From V1
-If an instance returned validation warnings for [searchable attributes](#searchable-attributes) at the time the [instance was stored](#store-changes-from-v1), those attributes may not be used to search for the stored instance.
-To correct an attribute, delete the stored instance and upload the corrected data.
+If an instance returned validation warnings for [searchable attributes](#searchable-attributes) at the time the [instance was stored](#store-changes-from-v1), those attributes may not be used to search for the stored instance. However, any [searchable attributes](#searchable-attributes) that failed validation will be able to return results if the values are overwritten by instances in the same study/series that are stored after the failed one, or if the values are already stored correctly by a previous instance. If the attribute values are not overwritten, then they will not produce any search results.
+
+To correct an attribute, delete the stored instance and upload the corrected data or a new instance with corrected data could be uploaded.
 
 ### Supported Search Parameters
 


### PR DESCRIPTION
## Description
Update v2-conformance-statement for searching attributes with leniency.

We already specify in QIDO, that only latest wins.  [QIDO Additional Notes](https://github.com/microsoft/dicom-server/blob/main/docs/resources/v2-conformance-statement.md#additional-notes). So there is no update needed.


## Related issues
Addresses [issue #].
