### PR TITLE
Add support to */* mediatype

### DIFF
--- a/docs/resources/conformance-statement.md
+++ b/docs/resources/conformance-statement.md
@@ -216,6 +216,7 @@ The following `Accept` header(s) are supported for retrieving instances within a
 - `multipart/related; type="application/dicom";` (when transfer-syntax is not specified, 1.2.840.10008.1.2.1 is used as default)
 - `multipart/related; type="application/dicom"; transfer-syntax=1.2.840.10008.1.2.1`
 - `multipart/related; type="application/dicom"; transfer-syntax=1.2.840.10008.1.2.4.90`
+- `*/*` (when transfer-syntax is not specified, `1.2.840.10008.1.2.1` is used as default and mediaType defaults to `application/dicom`)
 
 ### Retrieve an Instance
 
@@ -229,6 +230,7 @@ The following `Accept` header(s) are supported for retrieving a specific instanc
 - `multipart/related; type="application/dicom"; transfer-syntax=1.2.840.10008.1.2.1`
 - `application/dicom; transfer-syntax=1.2.840.10008.1.2.4.90`
 - `multipart/related; type="application/dicom"; transfer-syntax=1.2.840.10008.1.2.4.90`
+- `*/*` (when transfer-syntax is not specified, `1.2.840.10008.1.2.1` is used as default and mediaType defaults to `application/dicom`)
 
 ### Retrieve Frames
 
@@ -239,6 +241,7 @@ The following `Accept` headers are supported for retrieving frames:
 - `multipart/related; type="image/jp2";` (when transfer-syntax is not specified, `1.2.840.10008.1.2.4.90` is used as default)
 - `multipart/related; type="image/jp2";transfer-syntax=1.2.840.10008.1.2.4.90`
 - `application/octet-stream; transfer-syntax=*` for single frame retrieval
+- `*/*` (when transfer-syntax is not specified, `1.2.840.10008.1.2.1` is used as default and mediaType defaults to `application/octet-stream`)
 
 ### Retrieve Transfer Syntax
 

--- a/docs/resources/v2-conformance-statement.md
+++ b/docs/resources/v2-conformance-statement.md
@@ -293,6 +293,7 @@ The following `Accept` header(s) are supported for retrieving instances within a
 - `multipart/related; type="application/dicom";` (when transfer-syntax is not specified, 1.2.840.10008.1.2.1 is used as default)
 - `multipart/related; type="application/dicom"; transfer-syntax=1.2.840.10008.1.2.1`
 - `multipart/related; type="application/dicom"; transfer-syntax=1.2.840.10008.1.2.4.90`
+- `*/*` (when transfer-syntax is not specified, `1.2.840.10008.1.2.1` is used as default and mediaType defaults to `application/dicom`)
 
 ### Retrieve an Instance
 
@@ -306,6 +307,7 @@ The following `Accept` header(s) are supported for retrieving a specific instanc
 - `multipart/related; type="application/dicom"; transfer-syntax=1.2.840.10008.1.2.1`
 - `application/dicom; transfer-syntax=1.2.840.10008.1.2.4.90`
 - `multipart/related; type="application/dicom"; transfer-syntax=1.2.840.10008.1.2.4.90`
+- `*/*` (when transfer-syntax is not specified, `1.2.840.10008.1.2.1` is used as default and mediaType defaults to `application/dicom`)
 
 ### Retrieve Frames
 
@@ -316,6 +318,7 @@ The following `Accept` headers are supported for retrieving frames:
 - `multipart/related; type="image/jp2";` (when transfer-syntax is not specified, `1.2.840.10008.1.2.4.90` is used as default)
 - `multipart/related; type="image/jp2";transfer-syntax=1.2.840.10008.1.2.4.90`
 - `application/octet-stream; transfer-syntax=*` for single frame retrieval
+- `*/*` (when transfer-syntax is not specified, `1.2.840.10008.1.2.1` is used as default and mediaType defaults to `application/octet-stream`)
 
 ### Retrieve Transfer Syntax
 

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/AcceptHeaderHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/AcceptHeaderHandler.cs
@@ -130,15 +130,19 @@ public class AcceptHeaderHandler : IAcceptHeaderHandler
                 mediaType: KnownContentTypes.ApplicationDicom,
                 isTransferSyntaxMandatory: false,
                 transferSyntaxWhenMissing: DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID,
-                acceptableTransferSyntaxes: GetAcceptableTransferSyntaxSet(DicomTransferSyntaxUids.Original,
-                    DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID, DicomTransferSyntax.JPEG2000Lossless.UID.UID)),
+                acceptableTransferSyntaxes: GetAcceptableTransferSyntaxSet(
+                    DicomTransferSyntaxUids.Original,
+                    DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID,
+                    DicomTransferSyntax.JPEG2000Lossless.UID.UID)),
             new AcceptHeaderDescriptor(
                 payloadType: payloadTypes,
                 mediaType: KnownContentTypes.AnyMediaType,
                 isTransferSyntaxMandatory: false,
                 transferSyntaxWhenMissing: DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID,
-                acceptableTransferSyntaxes: GetAcceptableTransferSyntaxSet(DicomTransferSyntaxUids.Original,
-                    DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID, DicomTransferSyntax.JPEG2000Lossless.UID.UID))
+                acceptableTransferSyntaxes: GetAcceptableTransferSyntaxSet(
+                    DicomTransferSyntaxUids.Original,
+                    DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID,
+                    DicomTransferSyntax.JPEG2000Lossless.UID.UID))
         };
     }
 
@@ -151,7 +155,8 @@ public class AcceptHeaderHandler : IAcceptHeaderHandler
                 mediaType: KnownContentTypes.ApplicationOctetStream,
                 isTransferSyntaxMandatory: false,
                 transferSyntaxWhenMissing: DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID,
-                acceptableTransferSyntaxes: GetAcceptableTransferSyntaxSet(DicomTransferSyntaxUids.Original,
+                acceptableTransferSyntaxes: GetAcceptableTransferSyntaxSet(
+                    DicomTransferSyntaxUids.Original,
                     DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID)),
             new AcceptHeaderDescriptor(
                 payloadType: PayloadTypes.MultipartRelated,
@@ -164,7 +169,8 @@ public class AcceptHeaderHandler : IAcceptHeaderHandler
                 mediaType: KnownContentTypes.AnyMediaType,
                 isTransferSyntaxMandatory: false,
                 transferSyntaxWhenMissing: DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID,
-                acceptableTransferSyntaxes: GetAcceptableTransferSyntaxSet(DicomTransferSyntaxUids.Original,
+                acceptableTransferSyntaxes: GetAcceptableTransferSyntaxSet(
+                    DicomTransferSyntaxUids.Original,
                     DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID)),
         };
     }

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/AcceptHeaderHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/AcceptHeaderHandler.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using EnsureThat;
 using FellowOakDicom;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Dicom.Core.Exceptions;
 using Microsoft.Health.Dicom.Core.Messages;
 using Microsoft.Health.Dicom.Core.Messages.Retrieve;
@@ -77,7 +78,7 @@ public class AcceptHeaderHandler : IAcceptHeaderHandler
                 if (descriptor.IsAcceptable(header) && (selectedHeader == null || IsHigherPriorityTransferSyntax(header, selectedHeader)))
                 {
                     selectedHeader = new AcceptHeader(
-                        header.MediaType,
+                        GetMediaTypesString(header.MediaType, resourceType),
                         header.PayloadType,
                         descriptor.GetTransferSyntax(header),
                         header.Quality);
@@ -104,6 +105,22 @@ public class AcceptHeaderHandler : IAcceptHeaderHandler
         return (header.TransferSyntax.Value == DicomTransferSyntaxUids.Original && isQualityGreater);
     }
 
+    // If the media type is */* then we need to return the default media type for the resource type
+    private static StringSegment GetMediaTypesString(StringSegment mediaType, ResourceType resourceType)
+    {
+        if (mediaType != KnownContentTypes.AnyMediaType)
+        {
+            return mediaType;
+        }
+
+        if (resourceType == ResourceType.Frames)
+        {
+            return KnownContentTypes.ApplicationOctetStream;
+        }
+
+        return KnownContentTypes.ApplicationDicom;
+    }
+
     private static List<AcceptHeaderDescriptor> DescriptorsForGetNonFrameResource(PayloadTypes payloadTypes)
     {
         return new List<AcceptHeaderDescriptor>
@@ -111,6 +128,13 @@ public class AcceptHeaderHandler : IAcceptHeaderHandler
             new AcceptHeaderDescriptor(
                 payloadType: payloadTypes,
                 mediaType: KnownContentTypes.ApplicationDicom,
+                isTransferSyntaxMandatory: false,
+                transferSyntaxWhenMissing: DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID,
+                acceptableTransferSyntaxes: GetAcceptableTransferSyntaxSet(DicomTransferSyntaxUids.Original,
+                    DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID, DicomTransferSyntax.JPEG2000Lossless.UID.UID)),
+            new AcceptHeaderDescriptor(
+                payloadType: payloadTypes,
+                mediaType: KnownContentTypes.AnyMediaType,
                 isTransferSyntaxMandatory: false,
                 transferSyntaxWhenMissing: DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID,
                 acceptableTransferSyntaxes: GetAcceptableTransferSyntaxSet(DicomTransferSyntaxUids.Original,
@@ -134,7 +158,14 @@ public class AcceptHeaderHandler : IAcceptHeaderHandler
                 mediaType: KnownContentTypes.ImageJpeg2000,
                 isTransferSyntaxMandatory: false,
                 transferSyntaxWhenMissing: DicomTransferSyntax.JPEG2000Lossless.UID.UID,
-                acceptableTransferSyntaxes: GetAcceptableTransferSyntaxSet(DicomTransferSyntax.JPEG2000Lossless))
+                acceptableTransferSyntaxes: GetAcceptableTransferSyntaxSet(DicomTransferSyntax.JPEG2000Lossless)),
+            new AcceptHeaderDescriptor(
+                payloadType: PayloadTypes.SinglePartOrMultipartRelated,
+                mediaType: KnownContentTypes.AnyMediaType,
+                isTransferSyntaxMandatory: false,
+                transferSyntaxWhenMissing: DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID,
+                acceptableTransferSyntaxes: GetAcceptableTransferSyntaxSet(DicomTransferSyntaxUids.Original,
+                    DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID)),
         };
     }
 

