### PR TITLE
Addressed minor namespace, linting and reference issues

### DIFF
--- a/forks/Microsoft.Health.FellowOakDicom/Serialization/JsonDicomConverter.cs
+++ b/forks/Microsoft.Health.FellowOakDicom/Serialization/JsonDicomConverter.cs
@@ -20,1185 +20,1183 @@ using DicomSignedVeryLong = Microsoft.Health.FellowOakDicom.Core.DicomSignedVery
 using DicomUnsignedVeryLong = Microsoft.Health.FellowOakDicom.Core.DicomUnsignedVeryLong;
 
 
-namespace Microsoft.Health.FellowOakDicom.Serialization
+namespace Microsoft.Health.FellowOakDicom.Serialization;
+
+
+[Obsolete("Please use DicomJsonConverter instead.")]
+public class DicomArrayJsonConverter : JsonConverter<DicomDataset[]>
 {
+    private readonly bool _writeTagsAsKeywords;
 
-    [Obsolete("Please use DicomJsonConverter instead.")]
-    public class DicomArrayJsonConverter : JsonConverter<DicomDataset[]>
+    /// <summary>
+    /// Initialize the JsonDicomConverter.
+    /// </summary>
+    /// <param name="writeTagsAsKeywords">Whether to write the json keys as DICOM keywords instead of tags. This makes the json non-compliant to DICOM JSON.</param>
+    public DicomArrayJsonConverter()
+        : this(false)
     {
-        private readonly bool _writeTagsAsKeywords;
+    }
 
-        /// <summary>
-        /// Initialize the JsonDicomConverter.
-        /// </summary>
-        /// <param name="writeTagsAsKeywords">Whether to write the json keys as DICOM keywords instead of tags. This makes the json non-compliant to DICOM JSON.</param>
-        public DicomArrayJsonConverter()
-            : this(false)
+    /// <summary>
+    /// Initialize the JsonDicomConverter.
+    /// </summary>
+    /// <param name="writeTagsAsKeywords">Whether to write the json keys as DICOM keywords instead of tags. This makes the json non-compliant to DICOM JSON.</param>
+    public DicomArrayJsonConverter(bool writeTagsAsKeywords)
+    {
+        _writeTagsAsKeywords = writeTagsAsKeywords;
+    }
+
+    public override DicomDataset[] Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var datasetList = new List<DicomDataset>();
+        if (reader.TokenType != JsonTokenType.StartArray)
         {
-        }
-
-        /// <summary>
-        /// Initialize the JsonDicomConverter.
-        /// </summary>
-        /// <param name="writeTagsAsKeywords">Whether to write the json keys as DICOM keywords instead of tags. This makes the json non-compliant to DICOM JSON.</param>
-        public DicomArrayJsonConverter(bool writeTagsAsKeywords)
-        {
-            _writeTagsAsKeywords = writeTagsAsKeywords;
-        }
-
-        public override DicomDataset[] Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            var datasetList = new List<DicomDataset>();
-            if (reader.TokenType != JsonTokenType.StartArray)
-            {
-                return datasetList.ToArray();
-            }
-            reader.Read();
-            var conv = new DicomJsonConverter(writeTagsAsKeywords: _writeTagsAsKeywords);
-            while (reader.TokenType != JsonTokenType.EndArray)
-            {
-                DicomDataset ds;
-                switch (reader.TokenType)
-                {
-                    case JsonTokenType.StartObject:
-                        ds = conv.Read(ref reader, typeToConvert, options);
-                        reader.AssumeAndSkip(JsonTokenType.EndObject);
-                        break;
-                    case JsonTokenType.Null:
-                        ds = null;
-                        reader.Read();
-                        break;
-                    default:
-                        throw new JsonException($"Expected either the start of an object or null but found '{reader.TokenType}'.");
-                }
-
-                datasetList.Add(ds);
-            }
-            reader.Read();
             return datasetList.ToArray();
         }
