### PR TITLE
Get correct file path on copying files

### DIFF
--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Update/UpdateInstanceServiceTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Update/UpdateInstanceServiceTests.cs
@@ -281,7 +281,7 @@ public class UpdateInstanceServiceTests
         var firstBlock = new KeyValuePair<string, long>(Convert.ToBase64String(Guid.NewGuid().ToByteArray()), stream.Length);
 
         _fileStore.CopyFileAsync(fileIdentifier, newFileIdentifier, Partition.Default, DefaultFileProperties, cancellationToken).Returns(Task.CompletedTask);
-        _fileStore.GetFilePropertiesAsync(newFileIdentifier, Partition.Default, DefaultFileProperties, cancellationToken).Returns(DefaultFileProperties);
+        _fileStore.GetFilePropertiesAsync(newFileIdentifier, Partition.Default, null, cancellationToken).Returns(DefaultFileProperties);
         _fileStore.GetFileAsync(fileIdentifier, Partition.Default, DefaultFileProperties, cancellationToken).Returns(streamAndStoredFile.Value);
         _metadataStore.GetInstanceMetadataAsync(fileIdentifier, cancellationToken).Returns(streamAndStoredFile.Key.Dataset);
         _metadataStore.StoreInstanceMetadataAsync(streamAndStoredFile.Key.Dataset, newFileIdentifier, cancellationToken).Returns(Task.CompletedTask);
@@ -302,6 +302,7 @@ public class UpdateInstanceServiceTests
         streamAndStoredFile.Key.Dataset.Remove(DicomTag.PixelData);
 
         await _fileStore.Received(1).CopyFileAsync(fileIdentifier, newFileIdentifier, Partition.Default, DefaultFileProperties, cancellationToken);
+        await _fileStore.Received(1).GetFilePropertiesAsync(newFileIdentifier, Partition.Default, null, cancellationToken);
         await _fileStore.DidNotReceive().GetFileAsync(fileIdentifier, Partition.Default, DefaultFileProperties, cancellationToken);
         await _metadataStore.Received(1).GetInstanceMetadataAsync(fileIdentifier, cancellationToken);
         await _metadataStore.Received(1).StoreInstanceMetadataAsync(streamAndStoredFile.Key.Dataset, newFileIdentifier, cancellationToken);

--- a/src/Microsoft.Health.Dicom.Core/Features/Update/UpdateInstanceService.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Update/UpdateInstanceService.cs
@@ -94,7 +94,7 @@ public class UpdateInstanceService : IUpdateInstanceService
         {
             _logger.LogInformation("Begin copying instance file {OrignalFileIdentifier} - {NewFileIdentifier}", originFileIdentifier, newFileIdentifier);
             await _fileStore.CopyFileAsync(originFileIdentifier, newFileIdentifier, partition, instance.InstanceProperties.FileProperties, cancellationToken);
-            newFileProperties = await _fileStore.GetFilePropertiesAsync(newFileIdentifier, partition, instance.InstanceProperties.FileProperties, cancellationToken);
+            newFileProperties = await _fileStore.GetFilePropertiesAsync(newFileIdentifier, partition, null, cancellationToken);
         }
         else
         {


### PR DESCRIPTION
## Description
Get correct file path on copying files by always passing in null file properties when getting file properties for a copied file as it is a new file and we need the new path

## Related issues
Addresses [[AB#112069](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/112069)].

## Testing
Updated unit test to assert we are passing in null for fp
