### PR TITLE
Reduce Size of STOW Test to Accommodate Chunking

### DIFF
--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/StoreTransactionTestsLatest.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/StoreTransactionTestsLatest.cs
@@ -284,9 +284,9 @@ public class StoreTransactionTestsLatest : StoreTransactionTests
     public async Task GivenLargeSinglePartRequest_WhenStoring_ThenServerShouldReturnOk()
     {
         DicomFile dicomFile = Samples.CreateRandomDicomFileWithPixelData(
-            rows: 45000,
-            columns: 45000,
-            dicomTransferSyntax: DicomTransferSyntax.ExplicitVRLittleEndian); // ~2GB
+            rows: 43000,
+            columns: 43000,
+            dicomTransferSyntax: DicomTransferSyntax.ExplicitVRLittleEndian); // ~1.72GB
 
         using DicomWebResponse<DicomDataset> stow = await _instancesManager.StoreAsync(dicomFile);
         Assert.Equal(HttpStatusCode.OK, stow.StatusCode);
@@ -302,9 +302,9 @@ public class StoreTransactionTestsLatest : StoreTransactionTests
             .Repeat(studyInstanceUid, 1)
             .Select(study => Samples.CreateRandomDicomFileWithPixelData(
                 studyInstanceUid: study,
-                rows: 45000,
-                columns: 45000,
-                dicomTransferSyntax: DicomTransferSyntax.ExplicitVRLittleEndian)) // ~2GB
+                rows: 43000,
+                columns: 43000,
+                dicomTransferSyntax: DicomTransferSyntax.ExplicitVRLittleEndian)) // ~1.72GB
             .ToArray();
 
         using DicomWebResponse<DicomDataset> stow = await _instancesManager.StoreAsync(files);

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/StoreTransactionTestsLatest.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/StoreTransactionTestsLatest.cs
@@ -284,9 +284,9 @@ public class StoreTransactionTestsLatest : StoreTransactionTests
     public async Task GivenLargeSinglePartRequest_WhenStoring_ThenServerShouldReturnOk()
     {
         DicomFile dicomFile = Samples.CreateRandomDicomFileWithPixelData(
-            rows: 43000,
-            columns: 43000,
-            dicomTransferSyntax: DicomTransferSyntax.ExplicitVRLittleEndian); // ~1.72GB
+            rows: 42724,
+            columns: 42724,
+            dicomTransferSyntax: DicomTransferSyntax.ExplicitVRLittleEndian); // ~1.7 GB
 
         using DicomWebResponse<DicomDataset> stow = await _instancesManager.StoreAsync(dicomFile);
         Assert.Equal(HttpStatusCode.OK, stow.StatusCode);
@@ -302,9 +302,9 @@ public class StoreTransactionTestsLatest : StoreTransactionTests
             .Repeat(studyInstanceUid, 1)
             .Select(study => Samples.CreateRandomDicomFileWithPixelData(
                 studyInstanceUid: study,
-                rows: 43000,
-                columns: 43000,
-                dicomTransferSyntax: DicomTransferSyntax.ExplicitVRLittleEndian)) // ~1.72GB
+                rows: 42724,
+                columns: 42724,
+                dicomTransferSyntax: DicomTransferSyntax.ExplicitVRLittleEndian)) // ~1.7 GB
             .ToArray();
 
         using DicomWebResponse<DicomDataset> stow = await _instancesManager.StoreAsync(files);


### PR DESCRIPTION
## Description
Reduce the size of the 2 GB test to ~1.70 GB to allow for chunking the request as `Content-Length` is not specified to save on memory

## Related issues
N/A

## Testing
N/A
