### PR TITLE
Fix Workload Identity Argument

### DIFF
--- a/src/Microsoft.Health.Dicom.SchemaManager.Console/Properties/launchSettings.json
+++ b/src/Microsoft.Health.Dicom.SchemaManager.Console/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Microsoft.Health.Dicom.SchemaManager": {
       "commandName": "Project",
-      "commandLineArgs": "apply --connection-string \"server=(local);Initial Catalog=DICOM3;TrustServerCertificate=True;Integrated Security=True\" --version 20",
+      "commandLineArgs": "apply --connection-string \"server=(local);Initial Catalog=DICOM3;TrustServerCertificate=True;Integrated Security=True\" --version 20 -wi=false",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/Microsoft.Health.Dicom.SchemaManager/ApplyCommand.cs
+++ b/src/Microsoft.Health.Dicom.SchemaManager/ApplyCommand.cs
@@ -12,7 +12,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Extensions.Logging;
-using Microsoft.Health.Dicom.SchemaManager.Properties;
 using Microsoft.Health.SqlServer.Features.Schema.Manager;
 using Microsoft.Health.SqlServer.Features.Schema.Manager.Model;
 
@@ -35,6 +34,7 @@ public class ApplyCommand : Command
         AddOption(CommandOptions.ConnectionStringOption());
         AddOption(CommandOptions.ManagedIdentityClientIdOption());
         AddOption(CommandOptions.AuthenticationTypeOption());
+        AddOption(CommandOptions.EnableWorkloadIdentityOptions());
         AddOption(CommandOptions.VersionOption());
         AddOption(CommandOptions.NextOption());
         AddOption(CommandOptions.LatestOption());

--- a/src/Microsoft.Health.Dicom.SchemaManager/CommandCollectionExtensions.cs
+++ b/src/Microsoft.Health.Dicom.SchemaManager/CommandCollectionExtensions.cs
@@ -65,6 +65,7 @@ public static class CommandCollectionExtensions
             { OptionAliases.AuthenticationType, OptionAliases.AuthenticationType },
             { OptionAliases.Version, OptionAliases.Version },
             { OptionAliases.EnableWorkloadIdentityShort, OptionAliases.EnableWorkloadIdentity },
+            { OptionAliases.EnableWorkloadIdentity, OptionAliases.EnableWorkloadIdentity },
         };
 
         configurationBuilder.AddCommandLine(args, switchMappings);

--- a/src/Microsoft.Health.Dicom.SchemaManager/CommandLineOptions.cs
+++ b/src/Microsoft.Health.Dicom.SchemaManager/CommandLineOptions.cs
@@ -19,6 +19,4 @@ public class CommandLineOptions
 
     [Obsolete("Use Connection String instead for different authentication types.")]
     public string? ManagedIdentityClientId { get; set; }
-
-    public bool EnableWorkloadIdentity { get; set; }
 }

--- a/src/Microsoft.Health.Dicom.SchemaManager/CommandOptions.cs
+++ b/src/Microsoft.Health.Dicom.SchemaManager/CommandOptions.cs
@@ -1,10 +1,9 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
 using System.CommandLine;
-using Microsoft.Health.Dicom.SchemaManager.Properties;
 
 namespace Microsoft.Health.Dicom.SchemaManager;
 
@@ -51,6 +50,20 @@ public static class CommandOptions
         connectionStringOption.AddAlias(OptionAliases.AuthenticationTypeShort);
 
         return connectionStringOption;
+    }
+
+    public static Option EnableWorkloadIdentityOptions()
+    {
+        var enableWorkloadIdentityOptions = new Option<string>(
+            name: OptionAliases.EnableWorkloadIdentity,
+            description: Resources.EnableWorkloadIdentityDescription)
+        {
+            Arity = ArgumentArity.ZeroOrOne
+        };
+
+        enableWorkloadIdentityOptions.AddAlias(OptionAliases.EnableWorkloadIdentityShort);
+
+        return enableWorkloadIdentityOptions;
     }
 
     public static Option VersionOption()

--- a/src/Microsoft.Health.Dicom.SchemaManager/Microsoft.Health.Dicom.SchemaManager.csproj
+++ b/src/Microsoft.Health.Dicom.SchemaManager/Microsoft.Health.Dicom.SchemaManager.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Update="Properties\Resources.Designer.cs">
+    <Compile Update="Resources.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Update="Properties\Resources.resx">
+    <EmbeddedResource Update="Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>

--- a/src/Microsoft.Health.Dicom.SchemaManager/Resources.Designer.cs
+++ b/src/Microsoft.Health.Dicom.SchemaManager/Resources.Designer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Microsoft.Health.Dicom.SchemaManager.Properties {
+namespace Microsoft.Health.Dicom.SchemaManager {
     using System;
     
     
@@ -39,7 +39,7 @@ namespace Microsoft.Health.Dicom.SchemaManager.Properties {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.Health.Dicom.SchemaManager.Properties.Resources", typeof(Resources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.Health.Dicom.SchemaManager.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -93,6 +93,15 @@ namespace Microsoft.Health.Dicom.SchemaManager.Properties {
         internal static string ConnectionStringRequiredValidation {
             get {
                 return ResourceManager.GetString("ConnectionStringRequiredValidation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enables the use of workload identity over managed identity..
+        /// </summary>
+        internal static string EnableWorkloadIdentityDescription {
+            get {
+                return ResourceManager.GetString("EnableWorkloadIdentityDescription", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Dicom.SchemaManager/Resources.resx
+++ b/src/Microsoft.Health.Dicom.SchemaManager/Resources.resx
@@ -129,6 +129,9 @@
   <data name="ConnectionStringRequiredValidation" xml:space="preserve">
     <value>You must include a connection string.</value>
   </data>
+  <data name="EnableWorkloadIdentityDescription" xml:space="preserve">
+    <value>Enables the use of workload identity over managed identity.</value>
+  </data>
   <data name="ForceOptionDescription" xml:space="preserve">
     <value>The schema migration is run without validating the specified schema version.</value>
   </data>


### PR DESCRIPTION
## Description
Fix usage of the new `--enable-workload-identity` and `-wi` arguments. Without the new option, the arguments are flagged as invalid and the app fails to run

## Related issues
[AB#111048](https://microsofthealth.visualstudio.com/Health/_workitems/edit/111048/)

## Testing
Tested locally and equivalent changes in PaaS
