### PR TITLE
fix test

### DIFF
--- a/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/ExternalFileStoreTests.cs
+++ b/test/Microsoft.Health.Dicom.Tests.Integration/Persistence/ExternalFileStoreTests.cs
@@ -148,7 +148,7 @@ public class ExternalFileStoreTests : IClassFixture<DataStoreTestsFixture>
         Assert.Contains(ExpectedFailedSubstring(), copyFileEx.Message);
 
         var getFilePropsEx = await Assert.ThrowsAsync<DataStoreRequestFailedException>(() => _blobDataStore.GetFilePropertiesAsync(version, Partition.Default, badFileProperties));
-        Assert.Contains(ExpectedFailedSubstring(), getFilePropsEx.Message);
+        Assert.Contains(ConditionNotMetMessage, getFilePropsEx.Message);
     }
 
     [Fact]


### PR DESCRIPTION
## Description
don't conditionally switch expected strings when running in pipeline

## Related issues
Addresses [[AB#109237](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/109237)].

## Testing
n/a