-
-        public override void Write(Utf8JsonWriter writer, DicomDataset[] value, JsonSerializerOptions options)
+        reader.Read();
+        var conv = new DicomJsonConverter(writeTagsAsKeywords: _writeTagsAsKeywords);
+        while (reader.TokenType != JsonTokenType.EndArray)
         {
-            var conv = new DicomJsonConverter(writeTagsAsKeywords: _writeTagsAsKeywords);
-            writer.WriteStartArray();
-            foreach (var ds in value)
+            DicomDataset ds;
+            switch (reader.TokenType)
             {
-                conv.Write(writer, ds, options);
-            }
-            writer.WriteEndArray();
-        }
-
-    }
-
-    /// <summary>
-    /// Defines the way DICOM numbers (tags with VR: IS, DS, SV and UV) should be serialized
-    /// </summary>
-    public enum NumberSerializationMode
-    {
-        /// <summary>
-        /// Always serialize DICOM numbers (tags with VR: IS, DS, SV and UV) as JSON numbers.
-        /// ⚠️ This will throw FormatException when a number can't be parsed!
-        /// i.e.: "00081160":{"vr":"IS","Value":[76]}
-        /// </summary>
-        AsNumber,
-
-        /// <summary>
-        /// Always serialize DICOM numbers (tags with VR: IS, DS, SV and UV) as JSON strings.
-        /// i.e.: "00081160":{"vr":"IS","Value":["76"]}
-        /// </summary>
-        AsString,
-
-        /// <summary>
-        /// Try to serialize DICOM numbers (tags with VR: IS, DS, SV and UV) as JSON numbers. If not parsable as a number, defaults back to a JSON string.
-        /// This won't throw an error in case a number can't be parsed. It just returns the value as a JSON string.
-        /// i.e.: "00081160":{"vr":"IS","Value":[76]}
-        /// or "00081160":{"vr":"IS","Value":["A non parsable value"]}
-        /// </summary>
-        PreferablyAsNumber
-    }
-
-    /// <summary>
-    /// Converts a DicomDataset object to and from JSON using the NewtonSoft Json.NET library
-    /// </summary>
-    public class DicomJsonConverter : JsonConverter<DicomDataset>
-    {
-
-        private readonly bool _writeTagsAsKeywords;
-        private readonly bool _autoValidate;
-        private readonly NumberSerializationMode _numberSerializationMode;
-        private readonly static Encoding[] _jsonTextEncodings = { Encoding.UTF8 };
-        private readonly static char _personNameComponentGroupDelimiter = '=';
-        private readonly static string[] _personNameComponentGroupNames = { "Alphabetic", "Ideographic", "Phonetic" };
-
-        private delegate T GetValue<out T>(Utf8JsonReader reader);
-        private delegate bool TryParse<T>(string value, out T parsed);
-        private delegate void WriteValue<in T>(Utf8JsonWriter writer, T value);
-
-
-        /// <summary>
-        /// Initialize the JsonDicomConverter.
-        /// </summary>
-        /// <param name="writeTagsAsKeywords">Whether to write the json keys as DICOM keywords instead of tags. This makes the json non-compliant to DICOM JSON.</param>
-        /// <param name="autoValidate">Whether the content of DicomItems shall be validated when deserializing.</param>
-        /// <param name="numberSerializationMode">Defines how numbers should be serialized. Default 'AsNumber', will throw errors when a number is not parsable.</param>
-        public DicomJsonConverter(bool writeTagsAsKeywords = false, bool autoValidate = true, NumberSerializationMode numberSerializationMode = NumberSerializationMode.AsNumber)
-        {
-            _writeTagsAsKeywords = writeTagsAsKeywords;
-            _autoValidate = autoValidate;
-            _numberSerializationMode = numberSerializationMode;
-        }
-
-        #region JsonConverter overrides
-
-
-        /// <summary>
-        /// Writes the JSON representation of the object.
-        /// </summary>
-        /// <param name="writer">The <see cref="T:System.Text.Json.Utf8JsonWriter"/> to write to.</param>
-        /// <param name="value">The value.</param>
-        public override void Write(Utf8JsonWriter writer, DicomDataset value, JsonSerializerOptions options)
-        {
-            if (value == null)
-            {
-                writer.WriteNullValue();
-                return;
-            }
-
-            writer.WriteStartObject();
-            foreach (var item in value)
-            {
-                if (((uint)item.Tag & 0xffff) == 0)
-                {
-                    // Group length (gggg,0000) attributes shall not be included in a DICOM JSON Model object.
-                    continue;
-                }
-
-                // Unknown or masked tags cannot be written as keywords
-                var unknown = item.Tag.DictionaryEntry == null
-                              || string.IsNullOrWhiteSpace(item.Tag.DictionaryEntry.Keyword)
-                              ||
-                              (item.Tag.DictionaryEntry.MaskTag != null &&
-                               item.Tag.DictionaryEntry.MaskTag.Mask != 0xffffffff);
-                if (_writeTagsAsKeywords && !unknown)
-                {
-                    writer.WritePropertyName(item.Tag.DictionaryEntry.Keyword);
-                }
-                else
-                {
-                    writer.WritePropertyName(item.Tag.Group.ToString("X4") + item.Tag.Element.ToString("X4"));
-                }
-
-                WriteJsonDicomItem(writer, item, options);
-            }
-            writer.WriteEndObject();
-        }
-
-
-        /// <summary>
-        /// Reads the JSON representation of the object.
-        /// </summary>
-        /// <param name="reader">The <see cref="T:System.Text.Json.Utf8JsonReader"/> to read from.</param>
-        /// <param name="typeToConvert">Type of the object.</param>
-        /// <param name="options">Options to apply while reading.</param>
-        /// <returns>
-        /// The object value.
-        /// </returns>
-        public override DicomDataset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            var dataset = ReadJsonDataset(ref reader);
-            return dataset;
-        }
-
-
-        private DicomDataset ReadJsonDataset(ref Utf8JsonReader reader)
-        {
-            var dataset = _autoValidate
-                ? new DicomDataset()
-                : new DicomDataset().NotValidated();
-            if (reader.TokenType != JsonTokenType.StartObject)
-            {
-                throw new JsonException($"Expected the start of an object but found '{reader.TokenType}'.");
-            }
-            reader.Read();
-
-            while (reader.TokenType != JsonTokenType.EndObject)
-            {
-                reader.Assume(JsonTokenType.PropertyName);
-                var tagstr = reader.GetString();
-                DicomTag tag = ParseTag(tagstr);
-                reader.Read(); // move to value
-                var item = ReadJsonDicomItem(tag, ref reader);
-                dataset.Add(item);
-            }
-
-            foreach (var item in dataset)
-            {
-                if (item.Tag.IsPrivate && ((item.Tag.Element & 0xff00) != 0))
-                {
-                    var privateCreatorTag = new DicomTag(item.Tag.Group, (ushort)(item.Tag.Element >> 8));
-
-                    if (dataset.Contains(privateCreatorTag))
-                    {
-                        var privateCreatorItem = dataset.GetDicomItem<DicomItem>(privateCreatorTag);
-                        // Based on standard https://dicom.nema.org/dicom/2013/output/chtml/part05/sect_7.8.html private creator data item should be VM = 1, but there are buggy dcms
-                        bool isValidPrivateCreatorItem = privateCreatorItem is DicomLongString element && element.Count == 1;
-                        // Allow de-serialization to continue if autoValidate was set to false
-                        if (isValidPrivateCreatorItem || _autoValidate)
-                        {
-                            item.Tag.PrivateCreator = new DicomPrivateCreator(dataset.GetSingleValue<string>(privateCreatorTag));
-                        }
-                    }
-                }
-            }
-
-            return dataset;
-        }
-
-        /// <summary>
-        /// Determines whether this instance can convert the specified object type.
-        /// </summary>
-        /// <param name="objectType">Type of the object.</param>
-        /// <returns>
-        /// <c>true</c> if this instance can convert the specified object type; otherwise, <c>false</c>.
-        /// </returns>
-        public override bool CanConvert(Type typeToConvert)
-        {
-            return typeof(DicomDataset).GetTypeInfo().IsAssignableFrom(typeToConvert.GetTypeInfo());
-        }
-
-        #endregion
-
-        /// <summary>
-        /// Create an instance of a IBulkDataUriByteBuffer. Override this method to use a different IBulkDataUriByteBuffer implementation in applications.
-        /// </summary>
-        /// <param name="bulkDataUri">The URI of a bulk data element as defined in <see cref="!:http://dicom.nema.org/medical/dicom/current/output/chtml/part19/chapter_A.html#table_A.1.5-2">Table A.1.5-2 in PS3.19</see>.</param>
-        /// <returns>An instance of a Bulk URI Byte buffer.</returns>
-        protected virtual IBulkDataUriByteBuffer CreateBulkDataUriByteBuffer(string bulkDataUri) => new BulkDataUriByteBuffer(bulkDataUri);
-
-        #region Utilities
-
-        internal static DicomTag ParseTag(string tagstr)
-        {
-            if (Regex.IsMatch(tagstr, @"\A\b[0-9a-fA-F]+\b\Z"))
-            {
-                var group = Convert.ToUInt16(tagstr.Substring(0, 4), 16);
-                var element = Convert.ToUInt16(tagstr.Substring(4), 16);
-                var tag = new DicomTag(group, element);
-                return tag;
-            }
-
-            return DicomDictionary.Default[tagstr];
-        }
-
-        private static DicomItem CreateDicomItem(DicomTag tag, string vr, object data)
-        {
-            DicomItem item = vr switch
-            {
-                "AE" => new DicomApplicationEntity(tag, (string[])data),
-                "AS" => new DicomAgeString(tag, (string[])data),
-                "AT" => new DicomAttributeTag(tag, ((string[])data).Select(ParseTag).ToArray()),
-                "CS" => new DicomCodeString(tag, (string[])data),
-                "DA" => new DicomDate(tag, (string[])data),
-                "DS" => data is IByteBuffer dataBufferDS
-                            ? new DicomDecimalString(tag, dataBufferDS)
-                            : new DicomDecimalString(tag, (decimal[])data),
-                "DT" => new DicomDateTime(tag, (string[])data),
-                "FD" => data is IByteBuffer dataBufferFD
-                            ? new DicomFloatingPointDouble(tag, dataBufferFD)
-                            : new DicomFloatingPointDouble(tag, (double[])data),
-                "FL" => data is IByteBuffer dataBufferFL
-                            ? new DicomFloatingPointSingle(tag, dataBufferFL)
-                            : new DicomFloatingPointSingle(tag, (float[])data),
-                "IS" => data is IByteBuffer dataBufferIS
-                            ? new DicomIntegerString(tag, dataBufferIS)
-                            : new DicomIntegerString(tag, (int[])data),
-                "LO" => new DicomLongString(tag, (string[])data),
-                "LT" => data is IByteBuffer dataBufferLT
-                            ? new DicomLongText(tag, _jsonTextEncodings, dataBufferLT)
-                            : new DicomLongText(tag, data.GetAsStringArray().GetSingleOrEmpty()),
-                "OB" => new DicomOtherByte(tag, (IByteBuffer)data),
-                "OD" => new DicomOtherDouble(tag, (IByteBuffer)data),
-                "OF" => new DicomOtherFloat(tag, (IByteBuffer)data),
-                "OL" => new DicomOtherLong(tag, (IByteBuffer)data),
-                "OW" => new DicomOtherWord(tag, (IByteBuffer)data),
-                "OV" => new DicomOtherVeryLong(tag, (IByteBuffer)data),
-                "PN" => new DicomPersonName(tag, (string[])data),
-                "SH" => new DicomShortString(tag, (string[])data),
-                "SL" => data is IByteBuffer dataBufferSL
-                            ? new DicomSignedLong(tag, dataBufferSL)
-                            : new DicomSignedLong(tag, (int[])data),
-                "SQ" => new DicomSequence(tag, ((DicomDataset[])data)),
-                "SS" => data is IByteBuffer dataBufferSS
-                            ? new DicomSignedShort(tag, dataBufferSS)
-                            : new DicomSignedShort(tag, (short[])data),
-                "ST" => data is IByteBuffer dataBufferST
-                            ? new DicomShortText(tag, _jsonTextEncodings, dataBufferST)
-                            : new DicomShortText(tag, data.GetAsStringArray().GetFirstOrEmpty()),
-                "SV" => data is IByteBuffer dataBufferSV
-                                ? new DicomSignedVeryLong(tag, dataBufferSV)
-                                : new DicomSignedVeryLong(tag, (long[])data),
-                "TM" => new DicomTime(tag, (string[])data),
-                "UC" => data is IByteBuffer dataBufferUC
-                            ? new DicomUnlimitedCharacters(tag, _jsonTextEncodings, dataBufferUC)
-                            : new DicomUnlimitedCharacters(tag, data.GetAsStringArray().SingleOrDefault()),
-                "UI" => new DicomUniqueIdentifier(tag, (string[])data),
-                "UL" => data is IByteBuffer dataBufferUL
-                            ? new DicomUnsignedLong(tag, dataBufferUL)
-                            : new DicomUnsignedLong(tag, (uint[])data),
-                "UN" => new DicomUnknown(tag, (IByteBuffer)data),
-                "UR" => new DicomUniversalResource(tag, data.GetAsStringArray().GetSingleOrEmpty()),
-                "US" => data is IByteBuffer dataBufferUS
-                            ? new DicomUnsignedShort(tag, dataBufferUS)
-                            : new DicomUnsignedShort(tag, (ushort[])data),
-                "UT" => data is IByteBuffer dataBufferUT
-                            ? new DicomUnlimitedText(tag, _jsonTextEncodings, dataBufferUT)
-                            : new DicomUnlimitedText(tag, data.GetAsStringArray().GetSingleOrEmpty()),
-                "UV" => data is IByteBuffer dataBufferUV
-                            ? new DicomUnsignedVeryLong(tag, dataBufferUV)
-                            : new DicomUnsignedVeryLong(tag, (ulong[])data),
-                _ => throw new NotSupportedException("Unsupported value representation"),
-            };
-            return item;
-        }
-
-        #endregion
-
-        #region WriteJson helpers
-
-        private void WriteJsonDicomItem(Utf8JsonWriter writer, DicomItem item, JsonSerializerOptions options)
-        {
-            writer.WriteStartObject();
-            writer.WriteString("vr", item.ValueRepresentation.Code);
-
-            switch (item.ValueRepresentation.Code)
-            {
-                case "PN":
-                    WriteJsonPersonName(writer, (DicomPersonName)item);
+                case JsonTokenType.StartObject:
+                    ds = conv.Read(ref reader, typeToConvert, options);
+                    reader.AssumeAndSkip(JsonTokenType.EndObject);
                     break;
-                case "SQ":
-                    WriteJsonSequence(writer, (DicomSequence)item, options);
-                    break;
-                case "OB":
-                case "OD":
-                case "OF":
-                case "OL":
-                case "OV":
-                case "OW":
-                case "UN":
-                    WriteJsonOther(writer, (DicomElement)item);
-                    break;
-                case "FL":
-                    WriteJsonElement<float>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
-                    break;
-                case "FD":
-                    WriteJsonElement<double>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
-                    break;
-                case "IS":
-                    WriteJsonAsNumberOrString<int>(writer, (DicomElement)item,
-                        (w, v) => writer.WriteNumberValue(v));
-                    break;
-                case "SL":
-                    WriteJsonElement<int>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
-                    break;
-                case "SS":
-                    WriteJsonElement<short>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
-                    break;
-                case "SV":
-                    WriteJsonAsNumberOrString<long>(writer, (DicomElement)item,
-                        (w, v) => writer.WriteNumberValue(v));
-                    break;
-                case "UL":
-                    WriteJsonElement<uint>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
-                    break;
-                case "US":
-                    WriteJsonElement<ushort>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
-                    break;
-                case "UV":
-                    WriteJsonAsNumberOrString<ulong>(writer, (DicomElement)item,
-                        (w, v) => writer.WriteNumberValue(v));
-                    break;
-                case "DS":
-                    WriteJsonAsNumberOrString(writer, (DicomElement)item,
-                        () => WriteJsonDecimalString(writer, (DicomElement)item));
-                    break;
-                case "AT":
-                    WriteJsonAttributeTag(writer, (DicomElement)item);
+                case JsonTokenType.Null:
+                    ds = null;
+                    reader.Read();
                     break;
                 default:
-                    WriteJsonElement<string>(writer, (DicomElement)item, (w, v) => writer.WriteStringValue(v));
-                    break;
+                    throw new JsonException($"Expected either the start of an object or null but found '{reader.TokenType}'.");
             }
 
-            writer.WriteEndObject();
+            datasetList.Add(ds);
+        }
+        reader.Read();
+        return datasetList.ToArray();
+    }
+
+    public override void Write(Utf8JsonWriter writer, DicomDataset[] value, JsonSerializerOptions options)
+    {
+        var conv = new DicomJsonConverter(writeTagsAsKeywords: _writeTagsAsKeywords);
+        writer.WriteStartArray();
+        foreach (var ds in value)
+        {
+            conv.Write(writer, ds, options);
+        }
+        writer.WriteEndArray();
+    }
+
+}
+
+/// <summary>
+/// Defines the way DICOM numbers (tags with VR: IS, DS, SV and UV) should be serialized
+/// </summary>
+public enum NumberSerializationMode
+{
+    /// <summary>
+    /// Always serialize DICOM numbers (tags with VR: IS, DS, SV and UV) as JSON numbers.
+    /// ⚠️ This will throw FormatException when a number can't be parsed!
+    /// i.e.: "00081160":{"vr":"IS","Value":[76]}
+    /// </summary>
+    AsNumber,
+
+    /// <summary>
+    /// Always serialize DICOM numbers (tags with VR: IS, DS, SV and UV) as JSON strings.
+    /// i.e.: "00081160":{"vr":"IS","Value":["76"]}
+    /// </summary>
+    AsString,
+
+    /// <summary>
+    /// Try to serialize DICOM numbers (tags with VR: IS, DS, SV and UV) as JSON numbers. If not parsable as a number, defaults back to a JSON string.
+    /// This won't throw an error in case a number can't be parsed. It just returns the value as a JSON string.
+    /// i.e.: "00081160":{"vr":"IS","Value":[76]}
+    /// or "00081160":{"vr":"IS","Value":["A non parsable value"]}
+    /// </summary>
+    PreferablyAsNumber
+}
+
+/// <summary>
+/// Converts a DicomDataset object to and from JSON using the NewtonSoft Json.NET library
+/// </summary>
+public class DicomJsonConverter : JsonConverter<DicomDataset>
+{
+
+    private readonly bool _writeTagsAsKeywords;
+    private readonly bool _autoValidate;
+    private readonly NumberSerializationMode _numberSerializationMode;
+    private readonly static Encoding[] _jsonTextEncodings = { Encoding.UTF8 };
+    private readonly static char _personNameComponentGroupDelimiter = '=';
+    private readonly static string[] _personNameComponentGroupNames = { "Alphabetic", "Ideographic", "Phonetic" };
+
+    private delegate T GetValue<out T>(Utf8JsonReader reader);
+    private delegate bool TryParse<T>(string value, out T parsed);
+    private delegate void WriteValue<in T>(Utf8JsonWriter writer, T value);
+
+
+    /// <summary>
+    /// Initialize the JsonDicomConverter.
+    /// </summary>
+    /// <param name="writeTagsAsKeywords">Whether to write the json keys as DICOM keywords instead of tags. This makes the json non-compliant to DICOM JSON.</param>
+    /// <param name="autoValidate">Whether the content of DicomItems shall be validated when deserializing.</param>
+    /// <param name="numberSerializationMode">Defines how numbers should be serialized. Default 'AsNumber', will throw errors when a number is not parsable.</param>
+    public DicomJsonConverter(bool writeTagsAsKeywords = false, bool autoValidate = true, NumberSerializationMode numberSerializationMode = NumberSerializationMode.AsNumber)
+    {
+        _writeTagsAsKeywords = writeTagsAsKeywords;
+        _autoValidate = autoValidate;
+        _numberSerializationMode = numberSerializationMode;
+    }
+
+    #region JsonConverter overrides
+
+
+    /// <summary>
+    /// Writes the JSON representation of the object.
+    /// </summary>
+    /// <param name="writer">The <see cref="T:System.Text.Json.Utf8JsonWriter"/> to write to.</param>
+    /// <param name="value">The value.</param>
+    public override void Write(Utf8JsonWriter writer, DicomDataset value, JsonSerializerOptions options)
+    {
+        if (value == null)
+        {
+            writer.WriteNullValue();
+            return;
         }
 
-        private void WriteJsonAsNumberOrString<T>(Utf8JsonWriter writer, DicomElement elem, WriteValue<T> numberValueWriter)
-            => WriteJsonAsNumberOrString(writer, elem, () => WriteJsonElement(writer, elem, numberValueWriter));
-
-        private void WriteJsonAsNumberOrString(Utf8JsonWriter writer, DicomElement elem, Action numberWriterAction)
+        writer.WriteStartObject();
+        foreach (var item in value)
         {
-            if (_numberSerializationMode == NumberSerializationMode.AsString)
+            if (((uint)item.Tag & 0xffff) == 0)
             {
-                WriteJsonElement<string>(writer, elem, (w, v) => writer.WriteStringValue(v));
+                // Group length (gggg,0000) attributes shall not be included in a DICOM JSON Model object.
+                continue;
+            }
+
+            // Unknown or masked tags cannot be written as keywords
+            var unknown = item.Tag.DictionaryEntry == null
+                          || string.IsNullOrWhiteSpace(item.Tag.DictionaryEntry.Keyword)
+                          ||
+                          (item.Tag.DictionaryEntry.MaskTag != null &&
+                           item.Tag.DictionaryEntry.MaskTag.Mask != 0xffffffff);
+            if (_writeTagsAsKeywords && !unknown)
+            {
+                writer.WritePropertyName(item.Tag.DictionaryEntry.Keyword);
             }
             else
             {
-                try
-                {
-                    numberWriterAction();
-                }
-                catch (Exception ex) when (ex is FormatException || ex is OverflowException)
-                {
-                    if (_numberSerializationMode == NumberSerializationMode.PreferablyAsNumber)
-                    {
-                        WriteJsonElement<string>(writer, elem, (w, v) => writer.WriteStringValue(v));
-                    }
-                    else
-                    {
-                        throw;
-                    }
-                }
+                writer.WritePropertyName(item.Tag.Group.ToString("X4") + item.Tag.Element.ToString("X4"));
             }
+
+            WriteJsonDicomItem(writer, item, options);
         }
+        writer.WriteEndObject();
+    }
 
 
-        private static void WriteJsonDecimalString(Utf8JsonWriter writer, DicomElement elem)
+    /// <summary>
+    /// Reads the JSON representation of the object.
+    /// </summary>
+    /// <param name="reader">The <see cref="T:System.Text.Json.Utf8JsonReader"/> to read from.</param>
+    /// <param name="typeToConvert">Type of the object.</param>
+    /// <param name="options">Options to apply while reading.</param>
+    /// <returns>
+    /// The object value.
+    /// </returns>
+    public override DicomDataset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var dataset = ReadJsonDataset(ref reader);
+        return dataset;
+    }
+
+
+    private DicomDataset ReadJsonDataset(ref Utf8JsonReader reader)
+    {
+        var dataset = _autoValidate
+            ? new DicomDataset()
+            : new DicomDataset().NotValidated();
+        if (reader.TokenType != JsonTokenType.StartObject)
         {
-            if (elem.Count == 0) return;
+            throw new JsonException($"Expected the start of an object but found '{reader.TokenType}'.");
+        }
+        reader.Read();
 
-            var writerActions = new List<Action>
-            {
-                () => writer.WritePropertyName("Value"),
-                writer.WriteStartArray
-            };
+        while (reader.TokenType != JsonTokenType.EndObject)
+        {
+            reader.Assume(JsonTokenType.PropertyName);
+            var tagstr = reader.GetString();
+            DicomTag tag = ParseTag(tagstr);
+            reader.Read(); // move to value
+            var item = ReadJsonDicomItem(tag, ref reader);
+            dataset.Add(item);
+        }
 
-            foreach (var val in elem.Get<string[]>())
+        foreach (var item in dataset)
+        {
+            if (item.Tag.IsPrivate && ((item.Tag.Element & 0xff00) != 0))
             {
-                if (string.IsNullOrEmpty(val))
+                var privateCreatorTag = new DicomTag(item.Tag.Group, (ushort)(item.Tag.Element >> 8));
+
+                if (dataset.Contains(privateCreatorTag))
                 {
-                    writerActions.Add(writer.WriteNullValue);
-                }
-                else
-                {
-                    var fix = FixDecimalString(val);
-                    if (TryParseULong(fix, out ulong xulong))
+                    var privateCreatorItem = dataset.GetDicomItem<DicomItem>(privateCreatorTag);
+                    // Based on standard https://dicom.nema.org/dicom/2013/output/chtml/part05/sect_7.8.html private creator data item should be VM = 1, but there are buggy dcms
+                    bool isValidPrivateCreatorItem = privateCreatorItem is DicomLongString element && element.Count == 1;
+                    // Allow de-serialization to continue if autoValidate was set to false
+                    if (isValidPrivateCreatorItem || _autoValidate)
                     {
-                        writerActions.Add(() => writer.WriteNumberValue(xulong));
-                    }
-                    else if (TryParseLong(fix, out long xlong))
-                    {
-                        writerActions.Add(() => writer.WriteNumberValue(xlong));
-                    }
-                    else if (TryParseDecimal(fix, out decimal xdecimal))
-                    {
-                        writerActions.Add(() => writer.WriteNumberValue(xdecimal));
-                    }
-                    else if (TryParseDouble(fix, out double xdouble))
-                    {
-                        writerActions.Add(() => writer.WriteNumberValue(xdouble));
-                    }
-                    else
-                    {
-                        throw new FormatException($"Cannot write dicom number {val} to json");
+                        item.Tag.PrivateCreator = new DicomPrivateCreator(dataset.GetSingleValue<string>(privateCreatorTag));
                     }
                 }
-            }
-            writerActions.Add(writer.WriteEndArray);
-
-            foreach (var action in writerActions)
-            {
-                action();
             }
         }
 
-        private static bool IsValidJsonNumber(string val)
+        return dataset;
+    }
+
+    /// <summary>
+    /// Determines whether this instance can convert the specified object type.
+    /// </summary>
+    /// <param name="objectType">Type of the object.</param>
+    /// <returns>
+    /// <c>true</c> if this instance can convert the specified object type; otherwise, <c>false</c>.
+    /// </returns>
+    public override bool CanConvert(Type typeToConvert)
+    {
+        return typeof(DicomDataset).GetTypeInfo().IsAssignableFrom(typeToConvert.GetTypeInfo());
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Create an instance of a IBulkDataUriByteBuffer. Override this method to use a different IBulkDataUriByteBuffer implementation in applications.
+    /// </summary>
+    /// <param name="bulkDataUri">The URI of a bulk data element as defined in <see cref="!:http://dicom.nema.org/medical/dicom/current/output/chtml/part19/chapter_A.html#table_A.1.5-2">Table A.1.5-2 in PS3.19</see>.</param>
+    /// <returns>An instance of a Bulk URI Byte buffer.</returns>
+    protected virtual IBulkDataUriByteBuffer CreateBulkDataUriByteBuffer(string bulkDataUri) => new BulkDataUriByteBuffer(bulkDataUri);
+
+    #region Utilities
+
+    internal static DicomTag ParseTag(string tagstr)
+    {
+        if (Regex.IsMatch(tagstr, @"\A\b[0-9a-fA-F]+\b\Z"))
+        {
+            var group = Convert.ToUInt16(tagstr.Substring(0, 4), 16);
+            var element = Convert.ToUInt16(tagstr.Substring(4), 16);
+            var tag = new DicomTag(group, element);
+            return tag;
+        }
+
+        return DicomDictionary.Default[tagstr];
+    }
+
+    private static DicomItem CreateDicomItem(DicomTag tag, string vr, object data)
+    {
+        DicomItem item = vr switch
+        {
+            "AE" => new DicomApplicationEntity(tag, (string[])data),
+            "AS" => new DicomAgeString(tag, (string[])data),
+            "AT" => new DicomAttributeTag(tag, ((string[])data).Select(ParseTag).ToArray()),
+            "CS" => new DicomCodeString(tag, (string[])data),
+            "DA" => new DicomDate(tag, (string[])data),
+            "DS" => data is IByteBuffer dataBufferDS
+                        ? new DicomDecimalString(tag, dataBufferDS)
+                        : new DicomDecimalString(tag, (decimal[])data),
+            "DT" => new DicomDateTime(tag, (string[])data),
+            "FD" => data is IByteBuffer dataBufferFD
+                        ? new DicomFloatingPointDouble(tag, dataBufferFD)
+                        : new DicomFloatingPointDouble(tag, (double[])data),
+            "FL" => data is IByteBuffer dataBufferFL
+                        ? new DicomFloatingPointSingle(tag, dataBufferFL)
+                        : new DicomFloatingPointSingle(tag, (float[])data),
+            "IS" => data is IByteBuffer dataBufferIS
+                        ? new DicomIntegerString(tag, dataBufferIS)
+                        : new DicomIntegerString(tag, (int[])data),
+            "LO" => new DicomLongString(tag, (string[])data),
+            "LT" => data is IByteBuffer dataBufferLT
+                        ? new DicomLongText(tag, _jsonTextEncodings, dataBufferLT)
+                        : new DicomLongText(tag, data.GetAsStringArray().GetSingleOrEmpty()),
+            "OB" => new DicomOtherByte(tag, (IByteBuffer)data),
+            "OD" => new DicomOtherDouble(tag, (IByteBuffer)data),
+            "OF" => new DicomOtherFloat(tag, (IByteBuffer)data),
+            "OL" => new DicomOtherLong(tag, (IByteBuffer)data),
+            "OW" => new DicomOtherWord(tag, (IByteBuffer)data),
+            "OV" => new DicomOtherVeryLong(tag, (IByteBuffer)data),
+            "PN" => new DicomPersonName(tag, (string[])data),
+            "SH" => new DicomShortString(tag, (string[])data),
+            "SL" => data is IByteBuffer dataBufferSL
+                        ? new DicomSignedLong(tag, dataBufferSL)
+                        : new DicomSignedLong(tag, (int[])data),
+            "SQ" => new DicomSequence(tag, ((DicomDataset[])data)),
+            "SS" => data is IByteBuffer dataBufferSS
+                        ? new DicomSignedShort(tag, dataBufferSS)
+                        : new DicomSignedShort(tag, (short[])data),
+            "ST" => data is IByteBuffer dataBufferST
+                        ? new DicomShortText(tag, _jsonTextEncodings, dataBufferST)
+                        : new DicomShortText(tag, data.GetAsStringArray().GetFirstOrEmpty()),
+            "SV" => data is IByteBuffer dataBufferSV
+                            ? new DicomSignedVeryLong(tag, dataBufferSV)
+                            : new DicomSignedVeryLong(tag, (long[])data),
+            "TM" => new DicomTime(tag, (string[])data),
+            "UC" => data is IByteBuffer dataBufferUC
+                        ? new DicomUnlimitedCharacters(tag, _jsonTextEncodings, dataBufferUC)
+                        : new DicomUnlimitedCharacters(tag, data.GetAsStringArray().SingleOrDefault()),
+            "UI" => new DicomUniqueIdentifier(tag, (string[])data),
+            "UL" => data is IByteBuffer dataBufferUL
+                        ? new DicomUnsignedLong(tag, dataBufferUL)
+                        : new DicomUnsignedLong(tag, (uint[])data),
+            "UN" => new DicomUnknown(tag, (IByteBuffer)data),
+            "UR" => new DicomUniversalResource(tag, data.GetAsStringArray().GetSingleOrEmpty()),
+            "US" => data is IByteBuffer dataBufferUS
+                        ? new DicomUnsignedShort(tag, dataBufferUS)
+                        : new DicomUnsignedShort(tag, (ushort[])data),
+            "UT" => data is IByteBuffer dataBufferUT
+                        ? new DicomUnlimitedText(tag, _jsonTextEncodings, dataBufferUT)
+                        : new DicomUnlimitedText(tag, data.GetAsStringArray().GetSingleOrEmpty()),
+            "UV" => data is IByteBuffer dataBufferUV
+                        ? new DicomUnsignedVeryLong(tag, dataBufferUV)
+                        : new DicomUnsignedVeryLong(tag, (ulong[])data),
+            _ => throw new NotSupportedException("Unsupported value representation"),
+        };
+        return item;
+    }
+
+    #endregion
+
+    #region WriteJson helpers
+
+    private void WriteJsonDicomItem(Utf8JsonWriter writer, DicomItem item, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WriteString("vr", item.ValueRepresentation.Code);
+
+        switch (item.ValueRepresentation.Code)
+        {
+            case "PN":
+                WriteJsonPersonName(writer, (DicomPersonName)item);
+                break;
+            case "SQ":
+                WriteJsonSequence(writer, (DicomSequence)item, options);
+                break;
+            case "OB":
+            case "OD":
+            case "OF":
+            case "OL":
+            case "OV":
+            case "OW":
+            case "UN":
+                WriteJsonOther(writer, (DicomElement)item);
+                break;
+            case "FL":
+                WriteJsonElement<float>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
+                break;
+            case "FD":
+                WriteJsonElement<double>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
+                break;
+            case "IS":
+                WriteJsonAsNumberOrString<int>(writer, (DicomElement)item,
+                    (w, v) => writer.WriteNumberValue(v));
+                break;
+            case "SL":
+                WriteJsonElement<int>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
+                break;
+            case "SS":
+                WriteJsonElement<short>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
+                break;
+            case "SV":
+                WriteJsonAsNumberOrString<long>(writer, (DicomElement)item,
+                    (w, v) => writer.WriteNumberValue(v));
+                break;
+            case "UL":
+                WriteJsonElement<uint>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
+                break;
+            case "US":
+                WriteJsonElement<ushort>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
+                break;
+            case "UV":
+                WriteJsonAsNumberOrString<ulong>(writer, (DicomElement)item,
+                    (w, v) => writer.WriteNumberValue(v));
+                break;
+            case "DS":
+                WriteJsonAsNumberOrString(writer, (DicomElement)item,
+                    () => WriteJsonDecimalString(writer, (DicomElement)item));
+                break;
+            case "AT":
+                WriteJsonAttributeTag(writer, (DicomElement)item);
+                break;
+            default:
+                WriteJsonElement<string>(writer, (DicomElement)item, (w, v) => writer.WriteStringValue(v));
+                break;
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private void WriteJsonAsNumberOrString<T>(Utf8JsonWriter writer, DicomElement elem, WriteValue<T> numberValueWriter)
+        => WriteJsonAsNumberOrString(writer, elem, () => WriteJsonElement(writer, elem, numberValueWriter));
+
+    private void WriteJsonAsNumberOrString(Utf8JsonWriter writer, DicomElement elem, Action numberWriterAction)
+    {
+        if (_numberSerializationMode == NumberSerializationMode.AsString)
+        {
+            WriteJsonElement<string>(writer, elem, (w, v) => writer.WriteStringValue(v));
+        }
+        else
         {
             try
             {
-                DicomValidation.ValidateDS(val);
-                return true;
+                numberWriterAction();
             }
-            catch (DicomValidationException)
+            catch (Exception ex) when (ex is FormatException || ex is OverflowException)
             {
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Fix-up a Dicom DS number for use with json.
-        /// Rationale: There is a requirement that DS numbers shall be written as json numbers in part 18.F json, but the
-        /// requirements on DS allows values that are not json numbers. This method "fixes" them to conform to json numbers.
-        /// </summary>
-        /// <param name="val">A valid DS value</param>
-        /// <returns>A json number equivalent to the supplied DS value</returns>
-        private static string FixDecimalString(string val)
-        {
-            // trim invalid padded character
-            val = val.Trim().TrimEnd('\0');
-
-            if (IsValidJsonNumber(val))
-            {
-                return val;
-            }
-
-            if (string.IsNullOrWhiteSpace(val)) { return null; }
-
-            val = val.Trim();
-
-            var negative = false;
-            // Strip leading superfluous plus signs
-            if (val[0] == '+')
-            {
-                val = val.Substring(1);
-            }
-            else if (val[0] == '-')
-            {
-                // Temporarily remove negation sign for zero-stripping later
-                negative = true;
-                val = val.Substring(1);
-            }
-
-            // Strip leading superfluous zeros
-            if (val.Length > 1 && val[0] == '0' && val[1] != '.')
-            {
-                int i = 0;
-                while (i < val.Length - 1 && val[i] == '0' && val[i + 1] != '.')
+                if (_numberSerializationMode == NumberSerializationMode.PreferablyAsNumber)
                 {
-                    i++;
+                    WriteJsonElement<string>(writer, elem, (w, v) => writer.WriteStringValue(v));
                 }
-
-                val = val.Substring(i);
-            }
-
-            // Re-add negation sign
-            if (negative) { val = "-" + val; }
-
-            if (IsValidJsonNumber(val))
-            {
-                return val;
-            }
-
-            throw new FormatException("Failed converting DS value to json");
-        }
-
-        private static void WriteJsonElement<T>(Utf8JsonWriter writer, DicomElement elem, WriteValue<T> writeValue)
-        {
-            if (elem.Count != 0)
-            {
-                T[] values = elem.Get<T[]>();
-                writer.WritePropertyName("Value");
-                writer.WriteStartArray();
-                foreach (var val in values)
+                else
                 {
-                    if (val == null || (typeof(T) == typeof(string) && val.Equals("")))
-                    {
-                        writer.WriteNullValue();
-                    }
-                    else if (val is float f && float.IsNaN(f))
-                    {
-                        writer.WriteStringValue("NaN");
-                    }
-                    else
-                    {
-                        writeValue(writer, val);
-                    }
+                    throw;
                 }
-                writer.WriteEndArray();
             }
         }
+    }
 
-        private static void WriteJsonAttributeTag(Utf8JsonWriter writer, DicomElement elem)
+
+    private static void WriteJsonDecimalString(Utf8JsonWriter writer, DicomElement elem)
+    {
+        if (elem.Count == 0) return;
+
+        var writerActions = new List<Action>
         {
-            if (elem.Count != 0)
+            () => writer.WritePropertyName("Value"),
+            writer.WriteStartArray
+        };
+
+        foreach (var val in elem.Get<string[]>())
+        {
+            if (string.IsNullOrEmpty(val))
             {
-                writer.WritePropertyName("Value");
-                writer.WriteStartArray();
-                foreach (var val in elem.Get<DicomTag[]>())
+                writerActions.Add(writer.WriteNullValue);
+            }
+            else
+            {
+                var fix = FixDecimalString(val);
+                if (TryParseULong(fix, out ulong xulong))
                 {
-                    if (val == null) { writer.WriteNullValue(); }
-                    else { writer.WriteStringValue(((uint)val).ToString("X8")); }
+                    writerActions.Add(() => writer.WriteNumberValue(xulong));
                 }
-                writer.WriteEndArray();
-            }
-        }
-
-        private static void WriteJsonOther(Utf8JsonWriter writer, DicomElement elem)
-        {
-            if (elem.Buffer is IBulkDataUriByteBuffer buffer)
-            {
-                writer.WritePropertyName("BulkDataURI");
-                writer.WriteStringValue(buffer.BulkDataUri);
-            }
-            else if (elem.Count != 0)
-            {
-                writer.WritePropertyName("InlineBinary");
-                writer.WriteStartArray();
-                writer.WriteBase64StringValue(elem.Buffer.Data);
-                writer.WriteEndArray();
-            }
-        }
-
-        private void WriteJsonSequence(Utf8JsonWriter writer, DicomSequence seq, JsonSerializerOptions options)
-        {
-            if (seq.Items.Count != 0)
-            {
-                writer.WritePropertyName("Value");
-                writer.WriteStartArray();
-
-                foreach (var child in seq.Items)
+                else if (TryParseLong(fix, out long xlong))
                 {
-                    Write(writer, child, options);
+                    writerActions.Add(() => writer.WriteNumberValue(xlong));
                 }
-
-                writer.WriteEndArray();
+                else if (TryParseDecimal(fix, out decimal xdecimal))
+                {
+                    writerActions.Add(() => writer.WriteNumberValue(xdecimal));
+                }
+                else if (TryParseDouble(fix, out double xdouble))
+                {
+                    writerActions.Add(() => writer.WriteNumberValue(xdouble));
+                }
+                else
+                {
+                    throw new FormatException($"Cannot write dicom number {val} to json");
+                }
             }
         }
+        writerActions.Add(writer.WriteEndArray);
 
-        private static void WriteJsonPersonName(Utf8JsonWriter writer, DicomPersonName pn)
+        foreach (var action in writerActions)
         {
-            if (pn.Count != 0)
+            action();
+        }
+    }
+
+    private static bool IsValidJsonNumber(string val)
+    {
+        try
+        {
+            DicomValidation.ValidateDS(val);
+            return true;
+        }
+        catch (DicomValidationException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Fix-up a Dicom DS number for use with json.
+    /// Rationale: There is a requirement that DS numbers shall be written as json numbers in part 18.F json, but the
+    /// requirements on DS allows values that are not json numbers. This method "fixes" them to conform to json numbers.
+    /// </summary>
+    /// <param name="val">A valid DS value</param>
+    /// <returns>A json number equivalent to the supplied DS value</returns>
+    private static string FixDecimalString(string val)
+    {
+        // trim invalid padded character
+        val = val.Trim().TrimEnd('\0');
+
+        if (IsValidJsonNumber(val))
+        {
+            return val;
+        }
+
+        if (string.IsNullOrWhiteSpace(val)) { return null; }
+
+        val = val.Trim();
+
+        var negative = false;
+        // Strip leading superfluous plus signs
+        if (val[0] == '+')
+        {
+            val = val.Substring(1);
+        }
+        else if (val[0] == '-')
+        {
+            // Temporarily remove negation sign for zero-stripping later
+            negative = true;
+            val = val.Substring(1);
+        }
+
+        // Strip leading superfluous zeros
+        if (val.Length > 1 && val[0] == '0' && val[1] != '.')
+        {
+            int i = 0;
+            while (i < val.Length - 1 && val[i] == '0' && val[i + 1] != '.')
             {
-                writer.WritePropertyName("Value");
-                writer.WriteStartArray();
+                i++;
+            }
 
-                foreach (var val in pn.Get<string[]>())
+            val = val.Substring(i);
+        }
+
+        // Re-add negation sign
+        if (negative) { val = "-" + val; }
+
+        if (IsValidJsonNumber(val))
+        {
+            return val;
+        }
+
+        throw new FormatException("Failed converting DS value to json");
+    }
+
+    private static void WriteJsonElement<T>(Utf8JsonWriter writer, DicomElement elem, WriteValue<T> writeValue)
+    {
+        if (elem.Count != 0)
+        {
+            T[] values = elem.Get<T[]>();
+            writer.WritePropertyName("Value");
+            writer.WriteStartArray();
+            foreach (var val in values)
+            {
+                if (val == null || (typeof(T) == typeof(string) && val.Equals("")))
                 {
-                    if (string.IsNullOrEmpty(val))
-                    {
-                        writer.WriteNullValue();
-                    }
-                    else
-                    {
-                        var componentGroupValues = val.Split(_personNameComponentGroupDelimiter);
-                        int i = 0;
+                    writer.WriteNullValue();
+                }
+                else if (val is float f && float.IsNaN(f))
+                {
+                    writer.WriteStringValue("NaN");
+                }
+                else
+                {
+                    writeValue(writer, val);
+                }
+            }
+            writer.WriteEndArray();
+        }
+    }
 
-                        writer.WriteStartObject();
-                        foreach (var componentGroupValue in componentGroupValues)
+    private static void WriteJsonAttributeTag(Utf8JsonWriter writer, DicomElement elem)
+    {
+        if (elem.Count != 0)
+        {
+            writer.WritePropertyName("Value");
+            writer.WriteStartArray();
+            foreach (var val in elem.Get<DicomTag[]>())
+            {
+                if (val == null) { writer.WriteNullValue(); }
+                else { writer.WriteStringValue(((uint)val).ToString("X8")); }
+            }
+            writer.WriteEndArray();
+        }
+    }
+
+    private static void WriteJsonOther(Utf8JsonWriter writer, DicomElement elem)
+    {
+        if (elem.Buffer is IBulkDataUriByteBuffer buffer)
+        {
+            writer.WritePropertyName("BulkDataURI");
+            writer.WriteStringValue(buffer.BulkDataUri);
+        }
+        else if (elem.Count != 0)
+        {
+            writer.WritePropertyName("InlineBinary");
+            writer.WriteStartArray();
+            writer.WriteBase64StringValue(elem.Buffer.Data);
+            writer.WriteEndArray();
+        }
+    }
+
+    private void WriteJsonSequence(Utf8JsonWriter writer, DicomSequence seq, JsonSerializerOptions options)
+    {
+        if (seq.Items.Count != 0)
+        {
+            writer.WritePropertyName("Value");
+            writer.WriteStartArray();
+
+            foreach (var child in seq.Items)
+            {
+                Write(writer, child, options);
+            }
+
+            writer.WriteEndArray();
+        }
+    }
+
+    private static void WriteJsonPersonName(Utf8JsonWriter writer, DicomPersonName pn)
+    {
+        if (pn.Count != 0)
+        {
+            writer.WritePropertyName("Value");
+            writer.WriteStartArray();
+
+            foreach (var val in pn.Get<string[]>())
+            {
+                if (string.IsNullOrEmpty(val))
+                {
+                    writer.WriteNullValue();
+                }
+                else
+                {
+                    var componentGroupValues = val.Split(_personNameComponentGroupDelimiter);
+                    int i = 0;
+
+                    writer.WriteStartObject();
+                    foreach (var componentGroupValue in componentGroupValues)
+                    {
+                        // Based on standard http://dicom.nema.org/dicom/2013/output/chtml/part18/sect_F.2.html
+                        // 1. Empty values are skipped
+                        // 2. Leading componentGroups even if null need to have delimiters. Trailing componentGroup delimiter can be omitted
+                        if (!string.IsNullOrWhiteSpace(componentGroupValue))
                         {
-                            // Based on standard http://dicom.nema.org/dicom/2013/output/chtml/part18/sect_F.2.html
-                            // 1. Empty values are skipped
-                            // 2. Leading componentGroups even if null need to have delimiters. Trailing componentGroup delimiter can be omitted
-                            if (!string.IsNullOrWhiteSpace(componentGroupValue))
-                            {
-                                writer.WritePropertyName(_personNameComponentGroupNames[i]);
-                                writer.WriteStringValue(componentGroupValue);
-                            }
-                            i++;
+                            writer.WritePropertyName(_personNameComponentGroupNames[i]);
+                            writer.WriteStringValue(componentGroupValue);
                         }
-                        writer.WriteEndObject();
+                        i++;
                     }
+                    writer.WriteEndObject();
                 }
-
-                writer.WriteEndArray();
             }
+
+            writer.WriteEndArray();
         }
+    }
 
 
-        #endregion
+    #endregion
 
 
-        #region ReadJson helpers
+    #region ReadJson helpers
 
 
-        private DicomItem ReadJsonDicomItem(DicomTag tag, ref Utf8JsonReader reader)
+    private DicomItem ReadJsonDicomItem(DicomTag tag, ref Utf8JsonReader reader)
+    {
+        reader.AssumeAndSkip(JsonTokenType.StartObject);
+        var currentDepth = reader.CurrentDepth;
+
+        reader.Assume(JsonTokenType.PropertyName);
+
+        string vr;
+        var property = reader.GetString();
+        if (property == "vr")
         {
-            reader.AssumeAndSkip(JsonTokenType.StartObject);
-            var currentDepth = reader.CurrentDepth;
-
-            reader.Assume(JsonTokenType.PropertyName);
-
-            string vr;
-            var property = reader.GetString();
-            if (property == "vr")
-            {
-                reader.Read();
-                vr = reader.GetString();
-                reader.Read();
-            }
-            else
-            {
-                vr = FindValue(reader, "vr", "none");
-            }
-
-            if (vr == "none") { throw new JsonException("Malformed DICOM json. vr value missing"); }
-
-            object data;
-
-            switch (vr)
-            {
-                case "OB":
-                case "OD":
-                case "OF":
-                case "OL":
-                case "OW":
-                case "OV":
-                case "UN":
-                    data = ReadJsonOX(ref reader);
-                    break;
-                case "SQ":
-                    data = ReadJsonSequence(ref reader);
-                    break;
-                case "PN":
-                    data = ReadJsonPersonName(ref reader);
-                    break;
-                case "FL":
-                    data = ReadJsonMultiNumber(ref reader, r => r.GetSingle());
-                    break;
-                case "FD":
-                    data = ReadJsonMultiNumber(ref reader, r => r.GetDouble());
-                    break;
-                case "IS":
-                    data = ReadJsonMultiNumberOrString(ref reader, r => r.GetInt32(), TryParseInt);
-                    break;
-                case "SL":
-                    data = ReadJsonMultiNumber(ref reader, r => r.GetInt32());
-                    break;
-                case "SS":
-                    data = ReadJsonMultiNumber(ref reader, r => r.GetInt16());
-                    break;
-                case "SV":
-                    data = ReadJsonMultiNumberOrString(ref reader, r => r.GetInt64(), TryParseLong);
-                    break;
-                case "UL":
-                    data = ReadJsonMultiNumber(ref reader, r => r.GetUInt32());
-                    break;
-                case "US":
-                    data = ReadJsonMultiNumber(ref reader, r => r.GetUInt16());
-                    break;
-                case "UV":
-                    data = ReadJsonMultiNumberOrString(ref reader, r => r.GetUInt64(), TryParseULong);
-                    break;
-                case "DS":
-                    data = ReadJsonMultiNumberOrString(ref reader, r => r.GetDecimal(), TryParseDecimal);
-                    break;
-                default:
-                    data = ReadJsonMultiString(ref reader);
-                    break;
-            }
-
-            // move to the end of the object
-            while (reader.CurrentDepth >= currentDepth && reader.Read())
-            {
-                // skip this data
-            }
-            reader.AssumeAndSkip(JsonTokenType.EndObject);
-
-            DicomItem item = CreateDicomItem(tag, vr, data);
-            return item;
-        }
-
-
-        private object ReadJsonMultiString(ref Utf8JsonReader reader)
-        {
-            if (reader.TokenType == JsonTokenType.EndObject)
-            {
-                return Array.Empty<string>();
-            }
-            string propertyname = ReadPropertyName(ref reader);
-
-            if (propertyname == "Value")
-            {
-                return ReadJsonMultiStringValue(ref reader);
-            }
-            else if (propertyname == "BulkDataURI")
-            {
-                // JToken bulk
-                return ReadJsonBulkDataUri(ref reader);
-            }
-            else
-            {
-                return Array.Empty<string>();
-            }
-        }
-
-
-        private static string ReadPropertyName(ref Utf8JsonReader reader)
-        {
-            reader.Assume(JsonTokenType.PropertyName);
-            var propertyname = reader.GetString();
             reader.Read();
-            return propertyname;
+            vr = reader.GetString();
+            reader.Read();
+        }
+        else
+        {
+            vr = FindValue(reader, "vr", "none");
         }
 
+        if (vr == "none") { throw new JsonException("Malformed DICOM json. vr value missing"); }
 
-        private static string[] ReadJsonMultiStringValue(ref Utf8JsonReader reader)
+        object data;
+
+        switch (vr)
+        {
+            case "OB":
+            case "OD":
+            case "OF":
+            case "OL":
+            case "OW":
+            case "OV":
+            case "UN":
+                data = ReadJsonOX(ref reader);
+                break;
+            case "SQ":
+                data = ReadJsonSequence(ref reader);
+                break;
+            case "PN":
+                data = ReadJsonPersonName(ref reader);
+                break;
+            case "FL":
+                data = ReadJsonMultiNumber(ref reader, r => r.GetSingle());
+                break;
+            case "FD":
+                data = ReadJsonMultiNumber(ref reader, r => r.GetDouble());
+                break;
+            case "IS":
+                data = ReadJsonMultiNumberOrString(ref reader, r => r.GetInt32(), TryParseInt);
+                break;
+            case "SL":
+                data = ReadJsonMultiNumber(ref reader, r => r.GetInt32());
+                break;
+            case "SS":
+                data = ReadJsonMultiNumber(ref reader, r => r.GetInt16());
+                break;
+            case "SV":
+                data = ReadJsonMultiNumberOrString(ref reader, r => r.GetInt64(), TryParseLong);
+                break;
+            case "UL":
+                data = ReadJsonMultiNumber(ref reader, r => r.GetUInt32());
+                break;
+            case "US":
+                data = ReadJsonMultiNumber(ref reader, r => r.GetUInt16());
+                break;
+            case "UV":
+                data = ReadJsonMultiNumberOrString(ref reader, r => r.GetUInt64(), TryParseULong);
+                break;
+            case "DS":
+                data = ReadJsonMultiNumberOrString(ref reader, r => r.GetDecimal(), TryParseDecimal);
+                break;
+            default:
+                data = ReadJsonMultiString(ref reader);
+                break;
+        }
+
+        // move to the end of the object
+        while (reader.CurrentDepth >= currentDepth && reader.Read())
+        {
+            // skip this data
+        }
+        reader.AssumeAndSkip(JsonTokenType.EndObject);
+
+        DicomItem item = CreateDicomItem(tag, vr, data);
+        return item;
+    }
+
+
+    private object ReadJsonMultiString(ref Utf8JsonReader reader)
+    {
+        if (reader.TokenType == JsonTokenType.EndObject)
+        {
+            return Array.Empty<string>();
+        }
+        string propertyname = ReadPropertyName(ref reader);
+
+        if (propertyname == "Value")
+        {
+            return ReadJsonMultiStringValue(ref reader);
+        }
+        else if (propertyname == "BulkDataURI")
+        {
+            // JToken bulk
+            return ReadJsonBulkDataUri(ref reader);
+        }
+        else
+        {
+            return Array.Empty<string>();
+        }
+    }
+
+
+    private static string ReadPropertyName(ref Utf8JsonReader reader)
+    {
+        reader.Assume(JsonTokenType.PropertyName);
+        var propertyname = reader.GetString();
+        reader.Read();
+        return propertyname;
+    }
+
+
+    private static string[] ReadJsonMultiStringValue(ref Utf8JsonReader reader)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            reader.Read();
+            return Array.Empty<string>();
+        }
+        reader.AssumeAndSkip(JsonTokenType.StartArray);
+        var childStrings = new List<string>();
+
+        while (reader.TokenType != JsonTokenType.EndArray)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                childStrings.Add(null);
+            }
+            else if (reader.TokenType == JsonTokenType.String)
+            {
+                childStrings.Add(reader.GetString());
+            }
+            else
+            {
+                // TODO: invalid. handle this?
+            }
+            reader.Read();
+        }
+        reader.AssumeAndSkip(JsonTokenType.EndArray);
+        var data = childStrings.ToArray();
+        return data;
+    }
+
+
+    private object ReadJsonMultiNumberOrString<T>(ref Utf8JsonReader reader, GetValue<T> getValue, TryParse<T> tryParse)
+    {
+        if (reader.TokenType == JsonTokenType.EndObject)
+        {
+            return Array.Empty<T>();
+        }
+        string propertyname = ReadPropertyName(ref reader);
+
+        if (propertyname == "Value")
+        {
+            return ReadJsonMultiNumberOrStringValue<T>(ref reader, getValue, tryParse);
+        }
+        else if (propertyname == "BulkDataURI")
+        {
+            return ReadJsonBulkDataUri(ref reader);
+        }
+        else
+        {
+            return Array.Empty<T>();
+        }
+    }
+
+    private object ReadJsonMultiNumberOrStringValue<T>(ref Utf8JsonReader reader, GetValue<T> getValue, TryParse<T> tryParse)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            reader.Read();
+            return Array.Empty<T>();
+        }
+        reader.AssumeAndSkip(JsonTokenType.StartArray);
+
+        var hasNonNumericString = false;
+        var childValues = new List<object>();
+        while (reader.TokenType != JsonTokenType.EndArray)
+        {
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                childValues.Add(getValue(reader));
+            }
+            else if (reader.TokenType == JsonTokenType.String && reader.GetString() == "NaN")
+            {
+                childValues.Add((T)(float.NaN as object));
+            }
+            else if (reader.TokenType == JsonTokenType.String && tryParse(reader.GetString(), out T parsed))
+            {
+                childValues.Add(parsed);
+            }
+            else if (reader.TokenType == JsonTokenType.String && !_autoValidate)
+            {
+                hasNonNumericString = true;
+                childValues.Add(reader.GetString());
+            }
+            else
+            {
+                throw new JsonException("Malformed DICOM json, number expected");
+            }
+            reader.Read();
+        }
+        reader.AssumeAndSkip(JsonTokenType.EndArray);
+
+        if (hasNonNumericString)
+        {
+            var valArray = childValues.Select(x => x.ToString()).ToArray();
+            return ByteConverter.ToByteBuffer(string.Join("\\", valArray));
+        }
+
+        return childValues.Cast<T>().ToArray();
+    }
+
+    private object ReadJsonMultiNumber<T>(ref Utf8JsonReader reader, GetValue<T> getValue)
+    {
+        if (reader.TokenType == JsonTokenType.EndObject)
+        {
+            return Array.Empty<T>();
+        }
+        string propertyname = ReadPropertyName(ref reader);
+
+        if (propertyname == "Value")
+        {
+            return ReadJsonMultiNumberValue<T>(ref reader, getValue);
+        }
+        else if (propertyname == "BulkDataURI")
+        {
+            return ReadJsonBulkDataUri(ref reader);
+        }
+        else
+        {
+            return Array.Empty<T>();
+        }
+    }
+
+
+    private static T[] ReadJsonMultiNumberValue<T>(ref Utf8JsonReader reader, GetValue<T> getValue)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            reader.Read();
+            return Array.Empty<T>();
+        }
+        reader.AssumeAndSkip(JsonTokenType.StartArray);
+
+        var childValues = new List<T>();
+        while (reader.TokenType != JsonTokenType.EndArray)
+        {
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                childValues.Add(getValue(reader));
+            }
+            else if (reader.TokenType == JsonTokenType.String && reader.GetString() == "NaN")
+            {
+                childValues.Add((T)(float.NaN as object));
+            }
+            else
+            {
+                throw new JsonException("Malformed DICOM json, number expected");
+            }
+            reader.Read();
+        }
+        reader.AssumeAndSkip(JsonTokenType.EndArray);
+
+        var data = childValues.ToArray();
+        return data;
+    }
+
+
+    private string[] ReadJsonPersonName(ref Utf8JsonReader reader)
+    {
+        if (reader.TokenType == JsonTokenType.EndObject)
+        {
+            return Array.Empty<string>();
+        }
+        var propertyName = ReadPropertyName(ref reader);
+
+        if (propertyName == "Value")
         {
             if (reader.TokenType == JsonTokenType.Null)
             {
                 reader.Read();
                 return Array.Empty<string>();
             }
-            reader.AssumeAndSkip(JsonTokenType.StartArray);
-            var childStrings = new List<string>();
-
-            while (reader.TokenType != JsonTokenType.EndArray)
-            {
-                if (reader.TokenType == JsonTokenType.Null)
-                {
-                    childStrings.Add(null);
-                }
-                else if (reader.TokenType == JsonTokenType.String)
-                {
-                    childStrings.Add(reader.GetString());
-                }
-                else
-                {
-                    // TODO: invalid. handle this?
-                }
-                reader.Read();
-            }
-            reader.AssumeAndSkip(JsonTokenType.EndArray);
-            var data = childStrings.ToArray();
-            return data;
-        }
-
-
-        private object ReadJsonMultiNumberOrString<T>(ref Utf8JsonReader reader, GetValue<T> getValue, TryParse<T> tryParse)
-        {
-            if (reader.TokenType == JsonTokenType.EndObject)
-            {
-                return Array.Empty<T>();
-            }
-            string propertyname = ReadPropertyName(ref reader);
-
-            if (propertyname == "Value")
-            {
-                return ReadJsonMultiNumberOrStringValue<T>(ref reader, getValue, tryParse);
-            }
-            else if (propertyname == "BulkDataURI")
-            {
-                return ReadJsonBulkDataUri(ref reader);
-            }
             else
-            {
-                return Array.Empty<T>();
-            }
-        }
-
-        private object ReadJsonMultiNumberOrStringValue<T>(ref Utf8JsonReader reader, GetValue<T> getValue, TryParse<T> tryParse)
-        {
-            if (reader.TokenType == JsonTokenType.Null)
-            {
-                reader.Read();
-                return Array.Empty<T>();
-            }
-            reader.AssumeAndSkip(JsonTokenType.StartArray);
-
-            var hasNonNumericString = false;
-            var childValues = new List<object>();
-            while (reader.TokenType != JsonTokenType.EndArray)
-            {
-                if (reader.TokenType == JsonTokenType.Number)
-                {
-                    childValues.Add(getValue(reader));
-                }
-                else if (reader.TokenType == JsonTokenType.String && reader.GetString() == "NaN")
-                {
-                    childValues.Add((T)(float.NaN as object));
-                }
-                else if (reader.TokenType == JsonTokenType.String && tryParse(reader.GetString(), out T parsed))
-                {
-                    childValues.Add(parsed);
-                }
-                else if (reader.TokenType == JsonTokenType.String && !_autoValidate)
-                {
-                    hasNonNumericString = true;
-                    childValues.Add(reader.GetString());
-                }
-                else
-                {
-                    throw new JsonException("Malformed DICOM json, number expected");
-                }
-                reader.Read();
-            }
-            reader.AssumeAndSkip(JsonTokenType.EndArray);
-
-            if (hasNonNumericString)
-            {
-                var valArray = childValues.Select(x => x.ToString()).ToArray();
-                return ByteConverter.ToByteBuffer(string.Join("\\", valArray));
-            }
-
-            return childValues.Cast<T>().ToArray();
-        }
-
-        private object ReadJsonMultiNumber<T>(ref Utf8JsonReader reader, GetValue<T> getValue)
-        {
-            if (reader.TokenType == JsonTokenType.EndObject)
-            {
-                return Array.Empty<T>();
-            }
-            string propertyname = ReadPropertyName(ref reader);
-
-            if (propertyname == "Value")
-            {
-                return ReadJsonMultiNumberValue<T>(ref reader, getValue);
-            }
-            else if (propertyname == "BulkDataURI")
-            {
-                return ReadJsonBulkDataUri(ref reader);
-            }
-            else
-            {
-                return Array.Empty<T>();
-            }
-        }
-
-
-        private static T[] ReadJsonMultiNumberValue<T>(ref Utf8JsonReader reader, GetValue<T> getValue)
-        {
-            if (reader.TokenType == JsonTokenType.Null)
-            {
-                reader.Read();
-                return Array.Empty<T>();
-            }
-            reader.AssumeAndSkip(JsonTokenType.StartArray);
-
-            var childValues = new List<T>();
-            while (reader.TokenType != JsonTokenType.EndArray)
-            {
-                if (reader.TokenType == JsonTokenType.Number)
-                {
-                    childValues.Add(getValue(reader));
-                }
-                else if (reader.TokenType == JsonTokenType.String && reader.GetString() == "NaN")
-                {
-                    childValues.Add((T)(float.NaN as object));
-                }
-                else
-                {
-                    throw new JsonException("Malformed DICOM json, number expected");
-                }
-                reader.Read();
-            }
-            reader.AssumeAndSkip(JsonTokenType.EndArray);
-
-            var data = childValues.ToArray();
-            return data;
-        }
-
-
-        private string[] ReadJsonPersonName(ref Utf8JsonReader reader)
-        {
-            if (reader.TokenType == JsonTokenType.EndObject)
-            {
-                return Array.Empty<string>();
-            }
-            var propertyName = ReadPropertyName(ref reader);
-
-            if (propertyName == "Value")
-            {
-                if (reader.TokenType == JsonTokenType.Null)
-                {
-                    reader.Read();
-                    return Array.Empty<string>();
-                }
-                else
-                {
-                    reader.AssumeAndSkip(JsonTokenType.StartArray);
-
-                    var childStrings = new List<string>();
-                    while (reader.TokenType != JsonTokenType.EndArray)
-                    {
-                        if (reader.TokenType == JsonTokenType.Null)
-                        {
-                            reader.Read();
-                            childStrings.Add(null);
-                        }
-                        else if (reader.TokenType == JsonTokenType.StartObject)
-                        {
-                            // parse
-                            reader.Read(); // read into object
-                            var componentGroupCount = 3;
-                            var componentGroupValues = new string[componentGroupCount];
-                            while (reader.TokenType != JsonTokenType.EndObject)
-                            {
-                                if (reader.TokenType == JsonTokenType.PropertyName
-                                    && reader.GetString() == "Alphabetic")
-                                {
-                                    reader.Read(); // skip propertyname
-                                    componentGroupValues[0] = reader.GetString(); // read value
-                                }
-                                else if (reader.TokenType == JsonTokenType.PropertyName
-                                    && reader.GetString() == "Ideographic")
-                                {
-                                    reader.Read(); // skip propertyname
-                                    componentGroupValues[1] = reader.GetString(); // read value
-                                }
-                                else if (reader.TokenType == JsonTokenType.PropertyName
-                                    && reader.GetString() == "Phonetic")
-                                {
-                                    reader.Read(); // skip propertyname
-                                    componentGroupValues[2] = reader.GetString(); // read value
-                                }
-                                reader.Read();
-                            }
-
-                            //build
-                            StringBuilder stringBuilder = new StringBuilder();
-                            for (int i = 0; i < componentGroupCount; i++)
-                            {
-                                var val = componentGroupValues[i];
-
-                                if (!string.IsNullOrWhiteSpace(val))
-                                {
-                                    stringBuilder.Append(val);
-
-                                }
-                                stringBuilder.Append(_personNameComponentGroupDelimiter);
-                            }
-
-                            //remove optional trailing delimiters
-                            string pnVal = stringBuilder.ToString().TrimEnd(_personNameComponentGroupDelimiter);
-
-                            childStrings.Add(pnVal); // add value
-                            reader.AssumeAndSkip(JsonTokenType.EndObject);
-                        }
-                        else
-                        {
-                            // TODO: invalid. handle this?
-                        }
-                    }
-                    reader.AssumeAndSkip(JsonTokenType.EndArray);
-                    var data = childStrings.ToArray();
-                    return data;
-                }
-            }
-            else
-            {
-                throw new JsonException("Malformed DICOM json, property 'Value' expected");
-            }
-        }
-
-
-        private DicomDataset[] ReadJsonSequence(ref Utf8JsonReader reader)
-        {
-            if (reader.TokenType == JsonTokenType.EndObject)
-            {
-                return Array.Empty<DicomDataset>();
-            }
-            var propertyName = ReadPropertyName(ref reader);
-
-            if (propertyName == "Value")
             {
                 reader.AssumeAndSkip(JsonTokenType.StartArray);
-                var childItems = new List<DicomDataset>();
+
+                var childStrings = new List<string>();
                 while (reader.TokenType != JsonTokenType.EndArray)
                 {
                     if (reader.TokenType == JsonTokenType.Null)
                     {
                         reader.Read();
-                        childItems.Add(null);
+                        childStrings.Add(null);
                     }
                     else if (reader.TokenType == JsonTokenType.StartObject)
                     {
-                        childItems.Add(ReadJsonDataset(ref reader));
+                        // parse
+                        reader.Read(); // read into object
+                        var componentGroupCount = 3;
+                        var componentGroupValues = new string[componentGroupCount];
+                        while (reader.TokenType != JsonTokenType.EndObject)
+                        {
+                            if (reader.TokenType == JsonTokenType.PropertyName
+                                && reader.GetString() == "Alphabetic")
+                            {
+                                reader.Read(); // skip propertyname
+                                componentGroupValues[0] = reader.GetString(); // read value
+                            }
+                            else if (reader.TokenType == JsonTokenType.PropertyName
+                                && reader.GetString() == "Ideographic")
+                            {
+                                reader.Read(); // skip propertyname
+                                componentGroupValues[1] = reader.GetString(); // read value
+                            }
+                            else if (reader.TokenType == JsonTokenType.PropertyName
+                                && reader.GetString() == "Phonetic")
+                            {
+                                reader.Read(); // skip propertyname
+                                componentGroupValues[2] = reader.GetString(); // read value
+                            }
+                            reader.Read();
+                        }
+
+                        //build
+                        StringBuilder stringBuilder = new StringBuilder();
+                        for (int i = 0; i < componentGroupCount; i++)
+                        {
+                            var val = componentGroupValues[i];
+
+                            if (!string.IsNullOrWhiteSpace(val))
+                            {
+                                stringBuilder.Append(val);
+
+                            }
+                            stringBuilder.Append(_personNameComponentGroupDelimiter);
+                        }
+
+                        //remove optional trailing delimiters
+                        string pnVal = stringBuilder.ToString().TrimEnd(_personNameComponentGroupDelimiter);
+
+                        childStrings.Add(pnVal); // add value
                         reader.AssumeAndSkip(JsonTokenType.EndObject);
                     }
                     else
                     {
-                        throw new JsonException("Malformed DICOM json, object expected");
+                        // TODO: invalid. handle this?
                     }
                 }
                 reader.AssumeAndSkip(JsonTokenType.EndArray);
-                var data = childItems.ToArray();
+                var data = childStrings.ToArray();
                 return data;
             }
-            else
-            {
-                return Array.Empty<DicomDataset>();
-            }
         }
-
-
-        private IByteBuffer ReadJsonOX(ref Utf8JsonReader reader)
+        else
         {
-            if (reader.TokenType == JsonTokenType.EndObject)
-            {
-                return EmptyBuffer.Value;
-            }
-            var propertyName = ReadPropertyName(ref reader);
-
-            if (propertyName == "InlineBinary")
-            {
-                return ReadJsonInlineBinary(ref reader);
-            }
-            else if (propertyName == "BulkDataURI")
-            {
-                return ReadJsonBulkDataUri(ref reader);
-            }
-            return EmptyBuffer.Value;
+            throw new JsonException("Malformed DICOM json, property 'Value' expected");
         }
+    }
 
 
-        private static MemoryByteBuffer ReadJsonInlineBinary(ref Utf8JsonReader reader)
+    private DicomDataset[] ReadJsonSequence(ref Utf8JsonReader reader)
+    {
+        if (reader.TokenType == JsonTokenType.EndObject)
+        {
+            return Array.Empty<DicomDataset>();
+        }
+        var propertyName = ReadPropertyName(ref reader);
+
+        if (propertyName == "Value")
         {
             reader.AssumeAndSkip(JsonTokenType.StartArray);
-            if (reader.TokenType != JsonTokenType.String) { throw new JsonException("Malformed DICOM json. string expected"); }
-            var data = new MemoryByteBuffer(reader.GetBytesFromBase64());
-            reader.Read();
-            reader.AssumeAndSkip(JsonTokenType.EndArray);
-            return data;
-        }
-
-
-        private IBulkDataUriByteBuffer ReadJsonBulkDataUri(ref Utf8JsonReader reader)
-        {
-            if (reader.TokenType != JsonTokenType.String) { throw new JsonException("Malformed DICOM json. string expected"); }
-            var data = CreateBulkDataUriByteBuffer(reader.GetString());
-            reader.Read();
-            return data;
-        }
-
-
-        #endregion
-
-
-        private string FindValue(Utf8JsonReader reader, string property, string defaultValue)
-        {
-            var currentDepth = reader.CurrentDepth;
-            while (reader.CurrentDepth >= currentDepth)
+            var childItems = new List<DicomDataset>();
+            while (reader.TokenType != JsonTokenType.EndArray)
             {
-                if (reader.CurrentDepth == currentDepth
-                    && reader.TokenType == JsonTokenType.PropertyName
-                    && reader.GetString() == property)
+                if (reader.TokenType == JsonTokenType.Null)
                 {
-                    reader.Read(); // move to value
-                    return reader.GetString();
+                    reader.Read();
+                    childItems.Add(null);
                 }
-                reader.Read();
+                else if (reader.TokenType == JsonTokenType.StartObject)
+                {
+                    childItems.Add(ReadJsonDataset(ref reader));
+                    reader.AssumeAndSkip(JsonTokenType.EndObject);
+                }
+                else
+                {
+                    throw new JsonException("Malformed DICOM json, object expected");
+                }
             }
-            return defaultValue;
+            reader.AssumeAndSkip(JsonTokenType.EndArray);
+            var data = childItems.ToArray();
+            return data;
         }
-
-        private static bool TryParseInt(string value, out int parsed)
-            => int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out parsed);
-
-        private static bool TryParseDecimal(string value, out decimal parsed)
-            => decimal.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out parsed);
-
-        private static bool TryParseDouble(string value, out double parsed)
-            => double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out parsed);
-
-        private static bool TryParseLong(string value, out long parsed)
-            => long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out parsed);
-
-        private static bool TryParseULong(string value, out ulong parsed)
-            => ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out parsed);
-
+        else
+        {
+            return Array.Empty<DicomDataset>();
+        }
     }
 
 
