### PR TITLE
Use original transfer syntax for */* accept header

### DIFF
--- a/docs/resources/conformance-statement.md
+++ b/docs/resources/conformance-statement.md
@@ -216,7 +216,7 @@ The following `Accept` header(s) are supported for retrieving instances within a
 - `multipart/related; type="application/dicom";` (when transfer-syntax is not specified, 1.2.840.10008.1.2.1 is used as default)
 - `multipart/related; type="application/dicom"; transfer-syntax=1.2.840.10008.1.2.1`
 - `multipart/related; type="application/dicom"; transfer-syntax=1.2.840.10008.1.2.4.90`
-- `*/*` (when transfer-syntax is not specified, `1.2.840.10008.1.2.1` is used as default and mediaType defaults to `application/dicom`)
+- `*/*` (when transfer-syntax is not specified, `*` is used as default and mediaType defaults to `application/dicom`)
 
 ### Retrieve an Instance
 
@@ -230,7 +230,7 @@ The following `Accept` header(s) are supported for retrieving a specific instanc
 - `multipart/related; type="application/dicom"; transfer-syntax=1.2.840.10008.1.2.1`
 - `application/dicom; transfer-syntax=1.2.840.10008.1.2.4.90`
 - `multipart/related; type="application/dicom"; transfer-syntax=1.2.840.10008.1.2.4.90`
-- `*/*` (when transfer-syntax is not specified, `1.2.840.10008.1.2.1` is used as default and mediaType defaults to `application/dicom`)
+- `*/*` (when transfer-syntax is not specified, `*` is used as default and mediaType defaults to `application/dicom`)
 
 ### Retrieve Frames
 
@@ -241,7 +241,7 @@ The following `Accept` headers are supported for retrieving frames:
 - `multipart/related; type="image/jp2";` (when transfer-syntax is not specified, `1.2.840.10008.1.2.4.90` is used as default)
 - `multipart/related; type="image/jp2";transfer-syntax=1.2.840.10008.1.2.4.90`
 - `application/octet-stream; transfer-syntax=*` for single frame retrieval
-- `*/*` (when transfer-syntax is not specified, `1.2.840.10008.1.2.1` is used as default and mediaType defaults to `application/octet-stream`)
+- `*/*` (when transfer-syntax is not specified, `*` is used as default and mediaType defaults to `application/octet-stream`)
 
 ### Retrieve Transfer Syntax
 

--- a/docs/resources/v2-conformance-statement.md
+++ b/docs/resources/v2-conformance-statement.md
@@ -293,7 +293,7 @@ The following `Accept` header(s) are supported for retrieving instances within a
 - `multipart/related; type="application/dicom";` (when transfer-syntax is not specified, 1.2.840.10008.1.2.1 is used as default)
 - `multipart/related; type="application/dicom"; transfer-syntax=1.2.840.10008.1.2.1`
 - `multipart/related; type="application/dicom"; transfer-syntax=1.2.840.10008.1.2.4.90`
-- `*/*` (when transfer-syntax is not specified, `1.2.840.10008.1.2.1` is used as default and mediaType defaults to `application/dicom`)
+- `*/*` (when transfer-syntax is not specified, `*` is used as default and mediaType defaults to `application/dicom`)
 
 ### Retrieve an Instance
 
@@ -307,7 +307,7 @@ The following `Accept` header(s) are supported for retrieving a specific instanc
 - `multipart/related; type="application/dicom"; transfer-syntax=1.2.840.10008.1.2.1`
 - `application/dicom; transfer-syntax=1.2.840.10008.1.2.4.90`
 - `multipart/related; type="application/dicom"; transfer-syntax=1.2.840.10008.1.2.4.90`
-- `*/*` (when transfer-syntax is not specified, `1.2.840.10008.1.2.1` is used as default and mediaType defaults to `application/dicom`)
+- `*/*` (when transfer-syntax is not specified, `*` is used as default and mediaType defaults to `application/dicom`)
 
 ### Retrieve Frames
 
@@ -318,7 +318,7 @@ The following `Accept` headers are supported for retrieving frames:
 - `multipart/related; type="image/jp2";` (when transfer-syntax is not specified, `1.2.840.10008.1.2.4.90` is used as default)
 - `multipart/related; type="image/jp2";transfer-syntax=1.2.840.10008.1.2.4.90`
 - `application/octet-stream; transfer-syntax=*` for single frame retrieval
-- `*/*` (when transfer-syntax is not specified, `1.2.840.10008.1.2.1` is used as default and mediaType defaults to `application/octet-stream`)
+- `*/*` (when transfer-syntax is not specified, `*` is used as default and mediaType defaults to `application/octet-stream`)
 
 ### Retrieve Transfer Syntax
 

--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/AcceptHeaderHandlerTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/AcceptHeaderHandlerTests.cs
@@ -243,7 +243,7 @@ public class AcceptHeaderHandlerTests
         );
 
         var expectedTransferSyntax = string.IsNullOrEmpty(requestedAcceptHeaders.First().TransferSyntax.Value) ?
-            ValidStudyAcceptHeaderDescriptor.TransferSyntaxWhenMissing :
+            "*" :
             requestedAcceptHeaders.First().TransferSyntax.Value;
 
         Assert.Equal(mediaType, matchedAcceptHeader.MediaType);

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/AcceptHeaderHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/AcceptHeaderHandler.cs
@@ -138,7 +138,7 @@ public class AcceptHeaderHandler : IAcceptHeaderHandler
                 payloadType: payloadTypes,
                 mediaType: KnownContentTypes.AnyMediaType,
                 isTransferSyntaxMandatory: false,
-                transferSyntaxWhenMissing: DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID,
+                transferSyntaxWhenMissing: DicomTransferSyntaxUids.Original,
                 acceptableTransferSyntaxes: GetAcceptableTransferSyntaxSet(
                     DicomTransferSyntaxUids.Original,
                     DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID,
@@ -168,7 +168,7 @@ public class AcceptHeaderHandler : IAcceptHeaderHandler
                 payloadType: PayloadTypes.SinglePartOrMultipartRelated,
                 mediaType: KnownContentTypes.AnyMediaType,
                 isTransferSyntaxMandatory: false,
-                transferSyntaxWhenMissing: DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID,
+                transferSyntaxWhenMissing: DicomTransferSyntaxUids.Original,
                 acceptableTransferSyntaxes: GetAcceptableTransferSyntaxSet(
                     DicomTransferSyntaxUids.Original,
                     DicomTransferSyntax.ExplicitVRLittleEndian.UID.UID)),


### PR DESCRIPTION
## Description
Use original transfer syntax for */* accept header

DICOM standard - https://dicom.nema.org/medical/dicom/current/output/html/part18.html#sect_8.7

## Related issues
Addresses [AB#112103].

## Testing
Describe how this change was tested.
