### PR TITLE
Fix error message for Unique key violation error

### DIFF
--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Store/SqlIndexDataStoreV37.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Store/SqlIndexDataStoreV37.cs
@@ -119,7 +119,7 @@ internal class SqlIndexDataStoreV37 : SqlIndexDataStoreV1
             {
                 throw new PendingInstanceException();
             }
-            catch (SqlException ex) when (ex.Number == SqlErrorCodes.Conflict)
+            catch (SqlException ex) when (ex.Number == SqlErrorCodes.Conflict || ex.Number == SqlErrorCodes.UniqueKeyConstraintVoilation)
             {
                 throw new InstanceAlreadyExistsException();
             }


### PR DESCRIPTION
## Description
Throw an InstanceAlreadyExistsException when there is a unique key constraint violation

## Related issues
Addresses [issue #111025](https://microsofthealth.visualstudio.com/Health/_workitems/edit/111025).

## Testing
Tested manually
