### PR TITLE
Use multipart for any mediaType and for OHIF use original transfer syntax

### DIFF
--- a/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/AcceptHeaderHandlerTests.cs
+++ b/src/Microsoft.Health.Dicom.Core.UnitTests/Features/Retrieve/AcceptHeaderHandlerTests.cs
@@ -77,7 +77,8 @@ public class AcceptHeaderHandlerTests
                     ValidStudyAcceptHeaderDescriptor.TransferSyntaxWhenMissing)
             },
             ResourceType.Study,
-            KnownContentTypes.ApplicationDicom
+            KnownContentTypes.ApplicationDicom,
+            PayloadTypes.MultipartRelated,
         };
         yield return new object[]
         {
@@ -88,7 +89,8 @@ public class AcceptHeaderHandlerTests
                     ValidStudyAcceptHeaderDescriptor.PayloadType)
             },
             ResourceType.Series,
-            KnownContentTypes.ApplicationDicom
+            KnownContentTypes.ApplicationDicom,
+            PayloadTypes.MultipartRelated,
         };
         yield return new object[]
         {
@@ -99,7 +101,8 @@ public class AcceptHeaderHandlerTests
                     ValidStudyAcceptHeaderDescriptor.PayloadType)
             },
             ResourceType.Frames,
-            KnownContentTypes.ApplicationOctetStream
+            KnownContentTypes.ApplicationOctetStream,
+            PayloadTypes.MultipartRelated,
         };
     }
 
@@ -227,15 +230,14 @@ public class AcceptHeaderHandlerTests
         Assert.Equivalent(requestedAcceptHeader2, matchedAcceptHeader, strict: true);
     }
 
-
-
     [Theory]
     [MemberData(nameof(AnyMediaTypeHeadersList))]
     public void
         GivenASingleRequestedAcceptHeaderWithAnyMediaType_WhenRequestedMatchesHeadersWeAccept_ThenShouldReturnAcceptedHeaderWithTransferSyntaxAndDescriptorThatMatched(
             List<AcceptHeader> requestedAcceptHeaders,
             ResourceType requestedResourceType,
-            string mediaType)
+            string mediaType,
+            PayloadTypes payloadType)
     {
         AcceptHeader matchedAcceptHeader = _handler.GetValidAcceptHeader(
             requestedResourceType,
@@ -247,6 +249,7 @@ public class AcceptHeaderHandlerTests
             requestedAcceptHeaders.First().TransferSyntax.Value;
 
         Assert.Equal(mediaType, matchedAcceptHeader.MediaType);
+        Assert.Equal(payloadType, matchedAcceptHeader.PayloadType);
         Assert.Equal(expectedTransferSyntax, matchedAcceptHeader.TransferSyntax);
     }
 }

--- a/src/Microsoft.Health.Dicom.Core/Features/Retrieve/AcceptHeaderHandler.cs
+++ b/src/Microsoft.Health.Dicom.Core/Features/Retrieve/AcceptHeaderHandler.cs
@@ -79,7 +79,7 @@ public class AcceptHeaderHandler : IAcceptHeaderHandler
                 {
                     selectedHeader = new AcceptHeader(
                         GetMediaTypesString(header.MediaType, resourceType),
-                        header.PayloadType,
+                        GetPayloadType(header),
                         descriptor.GetTransferSyntax(header),
                         header.Quality);
 
@@ -103,6 +103,16 @@ public class AcceptHeaderHandler : IAcceptHeaderHandler
     {
         bool isQualityGreater = (header.Quality ?? AcceptHeader.DefaultQuality) >= (selectedHeader.Quality ?? AcceptHeader.DefaultQuality);
         return (header.TransferSyntax.Value == DicomTransferSyntaxUids.Original && isQualityGreater);
+    }
+
+    private static PayloadTypes GetPayloadType(AcceptHeader header)
+    {
+        if (header.MediaType != KnownContentTypes.AnyMediaType)
+        {
+            return header.PayloadType;
+        }
+
+        return PayloadTypes.MultipartRelated;
     }
 
     // If the media type is */* then we need to return the default media type for the resource type

--- a/src/Microsoft.Health.Dicom.Web/appsettings.json
+++ b/src/Microsoft.Health.Dicom.Web/appsettings.json
@@ -74,7 +74,7 @@
       "EnableExport": true,
       "EnableDataPartitions": false,
       "EnableFullDicomItemValidation": false,
-      "EnableOhifViewer": false,
+      "EnableOhifViewer": true,
       "EnableExternalStore": false,
       "DisableOperations": false
     },

--- a/src/Microsoft.Health.Dicom.Web/wwwroot/app-config.js
+++ b/src/Microsoft.Health.Dicom.Web/wwwroot/app-config.js
@@ -5,6 +5,8 @@ window.config = {
   extensions: [],
   modes: [],
   customizationService: {
+    dicomUploadComponent:
+      '@ohif/extension-cornerstone.customizationModule.cornerstoneDicomUploadComponent',
     // Shows a custom route -access via http://localhost:3000/custom
     // helloPage: '@ohif/extension-default.customizationModule.helloPage',
   },
@@ -42,6 +44,7 @@ window.config = {
       configuration: {
         friendlyName: 'Azure Dicom Web',
         name: 'AzureDicomWeb',
+        dicomUploadEnabled: true,
         wadoUriRoot: rootUrl,
         qidoRoot: rootUrl,
         wadoRoot: rootUrl,

--- a/src/Microsoft.Health.Dicom.Web/wwwroot/app-config.js
+++ b/src/Microsoft.Health.Dicom.Web/wwwroot/app-config.js
@@ -1,4 +1,4 @@
-var rootUrl = `${window.location.protocol}//${window.location.hostname}:${window.location.port}/v1`;
+var rootUrl = `${window.location.protocol}//${window.location.hostname}:${window.location.port}/v2`;
 window.config = {
   routerBasename: '/',
   // whiteLabeling: {},
@@ -53,6 +53,7 @@ window.config = {
         supportsFuzzyMatching: true,
         supportsWildcard: false,
         staticWado: true,
+        requestTransferSyntaxUID: '*',
         singlepart: 'bulkdata,video',
         // whether the data source should use retrieveBulkData to grab metadata,
         // and in case of relative path, what would it be relative to, options


### PR DESCRIPTION
## Description
This PR includes 2 changes

1. Use multipart related payload type for */*, since viewers works very well with multipart
2. Update the OHIF app.config to use original transfer syntax (*)
3. Enable dicom upload
4. Enable OHIF viewer 

## Related issues
Addresses [issue #].

## Testing
Manually tested with OHIF viewer.