-    internal static class JsonDicomConverterExtensions
+    private IByteBuffer ReadJsonOX(ref Utf8JsonReader reader)
     {
+        if (reader.TokenType == JsonTokenType.EndObject)
+        {
+            return EmptyBuffer.Value;
+        }
+        var propertyName = ReadPropertyName(ref reader);
 
-        public static string[] GetAsStringArray(this object data) => (string[])data;
-
-        public static string GetFirstOrEmpty(this string[] array) => array.Length > 0 ? array[0] : string.Empty;
-
-        public static string GetSingleOrEmpty(this string[] array) => array.Length > 0 ? array.Single() : string.Empty;
-
+        if (propertyName == "InlineBinary")
+        {
+            return ReadJsonInlineBinary(ref reader);
+        }
+        else if (propertyName == "BulkDataURI")
+        {
+            return ReadJsonBulkDataUri(ref reader);
+        }
+        return EmptyBuffer.Value;
     }
+
+
+    private static MemoryByteBuffer ReadJsonInlineBinary(ref Utf8JsonReader reader)
+    {
+        reader.AssumeAndSkip(JsonTokenType.StartArray);
+        if (reader.TokenType != JsonTokenType.String) { throw new JsonException("Malformed DICOM json. string expected"); }
+        var data = new MemoryByteBuffer(reader.GetBytesFromBase64());
+        reader.Read();
+        reader.AssumeAndSkip(JsonTokenType.EndArray);
+        return data;
+    }
+
+
+    private IBulkDataUriByteBuffer ReadJsonBulkDataUri(ref Utf8JsonReader reader)
+    {
+        if (reader.TokenType != JsonTokenType.String) { throw new JsonException("Malformed DICOM json. string expected"); }
+        var data = CreateBulkDataUriByteBuffer(reader.GetString());
+        reader.Read();
+        return data;
+    }
+
+
+    #endregion
+
+
+    private string FindValue(Utf8JsonReader reader, string property, string defaultValue)
+    {
+        var currentDepth = reader.CurrentDepth;
+        while (reader.CurrentDepth >= currentDepth)
+        {
+            if (reader.CurrentDepth == currentDepth
+                && reader.TokenType == JsonTokenType.PropertyName
+                && reader.GetString() == property)
+            {
+                reader.Read(); // move to value
+                return reader.GetString();
+            }
+            reader.Read();
+        }
+        return defaultValue;
+    }
+
+    private static bool TryParseInt(string value, out int parsed)
+        => int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out parsed);
+
+    private static bool TryParseDecimal(string value, out decimal parsed)
+        => decimal.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out parsed);
+
+    private static bool TryParseDouble(string value, out double parsed)
+        => double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out parsed);
+
+    private static bool TryParseLong(string value, out long parsed)
+        => long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out parsed);
+
+    private static bool TryParseULong(string value, out ulong parsed)
+        => ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out parsed);
+
+}
+
+
+internal static class JsonDicomConverterExtensions
+{
+
+    public static string[] GetAsStringArray(this object data) => (string[])data;
+
+    public static string GetFirstOrEmpty(this string[] array) => array.Length > 0 ? array[0] : string.Empty;
+
+    public static string GetSingleOrEmpty(this string[] array) => array.Length > 0 ? array.Single() : string.Empty;
 
 }

