### PR TITLE
Add configuration to filter health checks

### DIFF
--- a/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using EnsureThat;
@@ -69,6 +70,7 @@ public static class DicomServerServiceCollectionExtensions
 
         HealthCheckPublisherConfiguration healthCheckPublisherConfiguration = new HealthCheckPublisherConfiguration();
         configuration.GetSection(HealthCheckPublisherConfiguration.SectionName).Bind(healthCheckPublisherConfiguration);
+        IEnumerable<string> excludedHealthCheckNames = healthCheckPublisherConfiguration.GetListOfExcludedHealthCheckNames();
 
         serverBuilder.Services
             .AddCustomerKeyValidationBackgroundService(options => configuration
@@ -80,7 +82,7 @@ public static class DicomServerServiceCollectionExtensions
                     .GetSection(HealthCheckPublisherConfiguration.SectionName)
                     .Bind(options);
 
-                options.Predicate = (check) => !healthCheckPublisherConfiguration.ExcludedHealthCheckNames.Contains(check.Name);
+                options.Predicate = (check) => !excludedHealthCheckNames.Contains(check.Name);
             });
 
         return serverBuilder;

--- a/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Api/Registration/DicomServerServiceCollectionExtensions.cs
@@ -70,7 +70,7 @@ public static class DicomServerServiceCollectionExtensions
 
         HealthCheckPublisherConfiguration healthCheckPublisherConfiguration = new HealthCheckPublisherConfiguration();
         configuration.GetSection(HealthCheckPublisherConfiguration.SectionName).Bind(healthCheckPublisherConfiguration);
-        IEnumerable<string> excludedHealthCheckNames = healthCheckPublisherConfiguration.GetListOfExcludedHealthCheckNames();
+        IReadOnlyList<string> excludedHealthCheckNames = healthCheckPublisherConfiguration.GetListOfExcludedHealthCheckNames();
 
         serverBuilder.Services
             .AddCustomerKeyValidationBackgroundService(options => configuration

--- a/src/Microsoft.Health.Dicom.Blob/Registration/DicomServerBuilderBlobRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Dicom.Blob/Registration/DicomServerBuilderBlobRegistrationExtensions.cs
@@ -56,12 +56,9 @@ public static class DicomServerBuilderBlobRegistrationExtensions
             serverBuilder.Services
                 .AddPersistence<IFileStore, BlobFileStore>();
 
-            if (featureConfiguration.EnableExternalStoreHealthCheck)
-            {
-                serverBuilder.Services
-                    .AddHealthChecks()
-                    .AddCheck<DicomConnectedStoreHealthCheck>("DcmHealthCheck");
-            }
+            serverBuilder.Services
+                .AddHealthChecks()
+                .AddCheck<DicomConnectedStoreHealthCheck>("DcmHealthCheck");
         }
         else
         {

--- a/src/Microsoft.Health.Dicom.Core/Configs/FeatureConfiguration.cs
+++ b/src/Microsoft.Health.Dicom.Core/Configs/FeatureConfiguration.cs
@@ -39,9 +39,4 @@ public class FeatureConfiguration
     /// Disables all async operations
     /// </summary>
     public bool DisableOperations { get; set; }
-
-    /// <summary>
-    /// Enabled the health check for external store
-    /// </summary>
-    public bool EnableExternalStoreHealthCheck { get; set; }
 }

--- a/src/Microsoft.Health.Dicom.Core/Configs/HealthCheckPublisherConfiguration.cs
+++ b/src/Microsoft.Health.Dicom.Core/Configs/HealthCheckPublisherConfiguration.cs
@@ -18,7 +18,7 @@ public class HealthCheckPublisherConfiguration
     /// </summary>
     public string ExcludedHealthCheckNames { get; set; }
 
-    public IEnumerable<string> GetListOfExcludedHealthCheckNames()
+    public IReadOnlyList<string> GetListOfExcludedHealthCheckNames()
     {
         return ExcludedHealthCheckNames?.Split(',') ?? Array.Empty<string>();
     }

--- a/src/Microsoft.Health.Dicom.Core/Configs/HealthCheckPublisherConfiguration.cs
+++ b/src/Microsoft.Health.Dicom.Core/Configs/HealthCheckPublisherConfiguration.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Health.Dicom.Core.Configs;
@@ -11,5 +12,14 @@ public class HealthCheckPublisherConfiguration
 {
     public const string SectionName = "HealthCheckPublisher";
 
-    public IEnumerable<string> ExcludedHealthCheckNames { get; set; } = new List<string>();
+    /// <summary>
+    /// A comma separated list of health check names to exclude.
+    /// Example: "DcmHealthCheck,MetadataHealthCheck"
+    /// </summary>
+    public string ExcludedHealthCheckNames { get; set; }
+
+    public IEnumerable<string> GetListOfExcludedHealthCheckNames()
+    {
+        return ExcludedHealthCheckNames?.Split(',') ?? Array.Empty<string>();
+    }
 }

--- a/src/Microsoft.Health.Dicom.Core/Configs/HealthCheckPublisherConfiguration.cs
+++ b/src/Microsoft.Health.Dicom.Core/Configs/HealthCheckPublisherConfiguration.cs
@@ -1,0 +1,15 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+
+namespace Microsoft.Health.Dicom.Core.Configs;
+
+public class HealthCheckPublisherConfiguration
+{
+    public const string SectionName = "HealthCheckPublisher";
+
+    public IEnumerable<string> ExcludedHealthCheckNames { get; set; } = new List<string>();
+}

--- a/src/Microsoft.Health.Dicom.Web/appsettings.json
+++ b/src/Microsoft.Health.Dicom.Web/appsettings.json
@@ -83,7 +83,7 @@
       "EnableDataPartitions": false,
       "EnableFullDicomItemValidation": false,
       "EnableOhifViewer": true,
-      "EnableExternalStore": true,
+      "EnableExternalStore": false,
       "DisableOperations": false
     },
     "Services": {

--- a/src/Microsoft.Health.Dicom.Web/appsettings.json
+++ b/src/Microsoft.Health.Dicom.Web/appsettings.json
@@ -173,6 +173,6 @@
     }
   },
   "HealthCheckPublisher": {
-    "ExcludedHealthCheckNames": []
+    "ExcludedHealthCheckNames": ""
   }
 }

--- a/src/Microsoft.Health.Dicom.Web/appsettings.json
+++ b/src/Microsoft.Health.Dicom.Web/appsettings.json
@@ -83,9 +83,8 @@
       "EnableDataPartitions": false,
       "EnableFullDicomItemValidation": false,
       "EnableOhifViewer": true,
-      "EnableExternalStore": false,
-      "DisableOperations": false,
-      "EnableExternalStoreHealthCheck": false
+      "EnableExternalStore": true,
+      "DisableOperations": false
     },
     "Services": {
       "DeletedInstanceCleanup": {
@@ -172,5 +171,8 @@
     "SchemaOptions": {
       "AutomaticUpdatesEnabled": true
     }
+  },
+  "HealthCheckPublisher": {
+    "ExcludedHealthCheckNames": []
   }
 }


### PR DESCRIPTION
## Description
Add configuration to filter health checks. Any health check can be added to this list, and it will be excluded from running. 
Also fixed an issue with running the IDP health check locally - the http pipeline policy required a blob URI to run, which does not exist when running with Azurite

## Related issues
Addresses #115147

## Testing
Ran locally. Added single & multiple health check names to the list and saw that they were removed from execution. Also tried removing the config all together or using an empty list, in which case all of the health checks will run.