### PR TITLE
Wrap SQL Exception in DataStoreException

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
@@ -86,6 +86,7 @@ public class ExceptionHandlingMiddleware
             case AuditHeaderTooLargeException:
             case ConnectionResetException:
             case OperationCanceledException:
+            case DicomImageException ex when IsTaskCanceledException(ex.InnerException):
             case DataStoreException e when IsTaskCanceledException(e.InnerException):
             case BadHttpRequestException:
             case IOException io when io.Message.Equals("The request stream was aborted.", StringComparison.OrdinalIgnoreCase):


### PR DESCRIPTION
## Description
Wrap SQL Exception in DataStoreException to handle TaskCanceled exception as BadRequest.

## Related issues
AB#112589, AB#112741, AB#112755 

## Testing
Existing test was executed
