### PR TITLE
Handle OverflowException when converting an VR IS to an integer

### DIFF
--- a/forks/Microsoft.Health.FellowOakDicom/Serialization/JsonDicomConverter.cs
+++ b/forks/Microsoft.Health.FellowOakDicom/Serialization/JsonDicomConverter.cs
@@ -448,7 +448,7 @@ namespace Microsoft.Health.FellowOakDicom.Serialization
                 {
                     numberWriterAction();
                 }
-                catch (FormatException)
+                catch (Exception ex) when (ex is FormatException || ex is OverflowException)
                 {
                     if (_numberSerializationMode == NumberSerializationMode.PreferablyAsNumber)
                     {


### PR DESCRIPTION
## Description
Catch OverflowException when converting an VR IS to an integer. [Fo-dicom PR](https://github.com/fo-dicom/fo-dicom/pull/1522) for reference.

## Related issues
Addresses [issue #111029](https://microsofthealth.visualstudio.com/Health/_workitems/edit/111029), [issue #111027](https://microsofthealth.visualstudio.com/Health/_workitems/edit/111027).

## Testing
Added unit tests for invalid, overflow and floating point numbers