--- a/forks/Microsoft.Health.FellowOakDicom/Serialization/Utf8JsonReaderExtensions.cs
+++ b/forks/Microsoft.Health.FellowOakDicom/Serialization/Utf8JsonReaderExtensions.cs
@@ -3,22 +3,21 @@
 
 using System.Text.Json;
 
-namespace Microsoft.Health.FellowOakDicom.Serialization
-{
-    internal static class Utf8JsonReaderExtensions
-    {
-        public static void Assume(this ref Utf8JsonReader reader, JsonTokenType tokenType)
-        {
-            if (reader.TokenType != tokenType)
-            {
-                throw new JsonException($"invalid: {tokenType} expected at position {reader.TokenStartIndex}, instead found {reader.TokenType}");
-            }
-        }
+namespace Microsoft.Health.FellowOakDicom.Serialization;
 
-        public static void AssumeAndSkip(this ref Utf8JsonReader reader, JsonTokenType tokenType)
+internal static class Utf8JsonReaderExtensions
+{
+    public static void Assume(this ref Utf8JsonReader reader, JsonTokenType tokenType)
+    {
+        if (reader.TokenType != tokenType)
         {
-            Assume(ref reader, tokenType);
-            reader.Read();
+            throw new JsonException($"invalid: {tokenType} expected at position {reader.TokenStartIndex}, instead found {reader.TokenType}");
         }
+    }
+
+    public static void AssumeAndSkip(this ref Utf8JsonReader reader, JsonTokenType tokenType)
+    {
+        Assume(ref reader, tokenType);
+        reader.Read();
     }
 }

--- a/src/Microsoft.Health.Dicom.Client/Serialization/ExportDataOptionsJsonConverter.cs
+++ b/src/Microsoft.Health.Dicom.Client/Serialization/ExportDataOptionsJsonConverter.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -22,12 +22,18 @@ internal sealed class ExportDataOptionsJsonConverter : JsonConverterFactory
     {
         Type arg = EnsureArg.IsNotNull(typeToConvert, nameof(typeToConvert)).GetGenericArguments()[0];
         if (arg == typeof(ExportSourceType))
+        {
             return new ExportDataOptionsJsonConverter<ExportSourceType>(MapSourceType);
+        }
         else if (arg == typeof(ExportDestinationType))
+        {
             return new ExportDataOptionsJsonConverter<ExportDestinationType>(MapDestinationType);
+        }
         else
+        {
             throw new JsonException(
                 string.Format(CultureInfo.CurrentCulture, DicomClientResource.InvalidType, typeToConvert));
+        }
     }
 
     private static Type MapSourceType(ExportSourceType type)

--- a/src/Microsoft.Health.Dicom.Core/Serialization/ExportDataOptionsJsonConverter.cs
+++ b/src/Microsoft.Health.Dicom.Core/Serialization/ExportDataOptionsJsonConverter.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -21,12 +21,18 @@ internal sealed class ExportDataOptionsJsonConverter : JsonConverterFactory
     {
         Type arg = EnsureArg.IsNotNull(typeToConvert, nameof(typeToConvert)).GetGenericArguments()[0];
         if (arg == typeof(ExportSourceType))
+        {
             return new ExportDataOptionsJsonConverter<ExportSourceType>(MapSourceType);
+        }
         else if (arg == typeof(ExportDestinationType))
+        {
             return new ExportDataOptionsJsonConverter<ExportDestinationType>(MapDestinationType);
+        }
         else
+        {
             throw new JsonException(
                 string.Format(CultureInfo.CurrentCulture, DicomCoreResource.InvalidType, typeToConvert));
+        }
     }
 
     private static Type MapSourceType(ExportSourceType type)

--- a/src/Microsoft.Health.Dicom.Web/Microsoft.Health.Dicom.Web.csproj
+++ b/src/Microsoft.Health.Dicom.Web/Microsoft.Health.Dicom.Web.csproj
@@ -39,9 +39,9 @@
 
   <Target Name="SwaggerPostBuildTarget" AfterTargets="Build" Condition="'$(ContinuousIntegrationBuild)' != 'true'">
     <Exec Command="dotnet tool restore"></Exec>
-    <Exec Command="dotnet swagger tofile  --yaml --output ..\..\swagger\v1\swagger.yaml $(OutputPath)\Microsoft.Health.Dicom.Web.dll v1"></Exec>
-    <Exec Command="dotnet swagger tofile  --yaml --output ..\..\swagger\v1-prerelease\swagger.yaml $(OutputPath)\Microsoft.Health.Dicom.Web.dll v1-prerelease"></Exec>
-    <Exec Command="dotnet swagger tofile  --yaml --output ..\..\swagger\v2\swagger.yaml $(OutputPath)\Microsoft.Health.Dicom.Web.dll v2"></Exec>
+    <Exec Command="dotnet swagger tofile  --yaml --output ..\..\swagger\v1\swagger.yaml $(OutputPath)\Microsoft.Health.Dicom.Web.dll v1" EnvironmentVariables="DOTNET_ROLL_FORWARD=LatestMajor"></Exec>
+    <Exec Command="dotnet swagger tofile  --yaml --output ..\..\swagger\v1-prerelease\swagger.yaml $(OutputPath)\Microsoft.Health.Dicom.Web.dll v1-prerelease" EnvironmentVariables="DOTNET_ROLL_FORWARD=LatestMajor"></Exec>
+    <Exec Command="dotnet swagger tofile  --yaml --output ..\..\swagger\v2\swagger.yaml $(OutputPath)\Microsoft.Health.Dicom.Web.dll v2" EnvironmentVariables="DOTNET_ROLL_FORWARD=LatestMajor"></Exec>
   </Target>
 
 </Project>


### PR DESCRIPTION
Addressed minor namespace and linting issues that were preventing the successful build on certain environments

Updated post build swagger on Microsoft.Health.Dicom.Web to ensure compatibility with targeted .NET versions (6.0 and 8.0) instead of exclusively requiring .NET 7.0

## Description

The compiler required a file scoped namespace on the files
forks/Microsoft.Health.FellowOakDicom/Serialization/JsonDicomConverter.cs
forks/Microsoft.Health.FellowOakDicom/Serialization/Utf8JsonReaderExtensions.cs

And explicit else braces on files
src/Microsoft.Health.Dicom.Client/Serialization/ExportDataOptionsJsonConverter.cs
src/Microsoft.Health.Dicom.Client/Serialization/ExportDataOptionsJsonConverter.cs


Updated Microsoft.Health.Dicom.Web csproj swagger post build references to make Swashbuckle artifact look fot last .NET installed version. The Swashbuckle dependency on Microsoft.Health.Dicom.Web always look for .NET 7.0 instead of .NET 6.0 and .NET 8.0 that are the targets of the solutioon, this prevents docker builds via command line

## Related issues
Addresses compiler errors
Addresses docker build errors

## Testing
Build solution from Visual Studio
Build docker from command line