--- a/src/Microsoft.Health.Dicom.Core/Web/KnownContentTypes.cs
+++ b/src/Microsoft.Health.Dicom.Core/Web/KnownContentTypes.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -21,6 +21,7 @@ public static class KnownContentTypes
     public const string ImageJpeg2000Part2 = "image/jpx";
     public const string VideoMpeg2 = "video/mpeg2";
     public const string VideoMp4 = "video/mp4";
+    public const string AnyMediaType = "*/*";
     public const string TransferSyntax = "transfer-syntax";
     public const string Boundary = "boundary";
     public const string ContentType = "Content-Type";

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Frame.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Frame.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -86,6 +85,36 @@ public partial class RetrieveTransactionResourceTests
             seriesInstanceUid,
             sopInstanceUid,
             dicomTransferSyntax: "*",
+            frames: new[] { 1 });
+
+        Stream[] results = await response.ToArrayAsync();
+
+        Assert.Collection(
+            results,
+            item => Assert.Equal(item.ToByteArray(), DicomPixelData.Create(dicomFile.Dataset).GetFrame(0).Data));
+    }
+
+    [Fact]
+    public async Task GivenAnyMediaType_WhenRetrieveFrameWithOriginalTransferSyntax_ThenOriginalContentReturned()
+    {
+        var studyInstanceUid = TestUidGenerator.Generate();
+        var seriesInstanceUid = TestUidGenerator.Generate();
+        var sopInstanceUid = TestUidGenerator.Generate();
+
+        DicomFile dicomFile = Samples.CreateRandomDicomFileWith8BitPixelData(
+            studyInstanceUid,
+            seriesInstanceUid,
+            sopInstanceUid,
+            encode: false);
+
+        await _instancesManager.StoreAsync(dicomFile);
+
+        // Check for series
+        using DicomWebAsyncEnumerableResponse<Stream> response = await _client.RetrieveFramesAsync(
+            studyInstanceUid,
+            seriesInstanceUid,
+            sopInstanceUid,
+            mediaType: "*/*",
             frames: new[] { 1 });
 
         Stream[] results = await response.ToArrayAsync();
@@ -209,16 +238,6 @@ public partial class RetrieveTransactionResourceTests
         finally
         {
             await _client.DeleteInstanceAsync(studyInstanceUid, seriesInstanceUid, sopInstanceUid);
-        }
-    }
-
-    public static IEnumerable<object[]> GetUnsupportedAcceptHeadersForFrames
-    {
-        get
-        {
-            yield return new object[] { true, DicomWebConstants.ApplicationOctetStreamMediaType, DicomWebConstants.OriginalDicomTransferSyntax }; // use single part instead of multiple part
-            yield return new object[] { false, DicomWebConstants.ImagePngMediaType, DicomWebConstants.OriginalDicomTransferSyntax }; // unsupported media type image/png
-            yield return new object[] { false, DicomWebConstants.ApplicationOctetStreamMediaType, "1.2.840.10008.1.2.4.100" }; // unsupported media type MPEG2
         }
     }
 }

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Frame.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Frame.cs
@@ -17,6 +17,7 @@ using Microsoft.Health.Dicom.Core.Features.Model;
 using Microsoft.Health.Dicom.Core.Features.Partitioning;
 using Microsoft.Health.Dicom.Core.Web;
 using Microsoft.Health.Dicom.Tests.Common;
