### PR TITLE
Catch operation cancelled inner exceptions in middleware

### DIFF
--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Exceptions/ExceptionHandlingMiddlewareTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Features/Exceptions/ExceptionHandlingMiddlewareTests.cs
@@ -64,6 +64,9 @@ public class ExceptionHandlingMiddlewareTests
         yield return new object[] { new DataStoreException(new RequestFailedException(403, "The key vault key is not found to unwrap the encryption key.", "KeyVaultEncryptionKeyNotFound", new Exception())), HttpStatusCode.FailedDependency };
         yield return new object[] { new DataStoreRequestFailedException(new RequestFailedException(403, "The key vault key is not found to unwrap the encryption key.", "KeyVaultEncryptionKeyNotFound", new Exception())), HttpStatusCode.FailedDependency };
         yield return new object[] { new RequestFailedException(403, "The key vault key is not found to unwrap the encryption key.", "KeyVaultEncryptionKeyNotFound", new Exception()), HttpStatusCode.FailedDependency };
+        yield return new object[] { new DataStoreException("Something went wrong.", new TaskCanceledException()), HttpStatusCode.BadRequest };
+        yield return new object[] { new DataStoreException("Something went wrong.", new OperationCanceledException()), HttpStatusCode.BadRequest };
+        yield return new object[] { new MicrosoftHealthException("Something went wrong.", new OperationCanceledException()), HttpStatusCode.BadRequest };
     }
 
     [Theory]

--- a/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Runtime.ExceptionServices;
 using System.Text.Json;
@@ -21,9 +22,8 @@ using Microsoft.Health.Api.Features.Audit;
 using Microsoft.Health.Dicom.Core.Exceptions;
 using Microsoft.Health.Encryption.Customer.Extensions;
 using Microsoft.Health.SqlServer.Features.Storage;
-using NotSupportedException = Microsoft.Health.Dicom.Core.Exceptions.NotSupportedException;
 using ComponentModelValidationException = System.ComponentModel.DataAnnotations.ValidationException;
-using System.Linq;
+using NotSupportedException = Microsoft.Health.Dicom.Core.Exceptions.NotSupportedException;
 
 namespace Microsoft.Health.Dicom.Api.Features.Exceptions;
 
@@ -90,8 +90,7 @@ public class ExceptionHandlingMiddleware
             case AuditHeaderTooLargeException:
             case ConnectionResetException:
             case OperationCanceledException:
-            case DicomImageException ex when IsTaskCanceledException(ex.InnerException):
-            case DataStoreException e when IsTaskCanceledException(e.InnerException):
+            case Exception e when IsOperationCanceledException(e.InnerException):
             case BadHttpRequestException:
             case IOException io when io.Message.Equals("The request stream was aborted.", StringComparison.OrdinalIgnoreCase):
                 statusCode = HttpStatusCode.BadRequest;
@@ -162,9 +161,9 @@ public class ExceptionHandlingMiddleware
         return GetContentResult(statusCode, message);
     }
 
-    private static bool IsTaskCanceledException(Exception ex)
+    private static bool IsOperationCanceledException(Exception ex)
     {
-        return ex is TaskCanceledException || (ex is AggregateException aggEx && aggEx.InnerExceptions.Any(x => x is TaskCanceledException));
+        return ex is OperationCanceledException || (ex is AggregateException aggEx && aggEx.InnerExceptions.Any(x => x is OperationCanceledException));
     }
 
     private static bool IsCMKException(Exception ex)

--- a/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
@@ -91,7 +91,6 @@ public class ExceptionHandlingMiddleware
             case ConnectionResetException:
             case OperationCanceledException:
             case MicrosoftHealthException ex when IsOperationCanceledException(ex.InnerException):
-            case DataStoreException e when IsOperationCanceledException(e.InnerException):
             case BadHttpRequestException:
             case IOException io when io.Message.Equals("The request stream was aborted.", StringComparison.OrdinalIgnoreCase):
                 statusCode = HttpStatusCode.BadRequest;

--- a/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Exceptions/ExceptionHandlingMiddleware.cs
@@ -90,7 +90,8 @@ public class ExceptionHandlingMiddleware
             case AuditHeaderTooLargeException:
             case ConnectionResetException:
             case OperationCanceledException:
-            case Exception e when IsOperationCanceledException(e.InnerException):
+            case MicrosoftHealthException ex when IsOperationCanceledException(ex.InnerException):
+            case DataStoreException e when IsOperationCanceledException(e.InnerException):
             case BadHttpRequestException:
             case IOException io when io.Message.Equals("The request stream was aborted.", StringComparison.OrdinalIgnoreCase):
                 statusCode = HttpStatusCode.BadRequest;


### PR DESCRIPTION
## Description
Catch msft health exceptions where the inner exception is OperationCanceledException (TaskCanceledException derives from this)

## Related issues
Addresses [113536].

## Testing
Added new unit tests
