### PR TITLE
Update Pkgs for .NET 8

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,6 +34,16 @@
         <MediatRVersion>12.1.1</MediatRVersion>
         <OTelVersion>1.6.0</OTelVersion>
         <SdkPackageVersion>6.0.0</SdkPackageVersion>
+        <WebUtilitiesVersion>2.2.0</WebUtilitiesVersion>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(TargetFramework)' == 'netstandard2.0'">
+      <PropertyGroup>
+        <DependencyInjectionVersion>8.0.0</DependencyInjectionVersion>
+        <MediatRVersion>12.2.0</MediatRVersion>
+        <OTelVersion>1.7.0</OTelVersion>
+        <SdkPackageVersion>8.0.0</SdkPackageVersion>
+        <WebUtilitiesVersion>2.2.0</WebUtilitiesVersion>
       </PropertyGroup>
     </When>
     <Otherwise>
@@ -42,6 +52,7 @@
         <MediatRVersion>12.2.0</MediatRVersion>
         <OTelVersion>1.7.0</OTelVersion>
         <SdkPackageVersion>8.0.0</SdkPackageVersion>
+        <WebUtilitiesVersion>8.0.0</WebUtilitiesVersion>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,6 +32,7 @@
       <PropertyGroup>
         <DependencyInjectionVersion>6.0.1</DependencyInjectionVersion>
         <MediatRVersion>12.1.1</MediatRVersion>
+        <OTelVersion>1.6.0</OTelVersion>
         <SdkPackageVersion>6.0.0</SdkPackageVersion>
       </PropertyGroup>
     </When>
@@ -39,6 +40,7 @@
       <PropertyGroup>
         <DependencyInjectionVersion>8.0.0</DependencyInjectionVersion>
         <MediatRVersion>12.2.0</MediatRVersion>
