### PR TITLE
Pass the correct content type while retrieving single frame

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Features/Responses/ResourceResult.cs
+++ b/src/Microsoft.Health.Dicom.Api/Features/Responses/ResourceResult.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -34,7 +34,7 @@ internal class ResourceResult : IActionResult
 
     public async Task ExecuteResultAsync(ActionContext context)
     {
-        ObjectResult objectResult = null;
+        ObjectResult objectResult;
         if (_response.IsSinglePart)
         {
             objectResult = await GetSinglePartResult(context.HttpContext, context.HttpContext.RequestAborted);
@@ -61,7 +61,7 @@ internal class ResourceResult : IActionResult
             StatusCode = (int)HttpStatusCode.OK,
         };
 
-        var singlePartMediaType = new MediaTypeHeaderValue(KnownContentTypes.ApplicationDicom);
+        var singlePartMediaType = new MediaTypeHeaderValue(_response.ContentType);
         singlePartMediaType.Parameters.Add(new NameValueHeaderValue(KnownContentTypes.TransferSyntax, transferSyntax));
 
         objectResult.ContentTypes.Add(singlePartMediaType);

--- a/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Frame.cs
+++ b/test/Microsoft.Health.Dicom.Web.Tests.E2E/Rest/RetrieveTransactionResourceTests.Frame.cs
@@ -198,6 +198,7 @@ public partial class RetrieveTransactionResourceTests
         Stream frameStream = await response.GetValueAsync();
         Assert.NotNull(frameStream);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(KnownContentTypes.ApplicationOctetStream, response.ContentHeaders.ContentType.MediaType);
     }
 
     [Fact]


### PR DESCRIPTION
## Description
Today for single frame retrieval with accept header "application/octet-stream;transfer-syntax=*", the response header content-type looks like "application/dicom; transfer-syntax=1.2.840.10008.1.2.4.50"
This breaks the viewer since the viewer expects the content-type as application/octet-stream

## Related issues
Addresses AB#113758

## Testing
Describe how this change was tested.
