### PR TITLE
Handle unique constraint voilation

### DIFF
--- a/src/Microsoft.Health.Dicom.SqlServer/Features/Partitioning/SqlPartitionStoreV6.cs
+++ b/src/Microsoft.Health.Dicom.SqlServer/Features/Partitioning/SqlPartitionStoreV6.cs
@@ -57,7 +57,7 @@ internal class SqlPartitionStoreV6 : SqlPartitionStoreV4
             }
             catch (SqlException ex)
             {
-                if (ex.Number == SqlErrorCodes.Conflict)
+                if (ex.Number == SqlErrorCodes.Conflict || ex.Number == SqlErrorCodes.UniqueKeyConstraintViolation)
                 {
                     throw new DataPartitionAlreadyExistsException();
                 }

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/PartitionTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/PartitionTests.cs
@@ -64,7 +64,7 @@ public class PartitionTests : IClassFixture<SqlDataStoreTestsFixture>
     [Fact]
     public async Task WhenNewPartitionIsCreatedInParallelWithSame_Then_ItThrowsException()
     {
-        string partitionName = new Guid().ToString("N");
+        string partitionName = Guid.NewGuid().ToString("N");
 
         await Assert.ThrowsAsync<DataPartitionAlreadyExistsException>(() => Task.WhenAll(
                        _fixture.PartitionStore.AddPartitionAsync(partitionName),

--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/PartitionTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/PartitionTests.cs
@@ -60,4 +60,14 @@ public class PartitionTests : IClassFixture<SqlDataStoreTestsFixture>
 
         Assert.Equal(Partition.DefaultKey, partition.Key);
     }
+
+    [Fact]
+    public async Task WhenNewPartitionIsCreatedInParallelWithSame_Then_ItThrowsException()
+    {
+        string partitionName = new Guid().ToString("N");
+
+        await Assert.ThrowsAsync<DataPartitionAlreadyExistsException>(() => Task.WhenAll(
+                       _fixture.PartitionStore.AddPartitionAsync(partitionName),
+                       _fixture.PartitionStore.AddPartitionAsync(partitionName)));
+    }
 }


### PR DESCRIPTION
## Description
Handle the case when  sql throws 2601 error code meaning a race condition where a process tries to insert a partition key which already exists.


## Related issues
Addresses [issue #110438](https://microsofthealth.visualstudio.com/Health/_workitems/edit/110438)

## Testing
Manually tested. Also updated integration test.