+        <OTelVersion>1.7.0</OTelVersion>
         <SdkPackageVersion>8.0.0</SdkPackageVersion>
       </PropertyGroup>
     </Otherwise>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,7 +29,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(SdkPackageVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="$(WebUtilitiesVersion)" />
     <PackageVersion Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageVersion Include="Microsoft.Azure.ServiceBus" Version="5.2.0" />
     <PackageVersion Include="Microsoft.Azure.WebJobs" Version="3.0.39" />
@@ -65,23 +65,23 @@
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="$(SdkPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="$(SdkPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Health.Abstractions" Version="7.1.7" />
-    <PackageVersion Include="Microsoft.Health.Api" Version="7.1.7" />
-    <PackageVersion Include="Microsoft.Health.Blob" Version="7.1.7" />
-    <PackageVersion Include="Microsoft.Health.Client" Version="7.1.7" />
-    <PackageVersion Include="Microsoft.Health.Core" Version="7.1.7" />
-    <PackageVersion Include="Microsoft.Health.Encryption" Version="7.1.7" />
-    <PackageVersion Include="Microsoft.Health.Development.IdentityProvider" Version="7.1.7" />
-    <PackageVersion Include="Microsoft.Health.Extensions.BuildTimeCodeGenerator" Version="7.1.7" />
-    <PackageVersion Include="Microsoft.Health.Extensions.DependencyInjection" Version="7.1.7" />
+    <PackageVersion Include="Microsoft.Health.Abstractions" Version="7.1.8" />
+    <PackageVersion Include="Microsoft.Health.Api" Version="7.1.8" />
+    <PackageVersion Include="Microsoft.Health.Blob" Version="7.1.8" />
+    <PackageVersion Include="Microsoft.Health.Client" Version="7.1.8" />
+    <PackageVersion Include="Microsoft.Health.Core" Version="7.1.8" />
+    <PackageVersion Include="Microsoft.Health.Encryption" Version="7.1.8" />
+    <PackageVersion Include="Microsoft.Health.Development.IdentityProvider" Version="7.1.8" />
+    <PackageVersion Include="Microsoft.Health.Extensions.BuildTimeCodeGenerator" Version="7.1.8" />
+    <PackageVersion Include="Microsoft.Health.Extensions.DependencyInjection" Version="7.1.8" />
     <PackageVersion Include="Microsoft.Health.Fhir.R4.Client" Version="3.4.294" />
-    <PackageVersion Include="Microsoft.Health.Functions.Extensions" Version="7.1.7" />
-    <PackageVersion Include="Microsoft.Health.Operations" Version="7.1.7" />
-    <PackageVersion Include="Microsoft.Health.Operations.Functions" Version="7.1.7" />
-    <PackageVersion Include="Microsoft.Health.SqlServer" Version="7.1.7" />
-    <PackageVersion Include="Microsoft.Health.SqlServer.Api" Version="7.1.7" />
-    <PackageVersion Include="Microsoft.Health.Test.Utilities" Version="7.1.7" />
-    <PackageVersion Include="Microsoft.Health.Tools.Sql.Tasks" Version="7.1.7" />
+    <PackageVersion Include="Microsoft.Health.Functions.Extensions" Version="7.1.8" />
+    <PackageVersion Include="Microsoft.Health.Operations" Version="7.1.8" />
+    <PackageVersion Include="Microsoft.Health.Operations.Functions" Version="7.1.8" />
+    <PackageVersion Include="Microsoft.Health.SqlServer" Version="7.1.8" />
+    <PackageVersion Include="Microsoft.Health.SqlServer.Api" Version="7.1.8" />
+    <PackageVersion Include="Microsoft.Health.Test.Utilities" Version="7.1.8" />
+    <PackageVersion Include="Microsoft.Health.Tools.Sql.Tasks" Version="7.1.8" />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="7.0.3" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />
     <PackageVersion Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,9 +10,9 @@
     <PackageVersion Include="Azure.Storage.Queues" Version="12.17.1" />
     <PackageVersion Include="Azure.Storage.Common" Version="12.18.1" />
     <PackageVersion Include="Ensure.That" Version="10.1.0" />
-    <PackageVersion Include="fo-dicom" Version="5.1.1" />
+    <PackageVersion Include="fo-dicom" Version="5.1.2" />
     <PackageVersion Include="fo-dicom.Codecs" Version="5.11.0" />
-    <PackageVersion Include="fo-dicom.Imaging.ImageSharp" Version="5.1.0" />
+    <PackageVersion Include="fo-dicom.Imaging.ImageSharp" Version="5.1.2" />
     <PackageVersion Include="HashDepot" Version="3.1.0" />
     <PackageVersion Include="Hl7.Fhir.R4" Version="4.3.0" />
     <PackageVersion Include="Hl7.Fhir.Support" Version="4.3.0" />
@@ -91,10 +91,10 @@
     <PackageVersion Include="Microsoft.SqlServer.DACFx" Version="162.1.167" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.8.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="OpenTelemetry" Version="1.6.0" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="1.6.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.6.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.6.0" />
+    <PackageVersion Include="OpenTelemetry" Version="$(OTelVersion)" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="$(OTelVersion)" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="$(OTelVersion)" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="$(OTelVersion)" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="Polly" Version="8.2.0" />
     <PackageVersion Include="Polly.Extensions.Http" Version="3.0.0" />

--- a/renovate.json
+++ b/renovate.json
@@ -28,6 +28,12 @@
       ]
     },
     {
+      "groupName": "fo-dicom",
+      "matchPackagePrefixes": [
+        "fo-dicom"
+      ]
+    },
+    {
       "excludePackagePrefixes": [
         "Microsoft.Health.Fhir."
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -50,7 +50,6 @@
       ]
     },
     {
-      "allowedVersions": "<7.0.0",
       "groupName": "IdentityModel.Tokens",
       "matchPackagePatterns": [
         "IdentityModel.Tokens"

--- a/src/Microsoft.Health.Dicom.WebUtilities/Microsoft.Health.Dicom.WebUtilities.csproj
+++ b/src/Microsoft.Health.Dicom.WebUtilities/Microsoft.Health.Dicom.WebUtilities.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>$(LibraryFrameworks)</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
@@ -11,4 +12,5 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities"/>
   </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Description
Update some packages, including some like OTel which must only be updated for .NET 8 as it relies upon v8 versions of the Microsoft.Extensions.* libraries.

## Related issues
N/A

## Testing
Existing test suites
