### PR TITLE
Add log to connected store health check

### DIFF
--- a/src/Microsoft.Health.Dicom.Blob/Features/Health/DicomConnectedStoreHealthCheck.cs
+++ b/src/Microsoft.Health.Dicom.Blob/Features/Health/DicomConnectedStoreHealthCheck.cs
@@ -48,6 +48,8 @@ internal class DicomConnectedStoreHealthCheck : IHealthCheck
 
     public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
     {
+        _logger.LogInformation("Checking the health of the connected store.");
+
         BlobContainerClient containerClient = _blobClient.BlobContainerClient;
         BlockBlobClient blockBlobClient = containerClient.GetBlockBlobClient($"{_externalStoreOptions.StorageDirectory}{_externalStoreOptions.HealthCheckFileName}");
 


### PR DESCRIPTION
## Description
Add log to health check. Helps confirm health check is running and that the dicom has connected store enabled 
