### PR TITLE
Do not log cmk errors at critical level

### DIFF
--- a/src/Microsoft.Health.Dicom.Api.UnitTests/Features/BackgroundServices/DeletedInstanceCleanupWorkerTests.cs
+++ b/src/Microsoft.Health.Dicom.Api.UnitTests/Features/BackgroundServices/DeletedInstanceCleanupWorkerTests.cs
@@ -135,7 +135,7 @@ public sealed class DeletedInstanceCleanupWorkerTests : IDisposable
                 return new DeleteMetrics { OldestDeletion = oldest, TotalExhaustedRetries = TotalExhausted };
             });
 
-        await Assert.ThrowsAsync<TaskCanceledException>(() => _deletedInstanceCleanupWorker.ExecuteAsync(_cancellationTokenSource.Token));
+        await _deletedInstanceCleanupWorker.ExecuteAsync(_cancellationTokenSource.Token);
 
         // Force the meter provides to emit the metrics earlier than they might otherwise
         _meterProvider.ForceFlush();

--- a/src/Microsoft.Health.Dicom.Api/Features/BackgroundServices/DeletedInstanceCleanupWorker.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/BackgroundServices/DeletedInstanceCleanupWorker.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Dicom.Core.Configs;
@@ -15,6 +16,7 @@ using Microsoft.Health.Dicom.Core.Exceptions;
 using Microsoft.Health.Dicom.Core.Features.Delete;
 using Microsoft.Health.Dicom.Core.Features.Telemetry;
 using Microsoft.Health.Dicom.Core.Models.Delete;
+using Microsoft.Health.SqlServer.Features.Storage;
 
 namespace Microsoft.Health.Dicom.Api.Features.BackgroundServices;
 
@@ -71,6 +73,10 @@ public class DeletedInstanceCleanupWorker
             catch (DataStoreNotReadyException)
             {
                 _logger.LogInformation("The data store is not currently ready. Processing will continue after the next wait period.");
+            }
+            catch (SqlException sqlEx) when (sqlEx.IsCMKError())
+            {
+                _logger.LogInformation(sqlEx, "The customer-managed key is misconfigured by the customer.");
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {

--- a/src/Microsoft.Health.Dicom.Api/Features/BackgroundServices/DeletedInstanceCleanupWorker.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/BackgroundServices/DeletedInstanceCleanupWorker.cs
@@ -94,7 +94,7 @@ public class DeletedInstanceCleanupWorker
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
                 // Cancel requested.
-                throw;
+                break;
             }
         }
     }

--- a/src/Microsoft.Health.Dicom.Api/Features/BackgroundServices/DeletedInstanceCleanupWorker.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/BackgroundServices/DeletedInstanceCleanupWorker.cs
@@ -53,6 +53,8 @@ public class DeletedInstanceCleanupWorker
         {
             try
             {
+                await Task.Delay(_pollingInterval, stoppingToken).ConfigureAwait(false);
+
                 // Send metrics related to deletion progress
                 DeleteMetrics metrics = await _deleteService.GetMetricsAsync(stoppingToken);
 
@@ -85,16 +87,6 @@ public class DeletedInstanceCleanupWorker
             {
                 // The job failed.
                 _logger.LogCritical(ex, "Unhandled exception in the deleted instance cleanup worker.");
-            }
-
-            try
-            {
-                await Task.Delay(_pollingInterval, stoppingToken).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
-            {
-                // Cancel requested.
-                break;
             }
         }
     }


### PR DESCRIPTION
## Description
When we see CMK misconfigurations, the delete instance background worker will either:
1. Throw a DataStoreNotReadyException. There is no polling wait in the while loop here, so this will log infinitely until we are throttled, which will kill the pod (at least I think so, its hard to see the behavior here because its overwhelmed with logs
2. Throw a CMK specific exception, which is not handled specially and logged as a critical error.
 Ex: {"Timestamp":"2023-12-20T05:08:31.4623481+00:00","Level":"Fatal","MessageTemplate":"Unhandled exception in the deleted instance cleanup worker.","Exception":"Microsoft.Data.SqlClient.SqlException (0x80131904): Can not connect to the database in its current state.\n   at Microsoft.Data.SqlClient.TdsParser.ThrowExceptionAndWarning(TdsParserStateObject stateObj, Boolean callerHasConnectionLock, Boolean asyncClose)\n   at Microsoft.Data.SqlClient.TdsParser.TryRun(RunBehavior runBehavior, SqlCommand cmdHandler, SqlDataReader dataStream, BulkCopySimpleResultSet bulkCopyHandler, TdsParserStateObject stateObj, Boolean& dataReady)\n 
...

Instead log CMK specific errors as Information, and add polling delay even if we encounter an error

## Related issues
Addresses #109382

## Testing
Ensure unit tests pass