+using Microsoft.Health.Dicom.Tests.Common.Comparers;
 using Microsoft.Health.Dicom.Tests.Common.Extensions;
 using Microsoft.Health.Dicom.Tests.Common.TranscoderTests;
 using Xunit;
@@ -121,7 +122,7 @@ public partial class RetrieveTransactionResourceTests
 
         Assert.Collection(
             results,
-            item => Assert.Equal(item.ToByteArray(), DicomPixelData.Create(dicomFile.Dataset).GetFrame(0).Data));
+            item => Assert.Equal(item.ToByteArray(), DicomPixelData.Create(dicomFile.Dataset).GetFrame(0).Data, BinaryComparer.Instance));
     }
 
     [Fact]


### PR DESCRIPTION
## Description
Currently OHIF microscopic viewer, retrieves frames using `*/*` as accept header. The currently implementation, throws exception since we don't support. 

This PR adds support for retrieving frames/instance using `*/*` mediatype. Depends on the resourceType defaults are choosen.

Defaults are choosen as per the standard. 

Default MediaType - https://dicom.nema.org/medical/dicom/current/output/html/part18.html#sect_10.4.4
Default TransferSyntaxUID - https://dicom.nema.org/medical/dicom/current/output/html/part18.html#sect_8.7.3.1


## Related issues
Addresses [AB#112103].

## Testing
- New unit test and E2E test are added